### PR TITLE
Feat/subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Streaming** — Partial content and thinking deltas via `RunStream`
 - **Tools** — Built-in tools and custom tools via `interfaces.Tool`
 - **Tool approval** — Optional approval flow before executing tools
-- **Sub-agents** — Coordinator can delegate work to specialist agents you register
+- **Sub-agents** — Main agent can delegate work to specialist agents you register
 - **Temporal-native** — Durable execution, retries, visibility
 
 ## Getting started
@@ -205,7 +205,7 @@ result, _ := a.Run(ctx, "What's the weather in Tokyo?", "")
 
 ### Sub-agents
 
-Build each specialist with **`NewAgent`** (own **`TaskQueue`**, LLM, tools, prompts). Register them on the coordinator with **`WithSubAgents`**. Use **`WithName`** and **`WithDescription`** on specialists when you want clearer labels for the coordinator’s model. Use **`WithMaxSubAgentDepth`** only if the default nesting limit is not enough. Run **`Run`**, **`RunStream`**, or **`RunAsync`** on the coordinator. With **`WithConversation`**, delegated work does not reuse the coordinator’s `conversationID`. If you use **`DisableWorker`**, pair each **`NewAgentWorker`** with the same options as the **`NewAgent`** that runs that agent.
+Build each specialist with **`NewAgent`** (own **`TaskQueue`**, LLM, tools, prompts). Register them on the main agent with **`WithSubAgents`**. Use **`WithName`** and **`WithDescription`** on specialists when you want clearer labels for the main agent’s model. Use **`WithMaxSubAgentDepth`** only if the default nesting limit is not enough. Run **`Run`**, **`RunStream`**, or **`RunAsync`** on the main agent. With **`WithConversation`**, delegated work does not reuse the main agent’s `conversationID`. If you use **`DisableWorker`**, pair each **`NewAgentWorker`** with the same options as the **`NewAgent`** that runs that agent.
 
 ```go
 mathAgent, _ := agent.NewAgent(
@@ -221,21 +221,21 @@ mathAgent, _ := agent.NewAgent(
 )
 defer mathAgent.Close()
 
-coordinator, _ := agent.NewAgent(
-    agent.WithName("Coordinator"),
+mainAgent, _ := agent.NewAgent(
+    agent.WithName("Main agent"),
     agent.WithSystemPrompt("You are a helpful assistant."),
     agent.WithTemporalConfig(&agent.TemporalConfig{
         Host: "localhost", Port: 7233, Namespace: "default",
-        TaskQueue: "my-app-coordinator",
+        TaskQueue: "my-app-main-agent",
     }),
     agent.WithLLMClient(llmClient),
     agent.WithSubAgents(mathAgent),
     agent.WithMaxSubAgentDepth(2),
     agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
 )
-defer coordinator.Close()
+defer mainAgent.Close()
 
-result, _ := coordinator.Run(ctx, "What is 144 divided by 12?", "")
+result, _ := mainAgent.Run(ctx, "What is 144 divided by 12?", "")
 ```
 
 [examples/agent_with_subagents](examples/agent_with_subagents)
@@ -252,11 +252,11 @@ By default tools require approval, including delegation to sub-agents registered
 #### Sub-agents and approval
 
 - **`ApprovalRequest`** and **`ToolApprovalEvent`** (RunStream) include **`Kind`** (`tool` or `delegation`), **`AgentName`** (agent running the workflow), and **`DelegateToName`** (target specialist when `Kind` is `delegation`). Use them to show different UI labels while keeping one approval flow.
-- **Parent (coordinator):** one policy for its whole list—e.g. `RequireAll` → approving `subagent_MathSpecialist` is the same flow as approving `calculator` on that agent. `AutoToolApprovalPolicy()` → no approval for delegation or other tools on that agent.
+- **Parent (main agent):** one policy for its whole list—e.g. `RequireAll` → approving `subagent_MathSpecialist` is the same flow as approving `calculator` on that agent. `AutoToolApprovalPolicy()` → no approval for delegation or other tools on that agent.
 - **Specialist:** separate agent, **its own** `WithToolApprovalPolicy`. Calculator calls inside the specialist use **that** policy, not the parent’s.
 
 ```text
-Coordinator: WithToolApprovalPolicy(RequireAll)     → delegate to math → user approval
+Main agent: WithToolApprovalPolicy(RequireAll)     → delegate to math → user approval
 Math agent:  WithToolApprovalPolicy(Auto)         → calculator inside specialist → no approval
 ```
 
