### PR TITLE
Feat/tools exec parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - **AG-UI** — Stream events conform to the [AG-UI protocol](https://docs.ag-ui.com); agents work out of the box with any AG-UI compatible frontend such as [CopilotKit](https://copilotkit.ai).
 - **Reasoning** — Extended thinking / chain-of-thought where supported (Anthropic, Gemini).
 - **Token usage** — Track input, output, and reasoning token counts per run.
-- **Tools** — Register built-in or custom tools via `interfaces.Tool`.
+- **Tools** — Register built-in or custom tools via `interfaces.Tool`; optional **parallel vs sequential** execution for multiple tool calls in one LLM round (`WithAgentToolExecutionMode`).
 - **MCP** — Extend agent capabilities by connecting any MCP server as a tool source via `WithMCPConfig` or `WithMCPClients`.
 - **Human-in-the-loop** — Approval gates on tool calls and delegation across `Run`, `RunAsync`, and `Stream`.
 - **Sub-agents** — Delegate to specialist agents via `WithSubAgents`.
@@ -274,6 +274,13 @@ Examples: [examples/simple_agent](examples/simple_agent) (prints usage after `Ru
 
 Register tools and pass to the agent. Use `agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy())` to skip approval (or omit for default approval flow).
 
+**Tool execution mode.** When the model returns **several tool calls** in one assistant turn, you can run them **in parallel** (default) or **sequentially** (one completes before the next starts, in model order):
+
+- `agent.WithAgentToolExecutionMode(agent.AgentToolExecutionModeParallel)` — **default** if you omit the option; good when tool calls are independent and you want lower latency.
+- `agent.WithAgentToolExecutionMode(agent.AgentToolExecutionModeSequential)` — use when **order matters** or tools **must not run at the same time** (shared mutable state, rate limits, or similar).
+
+Use the **same** `WithAgentToolExecutionMode` value on **`NewAgent`** and **`NewAgentWorker`** (and on any **sub-agents** you register) for a given app or deployment so every process that runs that agent agrees on the option.
+
 Custom tools may also implement:
 
 - `interfaces.ToolApproval` — tool-level hint for **interactive human approval**. Use this when a person should decide whether the tool runs, and no agent-level approval policy is set.
@@ -289,6 +296,8 @@ a, _ := agent.NewAgent(
     agent.WithLLMClient(...),
     agent.WithToolRegistry(reg),
     agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
+    // Optional: agent.AgentToolExecutionModeSequential for ordered tool batches; default is Parallel.
+    // agent.WithAgentToolExecutionMode(agent.AgentToolExecutionModeSequential),
 )
 defer a.Close()
 

--- a/examples/agent_with_stream_conversation/main.go
+++ b/examples/agent_with_stream_conversation/main.go
@@ -141,7 +141,7 @@ func printEvent(ev agent.AgentEvent, streamedContent bool) {
 		}
 	case agent.AgentEventTypeReasoningMessageContent:
 		if r, ok := ev.(*agent.AgentReasoningMessageContentEvent); ok && r.Delta != "" {
-			fmt.Printf("[thinking] %s", r.Delta)
+			fmt.Printf("\n[thinking] %s", r.Delta)
 		}
 	case agent.AgentEventTypeToolCallStart:
 		if t, ok := ev.(*agent.AgentToolCallStartEvent); ok {
@@ -149,7 +149,7 @@ func printEvent(ev agent.AgentEvent, streamedContent bool) {
 		}
 	case agent.AgentEventTypeToolCallArgs:
 		if t, ok := ev.(*agent.AgentToolCallArgsEvent); ok && t.Delta != "" {
-			fmt.Printf("[%s] %s %s\n", eventType, t.ToolCallID, t.Delta)
+			fmt.Printf("\n[%s] %s %s\n", eventType, t.ToolCallID, t.Delta)
 		}
 	case agent.AgentEventTypeToolCallResult:
 		if t, ok := ev.(*agent.AgentToolCallResultEvent); ok {
@@ -157,16 +157,16 @@ func printEvent(ev agent.AgentEvent, streamedContent bool) {
 		}
 	case agent.AgentEventTypeRunStarted:
 		if r, ok := ev.(*agent.AgentRunStartedEvent); ok {
-			fmt.Printf("[%s] threadID=%s runID=%s\n", eventType, r.ThreadID, r.RunID)
+			fmt.Printf("\n[%s] threadID=%s runID=%s\n", eventType, r.ThreadID, r.RunID)
 		}
 	case agent.AgentEventTypeRunError:
 		if re, ok := ev.(*agent.AgentRunErrorEvent); ok {
-			fmt.Printf("[%s] %s\n", eventType, re.Message)
+			fmt.Printf("\n[%s] %s\n", eventType, re.Message)
 		}
 	case agent.AgentEventTypeRunFinished:
 		res := shared.RunResultFromFinishedEvent(ev)
 		if res != nil && res.Content != "" && !streamedContent {
-			fmt.Printf("[%s] %s\n", eventType, res.Content)
+			fmt.Printf("\n[%s] %s\n", eventType, res.Content)
 		}
 		if u := shared.UsageFooter(res); u != "" {
 			fmt.Println()

--- a/internal/runtime/temporal/agent_workflow.go
+++ b/internal/runtime/temporal/agent_workflow.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -150,6 +151,24 @@ type ToolCallRequest struct {
 	NeedsApproval   bool           `json:"needs_approval"`
 }
 
+// agentToolCallInput bundles the workflow handle, per-iteration activity contexts, and emit plumbing for tool execution.
+// Built once per sequential LLM tool round, or once per parallel branch (unique parallelSlot activity IDs).
+type agentToolCallInput struct {
+	wfCtx        workflow.Context
+	input        AgentWorkflowInput
+	messageID    string
+	emitEvent    func(events.AgentEvent) error
+	authorizeCtx workflow.Context
+	approvalCtx  workflow.Context
+	execCtx      workflow.Context
+}
+
+// agentToolCallOutput is the output of executeAgentToolCall.
+type agentToolCallOutput struct {
+	msg                  interfaces.Message
+	streamingUnavailable bool
+}
+
 // AgentToolExecuteInput is the input to AgentToolExecuteActivity.
 type AgentToolExecuteInput struct {
 	ToolName         string               `json:"tool_name"`
@@ -239,30 +258,6 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 		RetryPolicy:         retryPolicy(agentLLMActivityMaxAttempts),
 	})
 
-	approvalTaskTimeout := rt.AgentExecution.Limits.ApprovalTimeout
-	if approvalTaskTimeout == 0 {
-		approvalTaskTimeout = types.MaxApprovalTimeout
-	}
-	if approvalTaskTimeout > types.MaxApprovalTimeout {
-		approvalTaskTimeout = types.MaxApprovalTimeout
-	}
-
-	approvalCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ActivityID:          "AgentToolApprovalActivity_" + activityIDSuffix,
-		StartToCloseTimeout: approvalTaskTimeout,
-		RetryPolicy:         retryPolicy(agentToolApprovalActivityMaxAttempts),
-	})
-	authorizeCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ActivityID:          "AgentToolAuthorizeActivity_" + activityIDSuffix,
-		StartToCloseTimeout: agentToolAuthorizeActivityTaskTimeout,
-		RetryPolicy:         retryPolicy(agentToolAuthorizeActivityMaxAttempts),
-	})
-	execCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
-		ActivityID:          "AgentToolExecuteActivity_" + activityIDSuffix,
-		StartToCloseTimeout: agentToolExecuteActivityTaskTimeout,
-		HeartbeatTimeout:    agentLongActivityHeartbeatTimeout,
-		RetryPolicy:         retryPolicy(agentToolExecuteActivityMaxAttempts),
-	})
 	sendEventCtx := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 		ActivityID:          "SendAgentEventUpdateActivity_" + activityIDSuffix,
 		StartToCloseTimeout: sendEventActivityTaskTimeout,
@@ -275,7 +270,9 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 	})
 
 	var streamingUnavailable bool
-	emitEvent := func(ev events.AgentEvent) error {
+	// emitAgentEvent must use wfCtx (the coroutine that calls Get) for ExecuteActivity().Get — not the root
+	// workflow ctx — or parallel tool branches panic: "wrong Context is used to do blocking call".
+	emitAgentEvent := func(wfCtx workflow.Context, ev events.AgentEvent) error {
 		if ev == nil {
 			return nil
 		}
@@ -313,7 +310,7 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 			EventType:       ev.Type(),
 			Update:          upd,
 		}
-		if err := workflow.ExecuteActivity(sendEventCtx, rt.SendAgentEventUpdateActivity, actIn).Get(ctx, &res); err != nil {
+		if err := workflow.ExecuteActivity(sendEventCtx, rt.SendAgentEventUpdateActivity, actIn).Get(wfCtx, &res); err != nil {
 			return err
 		}
 		if res.StreamUnavailable {
@@ -386,7 +383,6 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 			break
 		}
 
-		var toolResults []interfaces.Message
 		// Accumulate assistant message for next iteration
 		assistantMsg := interfaces.Message{
 			Role:      interfaces.MessageRoleAssistant,
@@ -402,144 +398,138 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 		}
 		messages = append(messages, assistantMsg)
 
-		emitToolEndThenResult := func(toolCallID, content string) error {
-			if emitErr := emitEvent(events.NewAgentToolCallEndEvent(toolCallID)); emitErr != nil {
-				return emitErr
-			}
-			return emitEvent(events.NewAgentToolCallResultEvent(messageID, toolCallID, content, string(interfaces.MessageRoleTool)))
+		var toolResults []interfaces.Message
+
+		toolExecMode := rt.AgentToolExecutionMode
+		if toolExecMode == "" {
+			toolExecMode = types.AgentToolExecutionModeParallel
 		}
+		switch toolExecMode {
+		case types.AgentToolExecutionModeParallel:
+			{
+				logger.Info("workflow: tool execution (parallel)",
+					"scope", "workflow",
+					"executionMode", string(types.AgentToolExecutionModeParallel),
+					"toolCount", len(llmResult.ToolCalls))
 
-		// authorize / approve / execute, then TOOL_CALL_END + TOOL_CALL_RESULT.
-		for _, tc := range llmResult.ToolCalls {
-			//TOOL_CALL_START
-			if emitErr := emitEvent(events.NewAgentToolCallStartEvent(tc.ToolCallID, tc.ToolName, messageID)); emitErr != nil {
-				return nil, emitErr
-			}
-			//TOOL_CALL_ARGS
-			if argsJSON, err := json.Marshal(tc.Args); err == nil {
-				s := strings.TrimSpace(string(argsJSON))
-				if s != "" && s != "null" && s != "{}" {
-					if emitErr := emitEvent(events.NewAgentToolCallArgsEvent(tc.ToolCallID, s)); emitErr != nil {
-						return nil, emitErr
+				futures := make([]workflow.Future, len(llmResult.ToolCalls))
+				for i := range llmResult.ToolCalls {
+					i := i
+					tc := llmResult.ToolCalls[i]
+					logger.Debug("workflow: parallel tool branch scheduled",
+						"scope", "workflow",
+						"toolIndex", i,
+						"toolName", tc.ToolName,
+						"toolCallID", tc.ToolCallID)
+					fut, settable := workflow.NewFuture(ctx)
+					futures[i] = fut
+
+					workflow.Go(ctx, func(gCtx workflow.Context) {
+						gLog := workflow.GetLogger(gCtx)
+						gLog.Debug("workflow: parallel tool branch started",
+							"scope", "workflow",
+							"toolIndex", i,
+							"toolName", tc.ToolName,
+							"toolCallID", tc.ToolCallID)
+						slot := strconv.Itoa(i)
+						parallelInput := rt.newAgentToolCallInput(gCtx, input, activityIDSuffix, messageID, emitAgentEvent, slot)
+						toolOutput, runErr := rt.executeAgentToolCall(parallelInput, tc, streamingUnavailable)
+						if runErr != nil {
+							gLog.Debug("workflow: parallel tool branch finished with error",
+								"scope", "workflow",
+								"toolIndex", i,
+								"toolName", tc.ToolName,
+								"toolCallID", tc.ToolCallID,
+								"error", runErr)
+							settable.Set(nil, runErr)
+							return
+						}
+						// executeAgentToolCall returns (nil, err) or (non-nil *agentToolCallOutput, nil) only.
+						gLog.Debug("workflow: parallel tool branch finished ok",
+							"scope", "workflow",
+							"toolIndex", i,
+							"toolName", tc.ToolName,
+							"toolCallID", tc.ToolCallID)
+						settable.Set(toolOutput, nil)
+					})
+				}
+
+				toolResults = make([]interfaces.Message, len(futures))
+				for i, fut := range futures {
+					tc := llmResult.ToolCalls[i]
+					var v *agentToolCallOutput
+					err := fut.Get(ctx, &v)
+
+					if err != nil {
+						logger.Debug("workflow: parallel tool future collected (error → synthetic tool message)",
+							"scope", "workflow",
+							"toolIndex", i,
+							"toolName", tc.ToolName,
+							"toolCallID", tc.ToolCallID,
+							"error", err)
+						// Tool failed — send error as tool result so LLM can handle it
+						toolResults[i] = interfaces.Message{
+							Role:       interfaces.MessageRoleTool,
+							Content:    "Tool execution failed: " + err.Error(),
+							ToolName:   tc.ToolName,
+							ToolCallID: tc.ToolCallID,
+						}
+					} else {
+						// Success: branch always Set(non-nil *agentToolCallOutput, nil).
+						logger.Debug("workflow: parallel tool future collected (ok)",
+							"scope", "workflow",
+							"toolIndex", i,
+							"toolName", tc.ToolName,
+							"toolCallID", tc.ToolCallID,
+							"streamingUnavailable", v.streamingUnavailable)
+						toolResults[i] = v.msg
+						if v.streamingUnavailable {
+							streamingUnavailable = true
+						}
 					}
 				}
 			}
-
-			var authResult AgentToolAuthorizeResult
-			authInput := AgentToolAuthorizeInput{
-				ToolCallID:       tc.ToolCallID,
-				ToolName:         tc.ToolName,
-				Args:             tc.Args,
-				AgentFingerprint: input.AgentFingerprint,
-			}
-			if err := workflow.ExecuteActivity(authorizeCtx, rt.AgentToolAuthorizeActivity, authInput).Get(authorizeCtx, &authResult); err != nil {
-				return nil, err
-			}
-			if !authResult.Allowed {
-				logger.Info("workflow: tool authorization denied", "scope", "workflow", "toolName", tc.ToolName, "toolCallID", tc.ToolCallID)
-				content := msgToolUnauthorized
-				if strings.TrimSpace(authResult.Reason) != "" {
-					content = fmt.Sprintf("%s Reason: %s", content, authResult.Reason)
-				}
-				//TOOL_CALL_END + TOOL_CALL_RESULT
-				if emitErr := emitToolEndThenResult(tc.ToolCallID, content); emitErr != nil {
-					return nil, emitErr
-				}
-
-				toolResults = append(toolResults, interfaces.Message{
-					Role:       interfaces.MessageRoleTool,
-					Content:    content,
-					ToolName:   tc.ToolName,
-					ToolCallID: tc.ToolCallID,
-				})
-				continue
-			}
-
-			approvalStatus := types.ApprovalStatusApproved
-			if tc.NeedsApproval {
-				logger.Info("workflow: tool requires approval", "scope", "workflow", "toolName", tc.ToolName, "argCount", len(tc.Args))
-				if streamingUnavailable {
-					approvalStatus = types.ApprovalStatusUnavailable
-				} else {
-					var status types.ApprovalStatus
-					approvalInput := AgentToolApprovalInput{
-						AgentName:        agentName,
-						ToolCallID:       tc.ToolCallID,
-						ToolName:         tc.ToolName,
-						ToolDisplayName:  tc.ToolDisplayName,
-						Args:             tc.Args,
-						EventWorkflowID:  eventWorkflowID,
-						EventTaskQueue:   eventTaskQueue,
-						LocalChannelName: input.LocalChannelName,
-						AgentFingerprint: input.AgentFingerprint,
+		case types.AgentToolExecutionModeSequential:
+			{
+				logger.Info("workflow: tool execution (sequential)",
+					"scope", "workflow",
+					"executionMode", string(types.AgentToolExecutionModeSequential),
+					"toolCount", len(llmResult.ToolCalls))
+				toolInput := rt.newAgentToolCallInput(ctx, input, activityIDSuffix, messageID, emitAgentEvent, "")
+				// authorize / approve / execute, then TOOL_CALL_END + TOOL_CALL_RESULT.
+				for i, tc := range llmResult.ToolCalls {
+					logger.Debug("workflow: sequential tool executing",
+						"scope", "workflow",
+						"toolIndex", i,
+						"toolName", tc.ToolName,
+						"toolCallID", tc.ToolCallID,
+						"toolCount", len(llmResult.ToolCalls))
+					toolOutput, runErr := rt.executeAgentToolCall(toolInput, tc, streamingUnavailable)
+					if runErr != nil {
+						logger.Info("workflow: sequential tool failed",
+							"scope", "workflow",
+							"toolIndex", i,
+							"toolName", tc.ToolName,
+							"toolCallID", tc.ToolCallID,
+							"error", runErr)
+						return nil, runErr
 					}
-					if route, ok := input.SubAgentRoutes[tc.ToolName]; ok {
-						approvalInput.SubAgentName = route.Name
-					}
-					if err := workflow.ExecuteActivity(approvalCtx, rt.AgentToolApprovalActivity, approvalInput).Get(approvalCtx, &status); err != nil {
-						return nil, err
-					}
-					approvalStatus = status
-					if approvalStatus == types.ApprovalStatusUnavailable {
+					if toolOutput.streamingUnavailable {
 						streamingUnavailable = true
 					}
-				}
-			}
-
-			var content string
-			switch approvalStatus {
-			case types.ApprovalStatusApproved:
-				if route, ok := input.SubAgentRoutes[tc.ToolName]; ok {
-					logger.Info("workflow: executing sub-agent delegation",
+					logger.Debug("workflow: sequential tool completed",
 						"scope", "workflow",
-						"tool", tc.ToolName,
+						"toolIndex", i,
+						"toolName", tc.ToolName,
 						"toolCallID", tc.ToolCallID,
-						"childTaskQueue", strings.TrimSpace(route.TaskQueue),
-						"subAgentDepth", input.SubAgentDepth)
-					var subErr error
-					content, subErr = rt.delegateToSubAgent(ctx, input, tc, route, emitEvent)
-					if subErr != nil {
-						return nil, subErr
-					}
-				} else {
-					logger.Info("workflow: executing tool",
-						"scope", "workflow",
-						"tool", tc.ToolName,
-						"toolCallID", tc.ToolCallID)
-					var result string
-					execInput := AgentToolExecuteInput{
-						ToolName:         tc.ToolName,
-						Args:             tc.Args,
-						ConversationID:   input.ConversationID,
-						ToolCallID:       tc.ToolCallID,
-						AgentFingerprint: input.AgentFingerprint,
-					}
-					errExec := workflow.ExecuteActivity(execCtx, rt.AgentToolExecuteActivity, execInput).Get(execCtx, &result)
-					if errExec != nil {
-						content = "Tool execution failed: " + errExec.Error()
-					} else {
-						content = result
-					}
+						"streamingUnavailable", toolOutput.streamingUnavailable)
+					toolResults = append(toolResults, toolOutput.msg)
 				}
-			case types.ApprovalStatusRejected:
-				content = msgToolRejected
-			case types.ApprovalStatusUnavailable:
-				content = msgToolApprovalUnavailable
-			default:
-				return nil, fmt.Errorf("workflow: unexpected approval status %q for tool %q", approvalStatus, tc.ToolName)
 			}
-			//TOOL_CALL_END + TOOL_CALL_RESULT
-			if emitErr := emitToolEndThenResult(tc.ToolCallID, content); emitErr != nil {
-				return nil, emitErr
-			}
-
-			toolResults = append(toolResults, interfaces.Message{
-				Role:       interfaces.MessageRoleTool,
-				Content:    content,
-				ToolName:   tc.ToolName,
-				ToolCallID: tc.ToolCallID,
-			})
+		default:
+			return nil, fmt.Errorf("invalid tool execution mode %q: use %q or %q", toolExecMode, types.AgentToolExecutionModeParallel, types.AgentToolExecutionModeSequential)
 		}
+
 		messages = append(messages, toolResults...)
 	}
 
@@ -563,6 +553,198 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 	logger.Info("workflow: agent run completed", "scope", "workflow", "contentLen", len(lastContent))
 	return &types.AgentRunResult{
 		Content: lastContent, AgentName: agentName, Model: model, Metadata: map[string]any{}, Usage: runUsage,
+	}, nil
+}
+
+// newAgentToolCallInput builds activity contexts for one tool-call branch.
+// parallelSlot must be unique across concurrent tools (e.g. index string); use empty when calls run sequentially.
+func (rt *TemporalRuntime) newAgentToolCallInput(
+	wfCtx workflow.Context,
+	input AgentWorkflowInput,
+	activityIDSuffix, messageID string,
+	emitAgentEvent func(workflow.Context, events.AgentEvent) error,
+	parallelSlot string,
+) agentToolCallInput {
+	approvalTaskTimeout := rt.AgentExecution.Limits.ApprovalTimeout
+	if approvalTaskTimeout == 0 {
+		approvalTaskTimeout = types.MaxApprovalTimeout
+	}
+	if approvalTaskTimeout > types.MaxApprovalTimeout {
+		approvalTaskTimeout = types.MaxApprovalTimeout
+	}
+	activityScope := activityIDSuffix
+	if parallelSlot != "" {
+		activityScope = activityIDSuffix + "_" + parallelSlot
+	}
+	return agentToolCallInput{
+		wfCtx:     wfCtx,
+		input:     input,
+		messageID: messageID,
+		emitEvent: func(ev events.AgentEvent) error {
+			return emitAgentEvent(wfCtx, ev)
+		},
+		authorizeCtx: workflow.WithActivityOptions(wfCtx, workflow.ActivityOptions{
+			ActivityID:          "AgentToolAuthorizeActivity_" + activityScope,
+			StartToCloseTimeout: agentToolAuthorizeActivityTaskTimeout,
+			RetryPolicy:         retryPolicy(agentToolAuthorizeActivityMaxAttempts),
+		}),
+		approvalCtx: workflow.WithActivityOptions(wfCtx, workflow.ActivityOptions{
+			ActivityID:          "AgentToolApprovalActivity_" + activityScope,
+			StartToCloseTimeout: approvalTaskTimeout,
+			RetryPolicy:         retryPolicy(agentToolApprovalActivityMaxAttempts),
+		}),
+		execCtx: workflow.WithActivityOptions(wfCtx, workflow.ActivityOptions{
+			ActivityID:          "AgentToolExecuteActivity_" + activityScope,
+			StartToCloseTimeout: agentToolExecuteActivityTaskTimeout,
+			HeartbeatTimeout:    agentLongActivityHeartbeatTimeout,
+			RetryPolicy:         retryPolicy(agentToolExecuteActivityMaxAttempts),
+		}),
+	}
+}
+
+// executeAgentToolCall runs authorize → approval → execute or sub-agent delegation for one tool call,
+// emits tool stream events, and returns the tool role message for the conversation.
+// The second return is true when approval returned ApprovalStatusUnavailable (caller should set streamingUnavailable).
+func (rt *TemporalRuntime) executeAgentToolCall(input agentToolCallInput, tc ToolCallRequest, streamingUnavailable bool) (*agentToolCallOutput, error) {
+	logger := workflow.GetLogger(input.wfCtx)
+	agentName := rt.AgentSpec.Name
+	eventWorkflowID := input.input.EventWorkflowID
+	eventTaskQueue := input.input.EventTaskQueue
+
+	emitToolEndThenResult := func(toolCallID, content string) error {
+		if emitErr := input.emitEvent(events.NewAgentToolCallEndEvent(toolCallID)); emitErr != nil {
+			return emitErr
+		}
+		return input.emitEvent(events.NewAgentToolCallResultEvent(input.messageID, toolCallID, content, string(interfaces.MessageRoleTool)))
+	}
+
+	if emitErr := input.emitEvent(events.NewAgentToolCallStartEvent(tc.ToolCallID, tc.ToolName, input.messageID)); emitErr != nil {
+		return nil, emitErr
+	}
+	if argsJSON, err := json.Marshal(tc.Args); err == nil {
+		s := strings.TrimSpace(string(argsJSON))
+		if s != "" && s != "null" && s != "{}" {
+			if emitErr := input.emitEvent(events.NewAgentToolCallArgsEvent(tc.ToolCallID, s)); emitErr != nil {
+				return nil, emitErr
+			}
+		}
+	}
+
+	var authResult AgentToolAuthorizeResult
+	authInput := AgentToolAuthorizeInput{
+		ToolCallID:       tc.ToolCallID,
+		ToolName:         tc.ToolName,
+		Args:             tc.Args,
+		AgentFingerprint: input.input.AgentFingerprint,
+	}
+	if err := workflow.ExecuteActivity(input.authorizeCtx, rt.AgentToolAuthorizeActivity, authInput).Get(input.authorizeCtx, &authResult); err != nil {
+		return nil, err
+	}
+	if !authResult.Allowed {
+		logger.Info("workflow: tool authorization denied", "scope", "workflow", "toolName", tc.ToolName, "toolCallID", tc.ToolCallID)
+		content := msgToolUnauthorized
+		if strings.TrimSpace(authResult.Reason) != "" {
+			content = fmt.Sprintf("%s Reason: %s", content, authResult.Reason)
+		}
+		if emitErr := emitToolEndThenResult(tc.ToolCallID, content); emitErr != nil {
+			return nil, emitErr
+		}
+		return &agentToolCallOutput{
+			msg: interfaces.Message{
+				Role:       interfaces.MessageRoleTool,
+				Content:    content,
+				ToolName:   tc.ToolName,
+				ToolCallID: tc.ToolCallID,
+			},
+			streamingUnavailable: false,
+		}, nil
+	}
+
+	approvalStatus := types.ApprovalStatusApproved
+	markStreamingUnavailable := false
+	if tc.NeedsApproval {
+		logger.Info("workflow: tool requires approval", "scope", "workflow", "toolName", tc.ToolName, "argCount", len(tc.Args))
+		if streamingUnavailable {
+			approvalStatus = types.ApprovalStatusUnavailable
+		} else {
+			var status types.ApprovalStatus
+			approvalInput := AgentToolApprovalInput{
+				AgentName:        agentName,
+				ToolCallID:       tc.ToolCallID,
+				ToolName:         tc.ToolName,
+				ToolDisplayName:  tc.ToolDisplayName,
+				Args:             tc.Args,
+				EventWorkflowID:  eventWorkflowID,
+				EventTaskQueue:   eventTaskQueue,
+				LocalChannelName: input.input.LocalChannelName,
+				AgentFingerprint: input.input.AgentFingerprint,
+			}
+			if route, ok := input.input.SubAgentRoutes[tc.ToolName]; ok {
+				approvalInput.SubAgentName = route.Name
+			}
+			if err := workflow.ExecuteActivity(input.approvalCtx, rt.AgentToolApprovalActivity, approvalInput).Get(input.approvalCtx, &status); err != nil {
+				return nil, err
+			}
+			approvalStatus = status
+			if approvalStatus == types.ApprovalStatusUnavailable {
+				markStreamingUnavailable = true
+			}
+		}
+	}
+
+	var content string
+	switch approvalStatus {
+	case types.ApprovalStatusApproved:
+		if route, ok := input.input.SubAgentRoutes[tc.ToolName]; ok {
+			logger.Info("workflow: executing sub-agent delegation",
+				"scope", "workflow",
+				"tool", tc.ToolName,
+				"toolCallID", tc.ToolCallID,
+				"childTaskQueue", strings.TrimSpace(route.TaskQueue),
+				"subAgentDepth", input.input.SubAgentDepth)
+			var subErr error
+			content, subErr = rt.delegateToSubAgent(input.wfCtx, input.input, tc, route, input.emitEvent)
+			if subErr != nil {
+				return nil, subErr
+			}
+		} else {
+			logger.Info("workflow: executing tool",
+				"scope", "workflow",
+				"tool", tc.ToolName,
+				"toolCallID", tc.ToolCallID)
+			var result string
+			execInput := AgentToolExecuteInput{
+				ToolName:         tc.ToolName,
+				Args:             tc.Args,
+				ConversationID:   input.input.ConversationID,
+				ToolCallID:       tc.ToolCallID,
+				AgentFingerprint: input.input.AgentFingerprint,
+			}
+			errExec := workflow.ExecuteActivity(input.execCtx, rt.AgentToolExecuteActivity, execInput).Get(input.execCtx, &result)
+			if errExec != nil {
+				content = "Tool execution failed: " + errExec.Error()
+			} else {
+				content = result
+			}
+		}
+	case types.ApprovalStatusRejected:
+		content = msgToolRejected
+	case types.ApprovalStatusUnavailable:
+		content = msgToolApprovalUnavailable
+	default:
+		return nil, fmt.Errorf("workflow: unexpected approval status %q for tool %q", approvalStatus, tc.ToolName)
+	}
+	if emitErr := emitToolEndThenResult(tc.ToolCallID, content); emitErr != nil {
+		return nil, emitErr
+	}
+	return &agentToolCallOutput{
+		msg: interfaces.Message{
+			Role:       interfaces.MessageRoleTool,
+			Content:    content,
+			ToolName:   tc.ToolName,
+			ToolCallID: tc.ToolCallID,
+		},
+		streamingUnavailable: markStreamingUnavailable,
 	}, nil
 }
 

--- a/internal/runtime/temporal/config.go
+++ b/internal/runtime/temporal/config.go
@@ -41,6 +41,8 @@ type TemporalRuntimeConfig struct {
 	MCPFingerprint    string // from pkg/agent mcpConfigFingerprint; must match caller temporal.ComputeAgentFingerprint inputs
 	// AgentMode is the string form of [types.AgentMode] (e.g. "interactive", "autonomous"); must match pkg/agent WithAgentMode.
 	AgentMode string
+	// AgentToolExecutionMode is the [types.AgentToolExecutionMode] (e.g. "sequential", "parallel"); must match pkg/agent WithAgentToolExecutionMode.
+	AgentToolExecutionMode types.AgentToolExecutionMode
 	// DisableLocalWorker mirrors pkg/agent [DisableLocalWorker]: when false, the client embeds a worker
 	// so Execute/ExecuteStream skip DescribeTaskQueue poller checks. ([NewAgentWorker] never calls those methods.)
 	DisableLocalWorker bool
@@ -132,6 +134,14 @@ func WithAgentMode(mode string) Option {
 	}
 }
 
+// WithAgentToolExecutionMode sets the agent tool execution mode string used with [ComputeAgentFingerprint].
+// Must match pkg/agent [WithAgentToolExecutionMode] for the same agent (caller process and worker process).
+func WithAgentToolExecutionMode(mode types.AgentToolExecutionMode) Option {
+	return func(c *TemporalRuntimeConfig) {
+		c.AgentToolExecutionMode = mode
+	}
+}
+
 // WithDisableLocalWorker mirrors pkg/agent [DisableLocalWorker]. When false, the client embeds a worker
 // and the runtime skips DescribeTaskQueue poller checks before starting workflows.
 func WithDisableLocalWorker(disable bool) Option {
@@ -181,6 +191,8 @@ func buildTemporalRuntimeConfig(opts ...Option) (*TemporalRuntimeConfig, error) 
 		slog.String("instanceId", c.instanceId),
 		slog.Int("maxIterations", c.AgentExecution.Limits.MaxIterations),
 		slog.Bool("remoteWorker", c.remoteWorker),
+		slog.String("agentMode", c.AgentMode),
+		slog.String("agentToolExecutionMode", string(c.AgentToolExecutionMode)),
 		slog.Bool("enableRemoteWorkers", c.enableRemoteWorkers),
 		slog.Bool("disableFingerprintCheck", c.DisableFingerprintCheck),
 		slog.Duration("timeout", c.AgentExecution.Limits.Timeout),

--- a/internal/runtime/temporal/fingerprint.go
+++ b/internal/runtime/temporal/fingerprint.go
@@ -40,6 +40,9 @@ type AgentFingerprintPayload struct {
 	// AgentMode is the execution mode (e.g. interactive vs autonomous); must match pkg/agent WithAgentMode on caller and worker.
 	AgentMode string `json:"agent_mode"`
 
+	// AgentToolExecutionMode is the tool execution mode (e.g. sequential vs parallel); must match pkg/agent WithAgentToolExecutionMode on caller and worker.
+	AgentToolExecutionMode string `json:"agent_tool_execution_mode"`
+
 	Sampling *sdkruntime.LLMSampling `json:"sampling,omitempty"`
 
 	SessionSize int `json:"session_size"`
@@ -75,6 +78,7 @@ func BuildAgentFingerprintPayload(
 	limits sdkruntime.AgentLimits,
 	mcpFingerprint string,
 	agentMode string,
+	agentToolExecutionMode types.AgentToolExecutionMode,
 ) AgentFingerprintPayload {
 	names := append([]string(nil), toolNames...)
 	sort.Strings(names)
@@ -82,7 +86,10 @@ func BuildAgentFingerprintPayload(
 	if mode == "" {
 		mode = string(types.AgentModeInteractive)
 	}
-
+	toolExecutionMode := agentToolExecutionMode
+	if toolExecutionMode == "" {
+		toolExecutionMode = types.AgentToolExecutionModeParallel
+	}
 	m := AgentFingerprintPayload{
 		Name:              spec.Name,
 		Description:       spec.Description,
@@ -164,6 +171,7 @@ func computeAgentFingerprintFromRuntimeConfig(c *TemporalRuntimeConfig) string {
 		c.AgentExecution.Limits,
 		c.MCPFingerprint,
 		c.AgentMode,
+		c.AgentToolExecutionMode,
 	)
 	return ComputeAgentFingerprint(mat)
 }

--- a/internal/runtime/temporal/fingerprint.go
+++ b/internal/runtime/temporal/fingerprint.go
@@ -91,18 +91,19 @@ func BuildAgentFingerprintPayload(
 		toolExecutionMode = types.AgentToolExecutionModeParallel
 	}
 	m := AgentFingerprintPayload{
-		Name:              spec.Name,
-		Description:       spec.Description,
-		SystemPrompt:      spec.SystemPrompt,
-		ToolNames:         names,
-		PolicyFingerprint: policyFingerprint,
-		MCPFingerprint:    mcpFingerprint,
-		AgentMode:         mode,
-		Sampling:          cloneLLMSampling(sampling),
-		SessionSize:       sessionSize,
-		MaxIterations:     limits.MaxIterations,
-		TimeoutNs:         limits.Timeout.Nanoseconds(),
-		ApprovalTimeoutNs: limits.ApprovalTimeout.Nanoseconds(),
+		Name:                   spec.Name,
+		Description:            spec.Description,
+		SystemPrompt:           spec.SystemPrompt,
+		ToolNames:              names,
+		PolicyFingerprint:      policyFingerprint,
+		MCPFingerprint:         mcpFingerprint,
+		AgentMode:              mode,
+		AgentToolExecutionMode: string(toolExecutionMode),
+		Sampling:               cloneLLMSampling(sampling),
+		SessionSize:            sessionSize,
+		MaxIterations:          limits.MaxIterations,
+		TimeoutNs:              limits.Timeout.Nanoseconds(),
+		ApprovalTimeoutNs:      limits.ApprovalTimeout.Nanoseconds(),
 	}
 	if spec.ResponseFormat != nil {
 		rf := spec.ResponseFormat

--- a/internal/runtime/temporal/fingerprint_test.go
+++ b/internal/runtime/temporal/fingerprint_test.go
@@ -31,6 +31,7 @@ func TestComputeAgentFingerprint_stableAndToolOrder(t *testing.T) {
 		lim,
 		"",
 		"",
+		"",
 	)
 	h1 := ComputeAgentFingerprint(m)
 	h2 := ComputeAgentFingerprint(m)
@@ -38,8 +39,8 @@ func TestComputeAgentFingerprint_stableAndToolOrder(t *testing.T) {
 		t.Fatalf("fingerprint len=%d h1=%q h2=%q", len(h1), h1, h2)
 	}
 
-	hA := ComputeAgentFingerprint(BuildAgentFingerprintPayload(spec, []string{"a", "b", "c"}, "auto", nil, 0, lim, "", ""))
-	hB := ComputeAgentFingerprint(BuildAgentFingerprintPayload(spec, []string{"c", "a", "b"}, "auto", nil, 0, lim, "", ""))
+	hA := ComputeAgentFingerprint(BuildAgentFingerprintPayload(spec, []string{"a", "b", "c"}, "auto", nil, 0, lim, "", "", ""))
+	hB := ComputeAgentFingerprint(BuildAgentFingerprintPayload(spec, []string{"c", "a", "b"}, "auto", nil, 0, lim, "", "", ""))
 	if hA != hB {
 		t.Fatalf("tool order should not matter: %q vs %q", hA, hB)
 	}
@@ -48,8 +49,8 @@ func TestComputeAgentFingerprint_stableAndToolOrder(t *testing.T) {
 func TestComputeAgentFingerprint_agentModeChangesDigest(t *testing.T) {
 	spec := sdkruntime.AgentSpec{Name: "a", SystemPrompt: "p"}
 	lim := sdkruntime.AgentLimits{MaxIterations: 3}
-	interactive := BuildAgentFingerprintPayload(spec, nil, "auto", nil, 0, lim, "", "")
-	autonomous := BuildAgentFingerprintPayload(spec, nil, "auto", nil, 0, lim, "", "autonomous")
+	interactive := BuildAgentFingerprintPayload(spec, nil, "auto", nil, 0, lim, "", "", "")
+	autonomous := BuildAgentFingerprintPayload(spec, nil, "auto", nil, 0, lim, "", "autonomous", "")
 	if ComputeAgentFingerprint(interactive) == ComputeAgentFingerprint(autonomous) {
 		t.Fatal("expected different digests for autonomous vs interactive")
 	}
@@ -59,8 +60,8 @@ func TestComputeAgentFingerprint_mcpFingerprintChangesDigest(t *testing.T) {
 	spec := sdkruntime.AgentSpec{Name: "a", SystemPrompt: "p"}
 	lim := sdkruntime.AgentLimits{MaxIterations: 3}
 	tools := []string{"mcp_srv_echo"}
-	base := BuildAgentFingerprintPayload(spec, tools, "auto", nil, 0, lim, "", "")
-	withMCP := BuildAgentFingerprintPayload(spec, tools, "auto", nil, 0, lim, "abc123deadbeef", "")
+	base := BuildAgentFingerprintPayload(spec, tools, "auto", nil, 0, lim, "", "", "")
+	withMCP := BuildAgentFingerprintPayload(spec, tools, "auto", nil, 0, lim, "abc123deadbeef", "", "")
 	h0 := ComputeAgentFingerprint(base)
 	h1 := ComputeAgentFingerprint(withMCP)
 	if h0 == h1 {
@@ -127,6 +128,7 @@ func TestVerifyAgentFingerprint_disableCheckAllowsMismatch(t *testing.T) {
 			Session: sdkruntime.AgentSession{},
 			Limits:  sdkruntime.AgentLimits{},
 		},
+		AgentToolExecutionMode: "sequential",
 	}
 	rt := &TemporalRuntime{
 		TemporalRuntimeConfig: *cfg,
@@ -162,7 +164,7 @@ func TestBuildAgentFingerprintPayload_responseFormatAndSampling(t *testing.T) {
 		Reasoning:   &interfaces.LLMReasoning{Effort: "low"},
 	}
 	lim := sdkruntime.AgentLimits{MaxIterations: 1, Timeout: 0, ApprovalTimeout: 0}
-	p := BuildAgentFingerprintPayload(spec, []string{"t1"}, "p", sampling, 5, lim, "mcpfp", "")
+	p := BuildAgentFingerprintPayload(spec, []string{"t1"}, "p", sampling, 5, lim, "mcpfp", "", "")
 	if p.ResponseFormat == nil || p.ResponseFormat.Type != string(interfaces.ResponseFormatJSON) {
 		t.Fatalf("response format: %+v", p.ResponseFormat)
 	}

--- a/internal/types/agent.go
+++ b/internal/types/agent.go
@@ -29,3 +29,13 @@ const (
 	// for each step (subject to tool policy and limits).
 	AgentModeAutonomous AgentMode = "autonomous"
 )
+
+// ToolExecutionMode specifies how tools are executed in parallel or sequentially.
+type AgentToolExecutionMode string
+
+const (
+	// AgentToolExecutionModeParallel specifies that tools are executed in parallel.
+	AgentToolExecutionModeParallel AgentToolExecutionMode = "parallel"
+	// AgentToolExecutionModeSequential specifies that tools are executed sequentially.
+	AgentToolExecutionModeSequential AgentToolExecutionMode = "sequential"
+)

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -43,6 +43,14 @@ const (
 	AgentModeAutonomous  = types.AgentModeAutonomous
 )
 
+// AgentToolExecutionMode selects parallel (default) or sequential tool execution. Aliases [types.AgentToolExecutionMode].
+type AgentToolExecutionMode = types.AgentToolExecutionMode
+
+const (
+	AgentToolExecutionModeParallel   = types.AgentToolExecutionModeParallel
+	AgentToolExecutionModeSequential = types.AgentToolExecutionModeSequential
+)
+
 // MCPServers maps a stable server key (e.g. "github", "slack") to per-server MCP settings.
 // Registered tool names use prefix mcp_<serverKey>_<toolName> (see [MCPTool]).
 // nil or empty map means no MCP servers from configuration.
@@ -67,7 +75,7 @@ type MCPConfig struct {
 //     WithInstanceId, WithLLMClient, WithToolApprovalPolicy, WithTools, WithToolRegistry,
 //     WithMaxIterations, WithStream, WithLogger, WithLogLevel, WithConversation, WithConversationSize,
 //     WithResponseFormat, WithLLMSampling, WithSubAgents, WithMaxSubAgentDepth,
-//     WithMCPConfig, WithMCPClients, WithAgentMode, WithDisableFingerprintCheck
+//     WithMCPConfig, WithMCPClients, WithAgentMode, WithDisableFingerprintCheck, WithAgentToolExecutionMode
 type agentConfig struct {
 	ID                 string
 	Name               string
@@ -115,7 +123,8 @@ type agentConfig struct {
 	mcpClients []interfaces.MCPClient
 	mcpTools   []interfaces.Tool
 
-	agentMode AgentMode
+	agentMode              AgentMode
+	agentToolExecutionMode AgentToolExecutionMode
 }
 
 // Default Run/Stream deadlines when [WithTimeout] is unset: shorter for interactive sessions,
@@ -176,6 +185,12 @@ func WithInstanceId(id string) Option {
 // Default is [AgentModeInteractive]. Included in the Temporal agent fingerprint so caller and worker must agree.
 func WithAgentMode(mode AgentMode) Option {
 	return func(c *agentConfig) { c.agentMode = mode }
+}
+
+// WithAgentToolExecutionMode sets the tool execution mode. Applies to Agent and AgentWorker.
+// When this option is omitted, the agent uses [AgentToolExecutionModeParallel].
+func WithAgentToolExecutionMode(mode AgentToolExecutionMode) Option {
+	return func(c *agentConfig) { c.agentToolExecutionMode = mode }
 }
 
 // WithLLMClient sets the LLM client. Applies to Agent and AgentWorker.
@@ -381,6 +396,14 @@ func buildAgentConfig(opts []Option) (*agentConfig, error) {
 	default:
 		return nil, fmt.Errorf("invalid agent mode %q: use %q or %q", c.agentMode, AgentModeInteractive, AgentModeAutonomous)
 	}
+	if c.agentToolExecutionMode == "" {
+		c.agentToolExecutionMode = AgentToolExecutionModeParallel
+	}
+	switch c.agentToolExecutionMode {
+	case AgentToolExecutionModeSequential, AgentToolExecutionModeParallel:
+	default:
+		return nil, fmt.Errorf("invalid tool execution mode %q: use %q or %q", c.agentToolExecutionMode, AgentToolExecutionModeSequential, AgentToolExecutionModeParallel)
+	}
 	if c.maxSubAgentDepth <= 0 {
 		c.maxSubAgentDepth = defaultMaxSubAgentDepth
 	}
@@ -441,6 +464,7 @@ func buildAgentConfig(opts []Option) (*agentConfig, error) {
 		slog.Bool("remoteWorker", c.remoteWorker),
 		slog.Bool("disableFingerprintCheck", c.disableFingerprintCheck),
 		slog.String("agentMode", string(c.agentMode)),
+		slog.String("agentToolExecutionMode", string(c.agentToolExecutionMode)),
 		slog.Bool("hasApprovalHandler", c.approvalHandler != nil),
 		slog.Duration("timeout", c.timeout),
 		slog.Duration("approvalTimeout", c.approvalTimeout),
@@ -648,6 +672,7 @@ func (c *agentConfig) agentConfigFingerprint() string {
 		},
 		mcpConfigFingerprint(c.mcpServers, mcpExtraClientNames(c.mcpClients)),
 		string(c.agentMode),
+		c.agentToolExecutionMode,
 	)
 	return temporal.ComputeAgentFingerprint(mat)
 }

--- a/pkg/agent/runtime_factory.go
+++ b/pkg/agent/runtime_factory.go
@@ -29,6 +29,7 @@ func (cfg *agentConfig) buildTemporalRuntime(remoteWorker bool) (runtime.Runtime
 		temporal.WithPolicyFingerprint(toolPolicyFingerprint(cfg.toolApprovalPolicy)),
 		temporal.WithMCPFingerprint(mcpConfigFingerprint(cfg.mcpServers, mcpExtraClientNames(cfg.mcpClients))),
 		temporal.WithAgentMode(string(cfg.agentMode)),
+		temporal.WithAgentToolExecutionMode(cfg.agentToolExecutionMode),
 		temporal.WithDisableLocalWorker(cfg.disableLocalWorker),
 		// Never allow fingerprint bypass on remote worker runtime.
 		temporal.WithDisableFingerprintCheck(cfg.disableFingerprintCheck && !remoteWorker),


### PR DESCRIPTION
## Description

Parallel tool execution when the model returns multiple tool calls (default).
WithAgentToolExecutionMode: Parallel (default) or Sequential; use the same value on agent + worker + sub-agents.
Fix: event send activity uses the correct workflow context in parallel tool branches (no workflow panic).
Fingerprint payload includes tool execution mode; README documents the option (user-facing only).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / chore

## Related issues

Close #9 

## Checklist

- [x] I have run `make lint` and `make test` locally
- [x] I have run `make tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