@@ -524,7 +524,7 @@ a.Run(ctx, "What's my name?", convID) // agent uses history: "Alice"
 | **WithConversation**        | Message history store. Use `inmem` for single process; `redis` for remote workers. Pass same `conversationID` to `Run` and `RunStream` for a session. See [Conversation](#conversation-message-history). |
 | **WithConversationSize**    | Max messages to fetch for LLM context (default 20). Only applies when `WithConversation` is set.                                                                                                         |
 | **WithEnableRemoteWorkers** | Set `true` when using `DisableWorker` with approval or streaming.                                                                                                                                        |
-| **WithSubAgents**           | Attach specialist agents the coordinator can delegate to. Each needs its own task queue and worker. See [Sub-agents](#sub-agents).                                                                       |
+| **WithSubAgents**           | Attach specialist agents the main agent can delegate to. Each needs its own task queue and worker. See [Sub-agents](#sub-agents).                                                                       |
 | **WithMaxSubAgentDepth**    | Maximum delegation hops from this agent (default 2). See [Sub-agents](#sub-agents).                                                                                                                       |
 | **WithMaxIterations**       | Max LLM rounds (default 5).                                                                                                                                                                              |
 | **WithStream**              | Enable `RunStream` partial content streaming.                                                                                                                                                            |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **Streaming** — Partial content and thinking deltas via `RunStream`
 - **Tools** — Built-in tools and custom tools via `interfaces.Tool`
 - **Tool approval** — Optional approval flow before executing tools
+- **Sub-agents** — Coordinator can delegate work to specialist agents you register
 - **Temporal-native** — Durable execution, retries, visibility
 
 ## Getting started
@@ -202,9 +203,64 @@ result, _ := a.Run(ctx, "What's the weather in Tokyo?", "")
 
 [examples/agent_with_tools](examples/agent_with_tools)
 
+### Sub-agents
+
+Build each specialist with **`NewAgent`** (own **`TaskQueue`**, LLM, tools, prompts). Register them on the coordinator with **`WithSubAgents`**. Use **`WithName`** and **`WithDescription`** on specialists when you want clearer labels for the coordinator’s model. Use **`WithMaxSubAgentDepth`** only if the default nesting limit is not enough. Run **`Run`**, **`RunStream`**, or **`RunAsync`** on the coordinator. With **`WithConversation`**, delegated work does not reuse the coordinator’s `conversationID`. If you use **`DisableWorker`**, pair each **`NewAgentWorker`** with the same options as the **`NewAgent`** that runs that agent.
+
+```go
+mathAgent, _ := agent.NewAgent(
+    agent.WithName("MathSpecialist"),
+    agent.WithDescription("Arithmetic; uses calculator tools."),
+    agent.WithTemporalConfig(&agent.TemporalConfig{
+        Host: "localhost", Port: 7233, Namespace: "default",
+        TaskQueue: "my-app-math",
+    }),
+    agent.WithLLMClient(llmClient),
+    agent.WithToolRegistry(mathTools),
+    agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
+)
+defer mathAgent.Close()
+
+coordinator, _ := agent.NewAgent(
+    agent.WithName("Coordinator"),
+    agent.WithSystemPrompt("You are a helpful assistant."),
+    agent.WithTemporalConfig(&agent.TemporalConfig{
+        Host: "localhost", Port: 7233, Namespace: "default",
+        TaskQueue: "my-app-coordinator",
+    }),
+    agent.WithLLMClient(llmClient),
+    agent.WithSubAgents(mathAgent),
+    agent.WithMaxSubAgentDepth(2),
+    agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
+)
+defer coordinator.Close()
+
+result, _ := coordinator.Run(ctx, "What is 144 divided by 12?", "")
+```
+
+[examples/agent_with_subagents](examples/agent_with_subagents)
+
 ### Tool approval
 
-By default tools require approval. Use `WithApprovalHandler` on the agent (required for Run). Each `ApprovalRequest` includes `Respond`; call `req.Respond(Approved|Rejected)` when ready (same as RunAsync):
+By default tools require approval, including delegation to sub-agents registered with **`WithSubAgents`**—they follow the same **`WithToolApprovalPolicy`** as your other tools. Use `WithApprovalHandler` on the agent (required for Run when any tool needs approval). See [examples/agent_with_subagents](examples/agent_with_subagents).
+
+#### Tools vs agent policy
+
+- **`WithToolApprovalPolicy`** applies to **every** tool the agent exposes: registry / `WithTools` **and** sub-agent delegation. Default is require-all; `AutoToolApprovalPolicy()` skips all; `AllowlistToolApprovalPolicy("echo", "subagent_MathSpecialist", ...)` skips only those names.
+- Custom tools may implement **`interfaces.ToolApproval`**; with a normal **`NewAgent`** build, a default policy is always set, so **`WithToolApprovalPolicy` wins** for that agent (see `requiresApproval` in `config.go`).
+
+#### Sub-agents and approval
+
+- **`ApprovalRequest`** and **`ToolApprovalEvent`** (RunStream) include **`Kind`** (`tool` or `delegation`), **`AgentName`** (agent running the workflow), and **`DelegateToName`** (target specialist when `Kind` is `delegation`). Use them to show different UI labels while keeping one approval flow.
+- **Parent (coordinator):** one policy for its whole list—e.g. `RequireAll` → approving `subagent_MathSpecialist` is the same flow as approving `calculator` on that agent. `AutoToolApprovalPolicy()` → no approval for delegation or other tools on that agent.
+- **Specialist:** separate agent, **its own** `WithToolApprovalPolicy`. Calculator calls inside the specialist use **that** policy, not the parent’s.
+
+```text
+Coordinator: WithToolApprovalPolicy(RequireAll)     → delegate to math → user approval
+Math agent:  WithToolApprovalPolicy(Auto)         → calculator inside specialist → no approval
+```
+
+Each `ApprovalRequest` includes `Respond`; call `req.Respond(Approved|Rejected)` when ready (same as RunAsync):
 
 ```go
 a, _ := agent.NewAgent(
@@ -468,6 +524,8 @@ a.Run(ctx, "What's my name?", convID) // agent uses history: "Alice"
 | **WithConversation**        | Message history store. Use `inmem` for single process; `redis` for remote workers. Pass same `conversationID` to `Run` and `RunStream` for a session. See [Conversation](#conversation-message-history). |
 | **WithConversationSize**    | Max messages to fetch for LLM context (default 20). Only applies when `WithConversation` is set.                                                                                                         |
 | **WithEnableRemoteWorkers** | Set `true` when using `DisableWorker` with approval or streaming.                                                                                                                                        |
+| **WithSubAgents**           | Attach specialist agents the coordinator can delegate to. Each needs its own task queue and worker. See [Sub-agents](#sub-agents).                                                                       |
+| **WithMaxSubAgentDepth**    | Maximum delegation hops from this agent (default 2). See [Sub-agents](#sub-agents).                                                                                                                       |
 | **WithMaxIterations**       | Max LLM rounds (default 5).                                                                                                                                                                              |
 | **WithStream**              | Enable `RunStream` partial content streaming.                                                                                                                                                            |
 | **WithLLMSampling**         | Per-agent sampling (`Temperature`, `MaxTokens`, `TopP`, `TopK`). Pass `&agent.LLMSampling{...}`; nil fields = provider default. Extensible for more params.                                              |

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ The examples use `TEMPORAL_HOST`, `TEMPORAL_PORT`, `TEMPORAL_NAMESPACE` from `.e
 | `agent_with_run_async` | `RunAsync` — `resultCh` + `approvalCh`; use `req.Respond` (no `WithApprovalHandler`) |
 | `agent_with_custom_tools` | Custom tools via `WithTools` — implementing `interfaces.Tool` |
 | `multiple_agents` | Multiple agents with `WithInstanceId` — sequential or concurrent |
-| `agent_with_subagents` | Coordinator + math specialist — `WithSubAgents`, separate task queues |
+| `agent_with_subagents` | Main agent + math specialist — `WithSubAgents`, separate task queues |
 | `agent_with_worker` | Agent and worker in separate processes — `DisableWorker` + `NewAgentWorker` |
 
 ## Setup
@@ -92,9 +92,9 @@ go run ./agent_with_stream_conversation
 go run ./agent_with_stream_conversation "What is 5 * 8?"
 ```
 
-### Sub-agents (coordinator + specialist)
+### Sub-agents (main agent + specialist)
 
-Two agents in one process: coordinator with a math specialist registered via `WithSubAgents`. Requires workers on **both** task queues (each `NewAgent` starts its own embedded worker). Coordinator uses default tool approval (**RequireAll**): delegating to the specialist prompts on **stdin** (`y` / `n`). Specialist uses **AutoToolApprovalPolicy** so calculator does not prompt. Same stdin pattern as [agent_with_tools_approval](#tools--approval-custom-tools-multiple-agents-worker-split).
+Two agents in one process: main agent with a math specialist registered via `WithSubAgents`. Requires workers on **both** task queues (each `NewAgent` starts its own embedded worker). Main agent uses default tool approval (**RequireAll**): delegating to the specialist prompts on **stdin** (`y` / `n`). Specialist uses **AutoToolApprovalPolicy** so calculator does not prompt. Same stdin pattern as [agent_with_tools_approval](#tools--approval-custom-tools-multiple-agents-worker-split).
 
 ```bash
 go run ./agent_with_subagents "What is 987 times 654?"

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,7 @@ The examples use `TEMPORAL_HOST`, `TEMPORAL_PORT`, `TEMPORAL_NAMESPACE` from `.e
 | `agent_with_run_async` | `RunAsync` — `resultCh` + `approvalCh`; use `req.Respond` (no `WithApprovalHandler`) |
 | `agent_with_custom_tools` | Custom tools via `WithTools` — implementing `interfaces.Tool` |
 | `multiple_agents` | Multiple agents with `WithInstanceId` — sequential or concurrent |
+| `agent_with_subagents` | Coordinator + math specialist — `WithSubAgents`, separate task queues |
 | `agent_with_worker` | Agent and worker in separate processes — `DisableWorker` + `NewAgentWorker` |
 
 ## Setup
@@ -89,6 +90,14 @@ Interactive multi-turn with `RunStream`. Demonstrates how to handle ContentDelta
 ```bash
 go run ./agent_with_stream_conversation
 go run ./agent_with_stream_conversation "What is 5 * 8?"
+```
+
+### Sub-agents (coordinator + specialist)
+
+Two agents in one process: coordinator with a math specialist registered via `WithSubAgents`. Requires workers on **both** task queues (each `NewAgent` starts its own embedded worker). Coordinator uses default tool approval (**RequireAll**): delegating to the specialist prompts on **stdin** (`y` / `n`). Specialist uses **AutoToolApprovalPolicy** so calculator does not prompt. Same stdin pattern as [agent_with_tools_approval](#tools--approval-custom-tools-multiple-agents-worker-split).
+
+```bash
+go run ./agent_with_subagents "What is 987 times 654?"
 ```
 
 ### Tools + approval, custom tools, multiple agents, worker split

--- a/examples/agent_with_subagents/main.go
+++ b/examples/agent_with_subagents/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	config "github.com/vvsynapse/temporal-agent-sdk-go/examples"
+	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/agent"
+	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/tools"
+	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/tools/calculator"
+)
+
+// Coordinator uses the default tool approval policy (RequireAll): delegating to the
+// math specialist requires approval (stdin y/n). The specialist uses AutoToolApprovalPolicy
+// so its own tools (e.g. calculator) do not prompt.
+func main() {
+	cfg := config.LoadFromEnv()
+
+	llmClient, err := config.NewLLMClientFromConfig(cfg)
+	if err != nil {
+		log.Fatalf("failed to create LLM client: %v", err)
+	}
+
+	lineCh := make(chan string)
+	go func() {
+		scanner := bufio.NewScanner(os.Stdin)
+		for scanner.Scan() {
+			lineCh <- scanner.Text()
+		}
+		close(lineCh)
+	}()
+
+	baseQueue := cfg.TaskQueue
+	mathQueue := baseQueue + "-math-specialist"
+	coordQueue := baseQueue + "-coordinator"
+
+	mathReg := tools.NewRegistry()
+	mathReg.Register(calculator.New())
+
+	mathSpecialist, err := agent.NewAgent(
+		agent.WithName("MathSpecialist"),
+		agent.WithDescription("Arithmetic specialist with calculator tool."),
+		agent.WithSystemPrompt("You are a math specialist. Use the calculator tool for arithmetic. Reply with a short final answer."),
+		agent.WithTemporalConfig(&agent.TemporalConfig{
+			Host:      cfg.Host,
+			Port:      cfg.Port,
+			Namespace: cfg.Namespace,
+			TaskQueue: mathQueue,
+		}),
+		agent.WithLLMClient(llmClient),
+		agent.WithToolRegistry(mathReg),
+		agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
+		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
+	)
+	if err != nil {
+		log.Fatalf("math specialist agent: %v", err)
+	}
+	defer mathSpecialist.Close()
+
+	coordinator, err := agent.NewAgent(
+		agent.WithName("Coordinator"),
+		agent.WithDescription("General assistant."),
+		agent.WithSystemPrompt("You are a helpful assistant."),
+		agent.WithTemporalConfig(&agent.TemporalConfig{
+			Host:      cfg.Host,
+			Port:      cfg.Port,
+			Namespace: cfg.Namespace,
+			TaskQueue: coordQueue,
+		}),
+		agent.WithLLMClient(llmClient),
+		agent.WithSubAgents(mathSpecialist),
+		agent.WithMaxSubAgentDepth(2),
+		// Default RequireAllToolApprovalPolicy: sub-agent delegation follows same rules as any tool.
+		agent.WithApprovalHandler(makeToolApprovalHandler(lineCh)),
+		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
+	)
+	if err != nil {
+		log.Fatalf("coordinator agent: %v", err)
+	}
+	defer coordinator.Close()
+
+	prompt := strings.Join(os.Args[1:], " ")
+	if prompt == "" {
+		prompt = "What is 987 multiplied by 654?"
+	}
+
+	fmt.Println("user:", prompt)
+	fmt.Println("Coordinator tool calls (including delegation to the specialist) ask for approval: type y or n.")
+	resp, err := coordinator.Run(context.Background(), prompt, "")
+	if err != nil {
+		log.Printf("run failed: %v", err)
+		return
+	}
+	fmt.Println("coordinator:", resp.Content)
+}
+
+func makeToolApprovalHandler(lineCh <-chan string) agent.ApprovalHandler {
+	return func(ctx context.Context, req *agent.ApprovalRequest) {
+		argsJSON, _ := json.MarshalIndent(req.Args, "", "  ")
+		title := "Tool approval"
+		if req.Kind == agent.ToolApprovalKindDelegation {
+			title = "Delegate to specialist"
+		}
+		fmt.Printf("\n--- %s ---\nAgent: %s\n", title, req.AgentName)
+		if req.DelegateToName != "" {
+			fmt.Printf("Delegate to: %s\n", req.DelegateToName)
+		}
+		fmt.Printf("Args:\n%s\nApprove delegation? (y/n): ", string(argsJSON))
+		select {
+		case <-ctx.Done():
+			return
+		case line, ok := <-lineCh:
+			if ok && strings.TrimSpace(strings.ToLower(line)) == "y" {
+				_ = req.Respond(agent.ApprovalStatusApproved)
+			} else if ok {
+				_ = req.Respond(agent.ApprovalStatusRejected)
+			}
+		}
+	}
+}

--- a/examples/agent_with_subagents/main.go
+++ b/examples/agent_with_subagents/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/tools/calculator"
 )
 
-// Coordinator uses the default tool approval policy (RequireAll): delegating to the
+// Main agent uses the default tool approval policy (RequireAll): delegating to the
 // math specialist requires approval (stdin y/n). The specialist uses AutoToolApprovalPolicy
 // so its own tools (e.g. calculator) do not prompt.
 func main() {
@@ -37,7 +37,7 @@ func main() {
 
 	baseQueue := cfg.TaskQueue
 	mathQueue := baseQueue + "-math-specialist"
-	coordQueue := baseQueue + "-coordinator"
+	mainQueue := baseQueue + "-main-agent"
 
 	mathReg := tools.NewRegistry()
 	mathReg.Register(calculator.New())
@@ -62,15 +62,15 @@ func main() {
 	}
 	defer mathSpecialist.Close()
 
-	coordinator, err := agent.NewAgent(
-		agent.WithName("Coordinator"),
+	mainAgent, err := agent.NewAgent(
+		agent.WithName("Main agent"),
 		agent.WithDescription("General assistant."),
 		agent.WithSystemPrompt("You are a helpful assistant."),
 		agent.WithTemporalConfig(&agent.TemporalConfig{
 			Host:      cfg.Host,
 			Port:      cfg.Port,
 			Namespace: cfg.Namespace,
-			TaskQueue: coordQueue,
+			TaskQueue: mainQueue,
 		}),
 		agent.WithLLMClient(llmClient),
 		agent.WithSubAgents(mathSpecialist),
@@ -80,9 +80,9 @@ func main() {
 		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
 	)
 	if err != nil {
-		log.Fatalf("coordinator agent: %v", err)
+		log.Fatalf("main agent: %v", err)
 	}
-	defer coordinator.Close()
+	defer mainAgent.Close()
 
 	prompt := strings.Join(os.Args[1:], " ")
 	if prompt == "" {
@@ -90,13 +90,13 @@ func main() {
 	}
 
 	fmt.Println("user:", prompt)
-	fmt.Println("Coordinator tool calls (including delegation to the specialist) ask for approval: type y or n.")
-	resp, err := coordinator.Run(context.Background(), prompt, "")
+	fmt.Println("Main agent tool calls (including delegation to the specialist) ask for approval: type y or n.")
+	resp, err := mainAgent.Run(context.Background(), prompt, "")
 	if err != nil {
 		log.Printf("run failed: %v", err)
 		return
 	}
-	fmt.Println("coordinator:", resp.Content)
+	fmt.Println("main agent:", resp.Content)
 }
 
 func makeToolApprovalHandler(lineCh <-chan string) agent.ApprovalHandler {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -663,6 +664,16 @@ func (a *Agent) buildSubAgentRoutes() map[string]SubAgentRoute {
 	}
 	if len(out) == 0 {
 		return nil
+	}
+	if a.logger != nil {
+		names := make([]string, 0, len(out))
+		for k := range out {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		a.logger.Debug("built sub-agent routes for workflow input",
+			zap.Strings("subAgentToolNames", names),
+			zap.Int("routeCount", len(out)))
 	}
 	return out
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -158,22 +159,22 @@ func (a *Agent) ensureEventWorkflowStarted(ctx context.Context) (string, error) 
 	if a.activeEventWorkflowID != "" {
 		return a.activeEventWorkflowID, nil
 	}
-	eid := eventWorkflowIDPrefix + a.Name + "-" + a.ID
 
-	a.logger.Debug("executing event workflow", zap.String("eid", eid))
+	eventWorkflowID := a.getEventWorkflowID()
+	a.logger.Debug("executing event workflow", zap.String("eventWorkflowID", eventWorkflowID))
 
 	_, err := a.temporalClient.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
-		ID:                       eid,
+		ID:                       eventWorkflowID,
 		TaskQueue:                getEventTaskQueue(a.taskQueue),
 		WorkflowIDConflictPolicy: enumspb.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING,
 	}, a.AgentEventWorkflow)
 	if err != nil {
-		a.logger.Error("failed to start event workflow", zap.String("eid", eid), zap.Error(err))
+		a.logger.Error("failed to start event workflow", zap.String("eventWorkflowID", eventWorkflowID), zap.Error(err))
 		return "", err
 	}
-	a.activeEventWorkflowID = eid
-	a.logger.Info("event workflow started", zap.String("eventWorkflowID", eid))
-	return eid, nil
+	a.activeEventWorkflowID = eventWorkflowID
+	a.logger.Info("event workflow started", zap.String("eventWorkflowID", eventWorkflowID))
+	return eventWorkflowID, nil
 }
 
 func getEventTaskQueue(taskQueue string) string {
@@ -265,8 +266,7 @@ func (a *Agent) Run(ctx context.Context, input string, conversationID string) (*
 		defer cancel()
 	}
 
-	id := uuid.New().String()
-	workflowID := fmt.Sprintf("%s-%s", a.Name, id)
+	workflowID := a.getWorkflowID(false)
 	cleanup, err := a.beginRun(workflowID)
 	if err != nil {
 		return nil, err
@@ -279,6 +279,8 @@ func (a *Agent) Run(ctx context.Context, input string, conversationID string) (*
 		EventWorkflowID:  "",
 		ConversationID:   conversationID,
 		EventTypes:       []AgentEventType{},
+		SubAgentDepth:    0,
+		SubAgentRoutes:   a.buildSubAgentRoutes(),
 	}
 	if a.enableRemoteWorkers {
 		a.createEventWorker()
@@ -376,9 +378,12 @@ func (a *Agent) Run(ctx context.Context, input string, conversationID string) (*
 			}
 			approvalCtx, cancel := context.WithTimeout(runCtx, a.approvalTimeout)
 			a.approvalHandler(approvalCtx, &ApprovalRequest{
-				ToolName: ev.Approval.ToolName,
-				Args:     ev.Approval.Args,
-				Respond:  onApproval,
+				ToolName:       ev.Approval.ToolName,
+				Args:           ev.Approval.Args,
+				Respond:        onApproval,
+				Kind:           ev.Approval.Kind,
+				AgentName:      ev.Approval.AgentName,
+				DelegateToName: ev.Approval.DelegateToName,
 			})
 			cancel()
 		case resp := <-approvalResponseCh:
@@ -417,9 +422,12 @@ func (a *Agent) RunAsync(ctx context.Context, input string, conversationID strin
 			saved = a.approvalHandler
 			a.approvalHandler = func(handlerCtx context.Context, req *ApprovalRequest) {
 				out := &ApprovalRequest{
-					ToolName: req.ToolName,
-					Args:     copyApprovalArgs(req.Args),
-					Respond:  req.Respond,
+					ToolName:       req.ToolName,
+					Args:           copyApprovalArgs(req.Args),
+					Respond:        req.Respond,
+					Kind:           req.Kind,
+					AgentName:      req.AgentName,
+					DelegateToName: req.DelegateToName,
 				}
 				select {
 				case apprCh <- out:
@@ -464,8 +472,7 @@ func (a *Agent) RunStream(ctx context.Context, input string, conversationID stri
 		return nil, err
 	}
 
-	id := uuid.New().String()
-	workflowID := fmt.Sprintf("%s-%s", a.Name, id)
+	workflowID := a.getWorkflowID(true)
 	cleanup, err := a.beginRun(workflowID)
 	if err != nil {
 		return nil, err
@@ -493,6 +500,8 @@ func (a *Agent) RunStream(ctx context.Context, input string, conversationID stri
 		StreamingEnabled: a.streamEnabled,
 		ConversationID:   conversationID,
 		EventTypes:       []AgentEventType{AgentEventAll},
+		SubAgentDepth:    0,
+		SubAgentRoutes:   a.buildSubAgentRoutes(),
 	}
 
 	runCtx := ctx
@@ -597,10 +606,13 @@ func copyEventWithShortApprovalToken(ev *AgentEvent, shortToken string) *AgentEv
 	c := *ev
 	if c.Approval != nil {
 		c.Approval = &ToolApprovalEvent{
-			ToolCallID:    ev.Approval.ToolCallID,
-			ToolName:      ev.Approval.ToolName,
-			Args:          ev.Approval.Args,
-			ApprovalToken: shortToken,
+			ToolCallID:     ev.Approval.ToolCallID,
+			ToolName:       ev.Approval.ToolName,
+			Args:           ev.Approval.Args,
+			ApprovalToken:  shortToken,
+			Kind:           ev.Approval.Kind,
+			AgentName:      ev.Approval.AgentName,
+			DelegateToName: ev.Approval.DelegateToName,
 		}
 	}
 	return &c
@@ -614,4 +626,43 @@ func (a *Agent) validateConversationID(conversationID string) error {
 		return fmt.Errorf("conversationID is required when using conversation")
 	}
 	return nil
+}
+
+func (a *Agent) getWorkflowID(isStream bool) string {
+	id := uuid.New().String()
+	if isStream {
+		return fmt.Sprintf("agent-stream-%s-%s", a.Name, id)
+	}
+	return fmt.Sprintf("agent-run-%s-%s", a.Name, id)
+}
+
+func (a *Agent) getEventWorkflowID() string {
+	id := uuid.New().String()
+	return fmt.Sprintf("agent-event-%s-%s", a.Name, id)
+}
+
+// buildSubAgentRoutes snapshots sub-agent tool names, task queues, and nested routes for workflow input.
+func (a *Agent) buildSubAgentRoutes() map[string]SubAgentRoute {
+	if a == nil || len(a.subAgents) == 0 {
+		return nil
+	}
+	out := make(map[string]SubAgentRoute, len(a.subAgents))
+	for _, sub := range a.subAgents {
+		if sub == nil {
+			continue
+		}
+		tq := strings.TrimSpace(sub.taskQueue)
+		if tq == "" {
+			continue
+		}
+		name := SubAgentToolName(sub)
+		out[name] = SubAgentRoute{
+			TaskQueue:   tq,
+			ChildRoutes: sub.buildSubAgentRoutes(),
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -102,4 +102,64 @@ func (m *mockConversation) ListMessages(ctx context.Context, id string, opts ...
 	return nil, nil
 }
 func (m *mockConversation) Clear(ctx context.Context, id string) error { return nil }
-func (m *mockConversation) IsDistributed() bool                          { return false }
+func (m *mockConversation) IsDistributed() bool                        { return false }
+
+func TestSubAgentQueryFromArgs(t *testing.T) {
+	if subAgentQueryFromArgs(nil) != "" {
+		t.Error("nil args")
+	}
+	if subAgentQueryFromArgs(map[string]any{}) != "" {
+		t.Error("empty map")
+	}
+	if got := subAgentQueryFromArgs(map[string]any{"query": "hello"}); got != "hello" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestBuildWorkflowSubAgentRoutes_flat(t *testing.T) {
+	child := &Agent{agentConfig: agentConfig{Name: "Child", taskQueue: "q-child"}}
+	parent := &Agent{agentConfig: agentConfig{Name: "Parent", taskQueue: "q-parent", subAgents: []*Agent{child}}}
+	got := parent.buildSubAgentRoutes()
+	if got == nil {
+		t.Fatal("expected routes")
+	}
+	key := SubAgentToolName(child)
+	r, ok := got[key]
+	if !ok {
+		t.Fatalf("missing %q in %v", key, got)
+	}
+	if r.TaskQueue != "q-child" || r.ChildRoutes != nil {
+		t.Fatalf("route = %+v", r)
+	}
+}
+
+func TestBuildWorkflowSubAgentRoutes_nested(t *testing.T) {
+	leaf := &Agent{agentConfig: agentConfig{Name: "Leaf", taskQueue: "q-leaf"}}
+	mid := &Agent{agentConfig: agentConfig{Name: "Mid", taskQueue: "q-mid", subAgents: []*Agent{leaf}}}
+	root := &Agent{agentConfig: agentConfig{Name: "Root", taskQueue: "q-root", subAgents: []*Agent{mid}}}
+	got := root.buildSubAgentRoutes()
+	midKey := SubAgentToolName(mid)
+	rMid, ok := got[midKey]
+	if !ok {
+		t.Fatalf("missing mid %q", midKey)
+	}
+	if rMid.ChildRoutes == nil {
+		t.Fatal("expected nested child routes")
+	}
+	leafKey := SubAgentToolName(leaf)
+	rLeaf, ok := rMid.ChildRoutes[leafKey]
+	if !ok {
+		t.Fatalf("missing leaf %q", leafKey)
+	}
+	if rLeaf.TaskQueue != "q-leaf" || len(rLeaf.ChildRoutes) != 0 {
+		t.Fatalf("leaf route = %+v", rLeaf)
+	}
+}
+
+func TestBuildWorkflowSubAgentRoutes_skipsEmptyTaskQueue(t *testing.T) {
+	skip := &Agent{agentConfig: agentConfig{Name: "X", taskQueue: "  "}}
+	parent := &Agent{agentConfig: agentConfig{subAgents: []*Agent{skip}}}
+	if got := parent.buildSubAgentRoutes(); len(got) != 0 {
+		t.Fatalf("want empty, got %v", got)
+	}
+}

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/interfaces"
 	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/logger"
@@ -113,6 +114,20 @@ func TestSubAgentQueryFromArgs(t *testing.T) {
 	}
 	if got := subAgentQueryFromArgs(map[string]any{"query": "hello"}); got != "hello" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestSubAgentChildWorkflowTimeout(t *testing.T) {
+	if got := subAgentChildWorkflowTimeout(nil); got != defaultTimeout {
+		t.Fatalf("nil worker: got %v want %v", got, defaultTimeout)
+	}
+	aw := &AgentWorker{config: &agentConfig{timeout: 2 * time.Minute}}
+	if got := subAgentChildWorkflowTimeout(aw); got != 2*time.Minute {
+		t.Fatalf("custom timeout: got %v", got)
+	}
+	aw.config.timeout = 0
+	if got := subAgentChildWorkflowTimeout(aw); got != defaultTimeout {
+		t.Fatalf("zero timeout: got %v want %v", got, defaultTimeout)
 	}
 }
 

--- a/pkg/agent/approval.go
+++ b/pkg/agent/approval.go
@@ -32,6 +32,12 @@ type ApprovalRequest struct {
 	ToolName string         `json:"tool_name"`
 	Args     map[string]any `json:"args"`
 	Respond  ApprovalSender `json:"-"`
+	// Kind matches ToolApprovalEvent: distinguish normal tools from sub-agent delegation.
+	Kind ToolApprovalKind `json:"kind,omitempty"`
+	// AgentName is the agent running the workflow that requested approval.
+	AgentName string `json:"agent_name,omitempty"`
+	// DelegateToName is set for delegation: human-friendly target specialist name.
+	DelegateToName string `json:"delegate_to_name,omitempty"`
 }
 
 // OnApproval completes a tool approval when using RunStream. Pass the string from ev.Approval

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -85,6 +86,12 @@ type agentConfig struct {
 	enableRemoteWorkers bool // true: run event worker & workflow. false (default): use agentChannel only. Agent only.
 	remoteWorker        bool // true when AgentWorker; activities use UpdateWorkflow
 	agentWorker         bool
+
+	// subAgents
+	// subAgents are direct children; each is exposed to the LLM via NewSubAgentTool (see toolsList).
+	subAgents []*Agent
+	// maxSubAgentDepth limits nesting depth from this agent (direct subs = 1). Default 2 when unset or <= 0.
+	maxSubAgentDepth int
 }
 
 // defaultTimeout is used when no deadline set, to avoid blocking forever when no workers run.
@@ -241,6 +248,19 @@ func WithLLMSampling(s *LLMSampling) Option {
 	return func(c *agentConfig) { c.llmSampling = s }
 }
 
+// WithSubAgents registers sub-agents. Each is exposed to the parent LLM as a tool (AgentTool).
+// Execution is via workflow (child workflow), not Tool.Execute — see future workflow integration.
+// The sub-agent graph is validated at agent build: no cycles, depth <= WithMaxSubAgentDepth (default 2).
+func WithSubAgents(subAgents ...*Agent) Option {
+	return func(c *agentConfig) { c.subAgents = subAgents }
+}
+
+// WithMaxSubAgentDepth sets the maximum sub-agent nesting depth from this agent (direct children = 1).
+// Default is 2 when unset or <= 0. Applies to Agent and AgentWorker.
+func WithMaxSubAgentDepth(depth int) Option {
+	return func(c *agentConfig) { c.maxSubAgentDepth = depth }
+}
+
 // buildAgentConfig applies options, validates, and creates the Temporal client.
 // remoteWorker is false for Agent (local); NewAgentWorker overrides to true.
 func buildAgentConfig(opts []Option) (*agentConfig, error) {
@@ -276,6 +296,15 @@ func buildAgentConfig(opts []Option) (*agentConfig, error) {
 	}
 	if c.conversationSize <= 0 {
 		c.conversationSize = 20
+	}
+	if c.maxSubAgentDepth <= 0 {
+		c.maxSubAgentDepth = defaultMaxSubAgentDepth
+	}
+	if err := c.validateSubAgents(); err != nil {
+		return nil, err
+	}
+	if err := c.validateToolsAndSubAgentNames(); err != nil {
+		return nil, err
 	}
 	if c.timeout == 0 {
 		c.timeout = defaultTimeout
@@ -348,10 +377,110 @@ func buildAgentConfigForWorker(opts []Option) (*agentConfig, error) {
 }
 
 func (c *agentConfig) toolsList() []interfaces.Tool {
+	var base []interfaces.Tool
 	if c.toolRegistry != nil {
-		return c.toolRegistry.Tools()
+		base = c.toolRegistry.Tools()
+	} else {
+		base = c.tools
 	}
-	return c.tools
+	if len(c.subAgents) == 0 {
+		return base
+	}
+	out := make([]interfaces.Tool, len(base), len(base)+len(c.subAgents))
+	copy(out, base)
+	for _, sa := range c.subAgents {
+		if st := NewSubAgentTool(sa); st != nil {
+			out = append(out, st)
+		}
+	}
+	return out
+}
+
+// validateSubAgents checks for nil sub-agents, duplicate roots, cycles, and max nesting depth.
+func (c *agentConfig) validateSubAgents() error {
+	if len(c.subAgents) == 0 {
+		return nil
+	}
+	maxDepth := c.maxSubAgentDepth
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxSubAgentDepth
+	}
+	seen := make(map[*Agent]struct{}, len(c.subAgents))
+	for _, s := range c.subAgents {
+		if s == nil {
+			return fmt.Errorf("sub-agent must not be nil")
+		}
+		if _, dup := seen[s]; dup {
+			return fmt.Errorf("duplicate sub-agent %q in WithSubAgents", subAgentLabel(s))
+		}
+		seen[s] = struct{}{}
+	}
+	for _, s := range c.subAgents {
+		path := map[*Agent]struct{}{s: {}}
+		if err := dfsSubAgentDepth(s, path, 1, maxDepth); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func dfsSubAgentDepth(a *Agent, path map[*Agent]struct{}, depth, maxDepth int) error {
+	if depth > maxDepth {
+		return fmt.Errorf("sub-agent depth exceeds max (%d): at %q", maxDepth, subAgentLabel(a))
+	}
+	for _, child := range a.subAgents {
+		if child == nil {
+			return fmt.Errorf("sub-agent %q has a nil entry in WithSubAgents", subAgentLabel(a))
+		}
+		if _, cycle := path[child]; cycle {
+			return fmt.Errorf("sub-agent cycle detected involving %q and %q", subAgentLabel(a), subAgentLabel(child))
+		}
+		path[child] = struct{}{}
+		if err := dfsSubAgentDepth(child, path, depth+1, maxDepth); err != nil {
+			return err
+		}
+		delete(path, child)
+	}
+	return nil
+}
+
+func subAgentLabel(a *Agent) string {
+	if a == nil {
+		return "<nil>"
+	}
+	if n := strings.TrimSpace(a.Name); n != "" {
+		return n
+	}
+	return a.ID
+}
+
+// validateToolsAndSubAgentNames ensures tool names are unique across WithTools/registry and sub-agent tools.
+func (c *agentConfig) validateToolsAndSubAgentNames() error {
+	var base []interfaces.Tool
+	if c.toolRegistry != nil {
+		base = c.toolRegistry.Tools()
+	} else {
+		base = c.tools
+	}
+	names := make(map[string]struct{})
+	for _, t := range base {
+		n := t.Name()
+		if _, ok := names[n]; ok {
+			return fmt.Errorf("duplicate tool name %q in WithTools or registry", n)
+		}
+		names[n] = struct{}{}
+	}
+	for _, sa := range c.subAgents {
+		if sa == nil {
+			continue
+		}
+		n := SubAgentToolName(sa)
+		if _, ok := names[n]; ok {
+			return fmt.Errorf("sub-agent tool name %q conflicts with an existing tool", n)
+		}
+		names[n] = struct{}{}
+	}
+	return nil
 }
 
 // responseFormatForLLM returns the response format for LLM requests.

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/interfaces"
@@ -100,6 +101,96 @@ func TestAgentConfig_RequiresApproval(t *testing.T) {
 	}
 }
 
+func TestAgentConfig_validateSubAgents_duplicateRootSubs(t *testing.T) {
+	s := &Agent{agentConfig: agentConfig{Name: "Same"}}
+	c := &agentConfig{subAgents: []*Agent{s, s}, maxSubAgentDepth: 3}
+	err := c.validateSubAgents()
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("want duplicate error, got %v", err)
+	}
+}
+
+func TestAgentConfig_validateSubAgents_nilSubAgent(t *testing.T) {
+	c := &agentConfig{subAgents: []*Agent{nil}, maxSubAgentDepth: 3}
+	err := c.validateSubAgents()
+	if err == nil || !strings.Contains(err.Error(), "nil") {
+		t.Fatalf("want nil sub-agent error, got %v", err)
+	}
+}
+
+func TestAgentConfig_validateSubAgents_cycleAB(t *testing.T) {
+	a := &Agent{agentConfig: agentConfig{Name: "A"}}
+	b := &Agent{agentConfig: agentConfig{Name: "B"}}
+	a.subAgents = []*Agent{b}
+	b.subAgents = []*Agent{a}
+	c := &agentConfig{subAgents: []*Agent{a}, maxSubAgentDepth: 5}
+	err := c.validateSubAgents()
+	if err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("want cycle error, got %v", err)
+	}
+}
+
+func TestAgentConfig_validateSubAgents_depthExceeded(t *testing.T) {
+	d1 := &Agent{agentConfig: agentConfig{Name: "d1"}}
+	d2 := &Agent{agentConfig: agentConfig{Name: "d2"}}
+	d3 := &Agent{agentConfig: agentConfig{Name: "d3"}}
+	d4 := &Agent{agentConfig: agentConfig{Name: "d4"}}
+	d1.subAgents = []*Agent{d2}
+	d2.subAgents = []*Agent{d3}
+	d3.subAgents = []*Agent{d4}
+	c := &agentConfig{subAgents: []*Agent{d1}, maxSubAgentDepth: 3}
+	err := c.validateSubAgents()
+	if err == nil || !strings.Contains(err.Error(), "depth") {
+		t.Fatalf("want depth error, got %v", err)
+	}
+}
+
+func TestAgentConfig_validateSubAgents_okWithinDepth(t *testing.T) {
+	d1 := &Agent{agentConfig: agentConfig{Name: "d1"}}
+	d2 := &Agent{agentConfig: agentConfig{Name: "d2"}}
+	d3 := &Agent{agentConfig: agentConfig{Name: "d3"}}
+	d1.subAgents = []*Agent{d2}
+	d2.subAgents = []*Agent{d3}
+	c := &agentConfig{subAgents: []*Agent{d1}, maxSubAgentDepth: 3}
+	if err := c.validateSubAgents(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAgentConfig_validateToolsAndSubAgentNames_conflict(t *testing.T) {
+	sub := &Agent{agentConfig: agentConfig{Name: "Math"}}
+	c := &agentConfig{
+		tools:     []interfaces.Tool{mockTool{name: "subagent_Math"}},
+		subAgents: []*Agent{sub},
+	}
+	err := c.validateToolsAndSubAgentNames()
+	if err == nil || !strings.Contains(err.Error(), "conflicts") {
+		t.Fatalf("want conflict error, got %v", err)
+	}
+}
+
+func TestAgentConfig_toolsList_includesSubAgents(t *testing.T) {
+	sub := &Agent{agentConfig: agentConfig{Name: "Helper", ID: "id-sub"}}
+	c := &agentConfig{
+		tools:     []interfaces.Tool{mockTool{name: "echo"}},
+		subAgents: []*Agent{sub},
+	}
+	list := c.toolsList()
+	if len(list) != 2 {
+		t.Fatalf("toolsList len = %d, want 2", len(list))
+	}
+	if list[0].Name() != "echo" {
+		t.Errorf("first tool = %s", list[0].Name())
+	}
+	if list[1].Name() != "subagent_Helper" {
+		t.Errorf("sub tool name = %s", list[1].Name())
+	}
+	at, ok := list[1].(AgentTool)
+	if !ok || at.SubAgent() != sub {
+		t.Errorf("second tool should be AgentTool wrapping sub")
+	}
+}
+
 func TestAgentConfig_HasApprovalTools(t *testing.T) {
 	c := &agentConfig{
 		tools:              []interfaces.Tool{mockToolWithApproval{mockTool: mockTool{name: "x"}, needApproval: true}},
@@ -141,5 +232,5 @@ type mockToolWithApproval struct {
 func (m mockToolWithApproval) ApprovalRequired() bool { return m.needApproval }
 
 // Ensure mockToolWithApproval implements both interfaces
-var _ interfaces.Tool        = (*mockToolWithApproval)(nil)
+var _ interfaces.Tool = (*mockToolWithApproval)(nil)
 var _ interfaces.ToolApproval = (*mockToolWithApproval)(nil)

--- a/pkg/agent/event.go
+++ b/pkg/agent/event.go
@@ -18,7 +18,6 @@ var (
 	agentEventActivityMaxAttempts int32         = 3
 
 	agentEventName              = "agent-event"
-	eventWorkflowIDPrefix       = "event-"
 	eventWorkflowCompleteSignal = "complete" // received when agent Close is called
 )
 
@@ -69,6 +68,16 @@ type AgentEvent struct {
 	WorkflowID string                 `json:"workflow_id,omitempty"` // run workflow ID; for correlation only
 }
 
+// ToolApprovalKind classifies what the user is approving (same event type for RunStream).
+type ToolApprovalKind string
+
+const (
+	// ToolApprovalKindTool is a normal tool execution (default when Kind is empty for older payloads).
+	ToolApprovalKindTool ToolApprovalKind = "tool"
+	// ToolApprovalKindDelegation is approval to run a registered sub-agent (delegate).
+	ToolApprovalKindDelegation ToolApprovalKind = "delegation"
+)
+
 // ToolApprovalEvent is the payload for AgentEventToolApproval (RunStream).
 // Use with Agent.OnApproval when the user approves or rejects; see streaming examples.
 type ToolApprovalEvent struct {
@@ -76,6 +85,12 @@ type ToolApprovalEvent struct {
 	ToolName      string         `json:"tool_name"`
 	Args          map[string]any `json:"args,omitempty"`
 	ApprovalToken string         `json:"approval_token,omitempty"`
+	// Kind is tool vs sub-agent delegation; use for UI copy.
+	Kind ToolApprovalKind `json:"kind,omitempty"`
+	// AgentName is the agent executing this workflow (coordinator or specialist).
+	AgentName string `json:"agent_name,omitempty"`
+	// DelegateToName is set when Kind is delegation: display name of the target sub-agent.
+	DelegateToName string `json:"delegate_to_name,omitempty"`
 }
 
 type ToolCallStatus string

--- a/pkg/agent/event.go
+++ b/pkg/agent/event.go
@@ -87,7 +87,7 @@ type ToolApprovalEvent struct {
 	ApprovalToken string         `json:"approval_token,omitempty"`
 	// Kind is tool vs sub-agent delegation; use for UI copy.
 	Kind ToolApprovalKind `json:"kind,omitempty"`
-	// AgentName is the agent executing this workflow (coordinator or specialist).
+	// AgentName is the agent executing this workflow (main agent or specialist).
 	AgentName string `json:"agent_name,omitempty"`
 	// DelegateToName is set when Kind is delegation: display name of the target sub-agent.
 	DelegateToName string `json:"delegate_to_name,omitempty"`

--- a/pkg/agent/subagent.go
+++ b/pkg/agent/subagent.go
@@ -1,0 +1,100 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/interfaces"
+	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/tools"
+)
+
+var _ AgentTool = (*subAgentTool)(nil)
+var _ interfaces.Tool = (*subAgentTool)(nil)
+
+// subAgentToolParamQuery is the parameter name for the query to send to the sub-agent.
+const subAgentToolParamQuery = "query"
+
+// Sub-agent tool names must be identifier-like for LLM tool APIs; normalize display names accordingly.
+var subAgentToolNameNonIdent = regexp.MustCompile(`[^a-zA-Z0-9]+`)
+
+// defaultMaxSubAgentDepth is the maximum number of sub-agent hops from this agent when unset.
+const defaultMaxSubAgentDepth = 2
+
+// ErrSubAgentToolNotExecutable is returned by SubAgentTool.Execute.
+// Normal runs delegate via AgentWorkflow child workflows; Execute() is only for misconfigured or direct activity calls.
+var ErrSubAgentToolNotExecutable = errors.New("sub-agent tool must be executed via workflow, not Execute()")
+
+// AgentTool marks a tool that represents sub-agent delegation (child AgentWorkflow), not normal Tool.Execute.
+//
+// AgentWorkflow chooses delegation vs AgentToolExecuteActivity using SubAgentRoutes keyed by tool name, not by
+// asserting AgentTool in workflow code. AgentTool is still used elsewhere (e.g. toolApprovalMetadata walks
+// toolsList() and asserts AgentTool to set delegation fields on approval events).
+type AgentTool interface {
+	interfaces.Tool
+	// SubAgent returns the sub-agent this tool delegates to.
+	SubAgent() *Agent
+}
+
+// subAgentTool implements interfaces.Tool for LLM tool listing only.
+// Execution is handled by the agent workflow (child workflow), not Execute.
+type subAgentTool struct {
+	agent *Agent
+}
+
+// NewSubAgentTool wraps a sub-agent as a tool for the parent LLM.
+// Name is derived from the sub-agent's Name when set; otherwise a stable default is used.
+// Returns nil if sub is nil; callers should skip nil tools.
+func NewSubAgentTool(sub *Agent) interfaces.Tool {
+	if sub == nil {
+		return nil
+	}
+	return &subAgentTool{agent: sub}
+}
+
+func (t *subAgentTool) Name() string { return SubAgentToolName(t.agent) }
+
+func (t *subAgentTool) Description() string {
+	d := strings.TrimSpace(t.agent.Description)
+	if d != "" {
+		return "Delegate to specialist sub-agent: " + d
+	}
+	if strings.TrimSpace(t.agent.Name) != "" {
+		return "Delegate to specialist sub-agent: " + t.agent.Name
+	}
+	return "Delegate to a specialist sub-agent to handle this request."
+}
+
+func (t *subAgentTool) Parameters() interfaces.JSONSchema {
+	return tools.Params(map[string]interfaces.JSONSchema{
+		subAgentToolParamQuery: tools.ParamString("Task or question to send to the sub-agent."),
+	}, subAgentToolParamQuery)
+}
+
+func (t *subAgentTool) Execute(_ context.Context, _ map[string]any) (any, error) {
+	return nil, fmt.Errorf("%w: %s", ErrSubAgentToolNotExecutable, SubAgentToolName(t.agent))
+}
+
+func (t *subAgentTool) SubAgent() *Agent { return t.agent }
+
+// SubAgentToolName returns the tool name the parent LLM and workflow routing use for this sub-agent.
+// Single source: NewSubAgentTool, validateToolsAndSubAgentNames, and buildWorkflowSubAgentRoutes must use this (or Name() on the tool).
+//
+// Display names are not used verbatim: runs of non-alphanumeric ASCII become a single underscore; leading/trailing
+// underscores are trimmed. An empty or all-symbol name falls back to subagent_<Agent.ID> so the name stays stable and API-safe.
+func SubAgentToolName(a *Agent) string {
+	if a == nil {
+		return ""
+	}
+	base := strings.TrimSpace(a.Name)
+	if base == "" {
+		return "subagent_" + a.ID
+	}
+	safe := strings.Trim(subAgentToolNameNonIdent.ReplaceAllString(base, "_"), "_")
+	if safe == "" {
+		return "subagent_" + a.ID
+	}
+	return "subagent_" + safe
+}

--- a/pkg/agent/subagent.go
+++ b/pkg/agent/subagent.go
@@ -80,7 +80,7 @@ func (t *subAgentTool) Execute(_ context.Context, _ map[string]any) (any, error)
 func (t *subAgentTool) SubAgent() *Agent { return t.agent }
 
 // SubAgentToolName returns the tool name the parent LLM and workflow routing use for this sub-agent.
-// Single source: NewSubAgentTool, validateToolsAndSubAgentNames, and buildWorkflowSubAgentRoutes must use this (or Name() on the tool).
+// Single source: NewSubAgentTool, validateToolsAndSubAgentNames, and buildSubAgentRoutes must use this (or Name() on the tool).
 //
 // Display names are not used verbatim: runs of non-alphanumeric ASCII become a single underscore; leading/trailing
 // underscores are trimmed. An empty or all-symbol name falls back to subagent_<Agent.ID> so the name stays stable and API-safe.

--- a/pkg/agent/subagent_test.go
+++ b/pkg/agent/subagent_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewSubAgentTool_Execute(t *testing.T) {
+	sub := &Agent{agentConfig: agentConfig{Name: "S", ID: "x"}}
+	tool := NewSubAgentTool(sub)
+	_, err := tool.Execute(context.Background(), map[string]any{"query": "hi"})
+	if !errors.Is(err, ErrSubAgentToolNotExecutable) {
+		t.Fatalf("Execute err = %v, want ErrSubAgentToolNotExecutable", err)
+	}
+}
+
+func TestNewSubAgentTool_nilReturnsNil(t *testing.T) {
+	if NewSubAgentTool(nil) != nil {
+		t.Fatal("NewSubAgentTool(nil) should return nil")
+	}
+}

--- a/pkg/agent/workflow.go
+++ b/pkg/agent/workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,15 +35,26 @@ var (
 	defaultMaxIterations int = 5
 )
 
+// SubAgentRoute tells the workflow how to delegate to a sub-agent: child AgentWorkflow on TaskQueue,
+// with nested routes for that sub-agent's own sub-agents (frozen at parent run start).
+type SubAgentRoute struct {
+	TaskQueue   string                   `json:"task_queue"`
+	ChildRoutes map[string]SubAgentRoute `json:"child_routes,omitempty"`
+}
+
 // AgentWorkflowInput is the input to AgentWorkflow. EventWorkflowID is set when streaming or approval is used.
 // StreamingEnabled enables partial content streaming (from WithStream).
 // ConversationID is set when conversation is used; workflow fetches messages and writes assistant/tool via activities.
+// SubAgentDepth is 0 for a top-level user run; each child workflow increments it (runtime cap vs maxSubAgentDepth).
+// SubAgentRoutes maps sub-agent tool name -> route; built from WithSubAgents when the run starts.
 type AgentWorkflowInput struct {
-	UserPrompt       string           `json:"user_prompt,omitempty"`
-	EventWorkflowID  string           `json:"event_workflow_id,omitempty"`
-	StreamingEnabled bool             `json:"streaming_enabled,omitempty"`
-	ConversationID   string           `json:"conversation_id,omitempty"`
-	EventTypes       []AgentEventType `json:"event_types,omitempty"`
+	UserPrompt       string                   `json:"user_prompt,omitempty"`
+	EventWorkflowID  string                   `json:"event_workflow_id,omitempty"`
+	StreamingEnabled bool                     `json:"streaming_enabled,omitempty"`
+	ConversationID   string                   `json:"conversation_id,omitempty"`
+	EventTypes       []AgentEventType         `json:"event_types,omitempty"`
+	SubAgentDepth    int                      `json:"sub_agent_depth,omitempty"`
+	SubAgentRoutes   map[string]SubAgentRoute `json:"sub_agent_routes,omitempty"`
 }
 
 // AgentLLMInput is the input to AgentLLMActivity. When ConversationID is set, activity fetches messages from store.
@@ -292,19 +304,22 @@ func (aw *AgentWorker) AgentWorkflow(ctx workflow.Context, input AgentWorkflowIn
 
 			var content string
 			if approvalStatus == ApprovalStatusApproved {
-				var result string
-				execInput := AgentToolExecuteInput{
-					ToolName:       tc.ToolName,
-					Args:           tc.Args,
-					ConversationID: input.ConversationID,
-					ToolCallID:     tc.ToolCallID,
-				}
-				errExec := workflow.ExecuteActivity(execCtx, aw.AgentToolExecuteActivity, execInput).Get(execCtx, &result)
-				if errExec != nil {
-					content = "Tool execution failed: " + errExec.Error()
-					// ToolExecute activity adds tool message for both success and failure when conversation
+				if route, ok := input.SubAgentRoutes[tc.ToolName]; ok {
+					content = aw.delegateToSubAgent(ctx, input, tc, route)
 				} else {
-					content = result
+					var result string
+					execInput := AgentToolExecuteInput{
+						ToolName:       tc.ToolName,
+						Args:           tc.Args,
+						ConversationID: input.ConversationID,
+						ToolCallID:     tc.ToolCallID,
+					}
+					errExec := workflow.ExecuteActivity(execCtx, aw.AgentToolExecuteActivity, execInput).Get(execCtx, &result)
+					if errExec != nil {
+						content = "Tool execution failed: " + errExec.Error()
+					} else {
+						content = result
+					}
 				}
 			} else {
 				content = "Tool execution was rejected by the user."
@@ -530,6 +545,25 @@ func (aw *AgentWorker) AgentLLMActivity(ctx context.Context, input AgentLLMInput
 	return aw.llmResponseToResult(resp, tools)
 }
 
+func toolApprovalMetadata(aw *AgentWorker, toolName string) (kind ToolApprovalKind, agentName, delegateToName string) {
+	if aw == nil || aw.config == nil {
+		return ToolApprovalKindTool, "", ""
+	}
+	agentName = strings.TrimSpace(aw.config.Name)
+	kind = ToolApprovalKindTool
+	for _, t := range aw.config.toolsList() {
+		if t.Name() != toolName {
+			continue
+		}
+		if at, ok := t.(AgentTool); ok {
+			kind = ToolApprovalKindDelegation
+			delegateToName = subAgentLabel(at.SubAgent())
+		}
+		break
+	}
+	return kind, agentName, delegateToName
+}
+
 // AgentToolApprovalActivity blocks until the driver completes it via CompleteActivity.
 // Sends approval request as AgentEventToolApproval on event channel (same channel for Run and RunStream).
 func (aw *AgentWorker) AgentToolApprovalActivity(ctx context.Context, input AgentToolApprovalInput) (ApprovalStatus, error) {
@@ -540,13 +574,17 @@ func (aw *AgentWorker) AgentToolApprovalActivity(ctx context.Context, input Agen
 	workflowID := info.WorkflowExecution.ID
 	taskTokenB64 := base64.StdEncoding.EncodeToString(info.TaskToken)
 
+	kind, agentName, delegateToName := toolApprovalMetadata(aw, input.ToolName)
 	ev := &AgentEvent{
 		Type: AgentEventToolApproval,
 		Approval: &ToolApprovalEvent{
-			ToolCallID:    input.ToolCallID,
-			ToolName:      input.ToolName,
-			Args:          input.Args,
-			ApprovalToken: taskTokenB64,
+			ToolCallID:     input.ToolCallID,
+			ToolName:       input.ToolName,
+			Args:           input.Args,
+			ApprovalToken:  taskTokenB64,
+			Kind:           kind,
+			AgentName:      agentName,
+			DelegateToName: delegateToName,
 		},
 		Timestamp: time.Now(),
 	}
@@ -669,6 +707,53 @@ func (aw *AgentWorker) AgentToolExecuteActivity(ctx context.Context, input Agent
 	}
 	logger.Warn("unknown tool", zap.String("tool", toolName))
 	return "", fmt.Errorf("unknown tool: %s", toolName)
+}
+
+func (aw *AgentWorker) delegateToSubAgent(ctx workflow.Context, input AgentWorkflowInput, tc ToolCallRequest, route SubAgentRoute) string {
+	if strings.TrimSpace(route.TaskQueue) == "" {
+		return "Sub-agent delegation failed: sub-agent task queue is not configured."
+	}
+	maxDepth := aw.config.maxSubAgentDepth
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxSubAgentDepth
+	}
+	if input.SubAgentDepth >= maxDepth {
+		return fmt.Sprintf("Sub-agent delegation refused: maximum nesting depth (%d) reached for this agent.", maxDepth)
+	}
+	childInput := AgentWorkflowInput{
+		UserPrompt:       subAgentQueryFromArgs(tc.Args),
+		EventWorkflowID:  input.EventWorkflowID,
+		StreamingEnabled: input.StreamingEnabled,
+		ConversationID:   "",
+		EventTypes:       input.EventTypes,
+		SubAgentDepth:    input.SubAgentDepth + 1,
+		SubAgentRoutes:   route.ChildRoutes,
+	}
+	var childSuffix string
+	if err := workflow.SideEffect(ctx, func(workflow.Context) interface{} {
+		return uuid.New().String()
+	}).Get(&childSuffix); err != nil {
+		return "Sub-agent workflow failed: " + err.Error()
+	}
+	parentID := workflow.GetInfo(ctx).WorkflowExecution.ID
+	childWfID := fmt.Sprintf("%s-sub-%s-%s", parentID, tc.ToolCallID, childSuffix)
+	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
+		WorkflowID: childWfID,
+		TaskQueue:  route.TaskQueue,
+	})
+	var childResp AgentResponse
+	if err := workflow.ExecuteChildWorkflow(childCtx, aw.AgentWorkflow, childInput).Get(childCtx, &childResp); err != nil {
+		return "Sub-agent workflow failed: " + err.Error()
+	}
+	return childResp.Content
+}
+
+func subAgentQueryFromArgs(args map[string]any) string {
+	if args == nil {
+		return ""
+	}
+	q, _ := args[subAgentToolParamQuery].(string)
+	return q
 }
 
 func retryPolicy(maxAttempts int32) *temporal.RetryPolicy {

--- a/pkg/agent/workflow.go
+++ b/pkg/agent/workflow.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/interfaces"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -109,6 +110,11 @@ type AgentToolApprovalInput struct {
 func (aw *AgentWorker) AgentWorkflow(ctx workflow.Context, input AgentWorkflowInput) (*AgentResponse, error) {
 	logger := workflow.GetLogger(ctx)
 	logger.Info("agent workflow started")
+	if n := len(input.SubAgentRoutes); n > 0 {
+		logger.Debug("agent workflow sub-agent routes snapshot",
+			zap.Int("routeCount", n),
+			zap.Int("subAgentDepth", input.SubAgentDepth))
+	}
 	eventWorkflowID := input.EventWorkflowID
 	agentWorkflowID := workflow.GetInfo(ctx).WorkflowExecution.ID
 
@@ -305,8 +311,18 @@ func (aw *AgentWorker) AgentWorkflow(ctx workflow.Context, input AgentWorkflowIn
 			var content string
 			if approvalStatus == ApprovalStatusApproved {
 				if route, ok := input.SubAgentRoutes[tc.ToolName]; ok {
+					logger.Info("executing tool call",
+						zap.String("executionKind", "sub_agent"),
+						zap.String("tool", tc.ToolName),
+						zap.String("toolCallID", tc.ToolCallID),
+						zap.String("childTaskQueue", strings.TrimSpace(route.TaskQueue)),
+						zap.Int("subAgentDepth", input.SubAgentDepth))
 					content = aw.delegateToSubAgent(ctx, input, tc, route)
 				} else {
+					logger.Info("executing tool call",
+						zap.String("executionKind", "tool"),
+						zap.String("tool", tc.ToolName),
+						zap.String("toolCallID", tc.ToolCallID))
 					var result string
 					execInput := AgentToolExecuteInput{
 						ToolName:       tc.ToolName,
@@ -575,6 +591,12 @@ func (aw *AgentWorker) AgentToolApprovalActivity(ctx context.Context, input Agen
 	taskTokenB64 := base64.StdEncoding.EncodeToString(info.TaskToken)
 
 	kind, agentName, delegateToName := toolApprovalMetadata(aw, input.ToolName)
+	if kind == ToolApprovalKindDelegation {
+		logger.Debug("tool approval targets sub-agent delegation",
+			zap.String("tool", input.ToolName),
+			zap.String("delegateTo", delegateToName),
+			zap.String("mainAgent", agentName))
+	}
 	ev := &AgentEvent{
 		Type: AgentEventToolApproval,
 		Approval: &ToolApprovalEvent{
@@ -710,7 +732,11 @@ func (aw *AgentWorker) AgentToolExecuteActivity(ctx context.Context, input Agent
 }
 
 func (aw *AgentWorker) delegateToSubAgent(ctx workflow.Context, input AgentWorkflowInput, tc ToolCallRequest, route SubAgentRoute) string {
+	logger := workflow.GetLogger(ctx)
 	if strings.TrimSpace(route.TaskQueue) == "" {
+		logger.Warn("sub-agent delegation skipped: empty child task queue",
+			zap.String("tool", tc.ToolName),
+			zap.String("toolCallID", tc.ToolCallID))
 		return "Sub-agent delegation failed: sub-agent task queue is not configured."
 	}
 	maxDepth := aw.config.maxSubAgentDepth
@@ -718,10 +744,16 @@ func (aw *AgentWorker) delegateToSubAgent(ctx workflow.Context, input AgentWorkf
 		maxDepth = defaultMaxSubAgentDepth
 	}
 	if input.SubAgentDepth >= maxDepth {
+		logger.Warn("sub-agent delegation refused: max nesting depth",
+			zap.Int("subAgentDepth", input.SubAgentDepth),
+			zap.Int("maxDepth", maxDepth),
+			zap.String("tool", tc.ToolName),
+			zap.String("toolCallID", tc.ToolCallID))
 		return fmt.Sprintf("Sub-agent delegation refused: maximum nesting depth (%d) reached for this agent.", maxDepth)
 	}
+	query := subAgentQueryFromArgs(tc.Args)
 	childInput := AgentWorkflowInput{
-		UserPrompt:       subAgentQueryFromArgs(tc.Args),
+		UserPrompt:       query,
 		EventWorkflowID:  input.EventWorkflowID,
 		StreamingEnabled: input.StreamingEnabled,
 		ConversationID:   "",
@@ -733,18 +765,41 @@ func (aw *AgentWorker) delegateToSubAgent(ctx workflow.Context, input AgentWorkf
 	if err := workflow.SideEffect(ctx, func(workflow.Context) interface{} {
 		return uuid.New().String()
 	}).Get(&childSuffix); err != nil {
+		logger.Warn("sub-agent child workflow id generation failed", zap.Error(err))
 		return "Sub-agent workflow failed: " + err.Error()
 	}
 	parentID := workflow.GetInfo(ctx).WorkflowExecution.ID
 	childWfID := fmt.Sprintf("%s-sub-%s-%s", parentID, tc.ToolCallID, childSuffix)
+	childTO := subAgentChildWorkflowTimeout(aw)
+	logger.Debug("starting sub-agent child workflow",
+		zap.String("childWorkflowID", childWfID),
+		zap.String("childTaskQueue", strings.TrimSpace(route.TaskQueue)),
+		zap.String("tool", tc.ToolName),
+		zap.String("toolCallID", tc.ToolCallID),
+		zap.Int("parentSubAgentDepth", input.SubAgentDepth),
+		zap.Int("childSubAgentDepth", childInput.SubAgentDepth),
+		zap.Int("nestedChildRouteCount", len(route.ChildRoutes)),
+		zap.Duration("workflowExecutionTimeout", childTO),
+		zap.Int("delegatedQueryLen", len(query)))
 	childCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
-		WorkflowID: childWfID,
-		TaskQueue:  route.TaskQueue,
+		WorkflowID:               childWfID,
+		TaskQueue:                route.TaskQueue,
+		WorkflowExecutionTimeout: childTO,
+		ParentClosePolicy:        enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+		WaitForCancellation:      true,
 	})
 	var childResp AgentResponse
 	if err := workflow.ExecuteChildWorkflow(childCtx, aw.AgentWorkflow, childInput).Get(childCtx, &childResp); err != nil {
+		logger.Warn("sub-agent child workflow failed",
+			zap.String("childWorkflowID", childWfID),
+			zap.String("tool", tc.ToolName),
+			zap.Error(err))
 		return "Sub-agent workflow failed: " + err.Error()
 	}
+	logger.Debug("sub-agent child workflow completed",
+		zap.String("childWorkflowID", childWfID),
+		zap.String("tool", tc.ToolName),
+		zap.Int("responseContentLen", len(childResp.Content)))
 	return childResp.Content
 }
 
@@ -754,6 +809,16 @@ func subAgentQueryFromArgs(args map[string]any) string {
 	}
 	q, _ := args[subAgentToolParamQuery].(string)
 	return q
+}
+
+// subAgentChildWorkflowTimeout caps how long the main agent waits on a delegated sub-agent run.
+// Uses the main agent worker's agent timeout (same package as delegateToSubAgent); sub-agent workers may define
+// their own limits separately, but this bounds the child execution from the main agent's perspective.
+func subAgentChildWorkflowTimeout(aw *AgentWorker) time.Duration {
+	if aw != nil && aw.config != nil && aw.config.timeout > 0 {
+		return aw.config.timeout
+	}
+	return defaultTimeout
 }
 
 func retryPolicy(maxAttempts int32) *temporal.RetryPolicy {

--- a/pkg/agent/workflow_test.go
+++ b/pkg/agent/workflow_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestToolApprovalMetadata_regularTool(t *testing.T) {
 	cfg := &agentConfig{
-		Name:  "Coordinator",
+		Name:  "Main agent",
 		tools: []interfaces.Tool{mockTool{name: "echo"}},
 	}
 	aw := &AgentWorker{config: cfg}
 	kind, agent, delegate := toolApprovalMetadata(aw, "echo")
-	if kind != ToolApprovalKindTool || agent != "Coordinator" || delegate != "" {
+	if kind != ToolApprovalKindTool || agent != "Main agent" || delegate != "" {
 		t.Fatalf("got kind=%q agent=%q delegate=%q", kind, agent, delegate)
 	}
 }
@@ -21,7 +21,7 @@ func TestToolApprovalMetadata_regularTool(t *testing.T) {
 func TestToolApprovalMetadata_delegation(t *testing.T) {
 	sub := &Agent{agentConfig: agentConfig{Name: "MathPro"}}
 	cfg := &agentConfig{
-		Name:      "Coordinator",
+		Name:      "Main agent",
 		subAgents: []*Agent{sub},
 	}
 	aw := &AgentWorker{config: cfg}
@@ -30,7 +30,7 @@ func TestToolApprovalMetadata_delegation(t *testing.T) {
 	if kind != ToolApprovalKindDelegation {
 		t.Fatalf("kind = %q, want delegation", kind)
 	}
-	if agent != "Coordinator" {
+	if agent != "Main agent" {
 		t.Fatalf("agent = %q", agent)
 	}
 	if delegate != "MathPro" {

--- a/pkg/agent/workflow_test.go
+++ b/pkg/agent/workflow_test.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/vvsynapse/temporal-agent-sdk-go/pkg/interfaces"
+)
+
+func TestToolApprovalMetadata_regularTool(t *testing.T) {
+	cfg := &agentConfig{
+		Name:  "Coordinator",
+		tools: []interfaces.Tool{mockTool{name: "echo"}},
+	}
+	aw := &AgentWorker{config: cfg}
+	kind, agent, delegate := toolApprovalMetadata(aw, "echo")
+	if kind != ToolApprovalKindTool || agent != "Coordinator" || delegate != "" {
+		t.Fatalf("got kind=%q agent=%q delegate=%q", kind, agent, delegate)
+	}
+}
+
+func TestToolApprovalMetadata_delegation(t *testing.T) {
+	sub := &Agent{agentConfig: agentConfig{Name: "MathPro"}}
+	cfg := &agentConfig{
+		Name:      "Coordinator",
+		subAgents: []*Agent{sub},
+	}
+	aw := &AgentWorker{config: cfg}
+	toolName := SubAgentToolName(sub)
+	kind, agent, delegate := toolApprovalMetadata(aw, toolName)
+	if kind != ToolApprovalKindDelegation {
+		t.Fatalf("kind = %q, want delegation", kind)
+	}
+	if agent != "Coordinator" {
+		t.Fatalf("agent = %q", agent)
+	}
+	if delegate != "MathPro" {
+		t.Fatalf("delegate = %q, want MathPro", delegate)
+	}
+}

--- a/pkg/logger/zap_adapter.go
+++ b/pkg/logger/zap_adapter.go
@@ -43,6 +43,15 @@ func parseLevel(s string) zapcore.Level {
 	}
 }
 
+func levelEncoderForOutput(output string) zapcore.LevelEncoder {
+	// Color codes (e.g. \x1b[34m) are for TTYs; files show raw ESC sequences as garbage like "[34mINFO[0m".
+	o := strings.ToLower(strings.TrimSpace(output))
+	if o == "stdout" || o == "stderr" {
+		return zapcore.CapitalColorLevelEncoder
+	}
+	return zapcore.CapitalLevelEncoder
+}
+
 func newZapLoggerConfig(level zapcore.Level, output string) zap.Config {
 	encodeConfig := zapcore.EncoderConfig{
 		TimeKey:        "ts",
@@ -52,7 +61,7 @@ func newZapLoggerConfig(level zapcore.Level, output string) zap.Config {
 		MessageKey:     "msg",
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
-		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+		EncodeLevel:    levelEncoderForOutput(output),
 		EncodeTime:     zapcore.ISO8601TimeEncoder,
 		EncodeDuration: zapcore.MillisDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,


### PR DESCRIPTION
## Description

Adds sub-agents: the main agent can delegate work to specialist agents registered with WithSubAgents. Each specialist is a normal Agent (own TaskQueue, LLM, tools, system prompt) and is exposed to the main agent’s model as a tool (subagent_*). Execution is not Tool.Execute on the parent worker—it runs as a child AgentWorkflow on the specialist’s task queue, and the result is returned to the main loop as the tool result.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] I have run `make lint` and `make test` locally
- [x] I have run `make tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
