### PR TITLE
feat: deepseek llm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fmt.Println(result.Content)
 
 ## Features
 
-- **LLM providers** — OpenAI, Anthropic, Gemini + custom via `interfaces.LLMClient`
+- **LLM providers** — OpenAI, Anthropic, Gemini, DeepSeek + custom via `interfaces.LLMClient`
 - **Tools & MCP** — built-in and custom tools; MCP servers over stdio or streamable HTTP
 - **A2A** — expose agents as A2A servers or connect remote A2A agents as tools
 - **Sub-agents** — delegate to specialist agents with independent LLMs, tools, and task queues
@@ -82,7 +82,7 @@ fmt.Println(result.Content)
 - **Conversation history** — multi-turn sessions via in-memory or Redis backends
 - **Memory & RAG** — long-term scoped memory and retrieval-augmented generation
 - **Streaming & AG-UI** — partial token streaming; AG-UI protocol for frontend integration
-- **Reasoning** — extended thinking on Anthropic, Gemini, and OpenAI reasoning models
+- **Reasoning** — extended thinking on Anthropic, Gemini, DeepSeek, and OpenAI reasoning models
 - **Token usage** — aggregate prompt, completion, and reasoning token counts per run
 - **Hooks & guardrails** — middleware at LLM, tool, retrieval, and memory lifecycle points
 - **Execution config** — per-operation timeouts and max attempts via `With*ExecutionConfig`

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/anthropic"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm/deepseek"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/gemini"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/openai"
 	"github.com/agenticenv/agent-sdk-go/pkg/logger"
@@ -204,7 +205,8 @@ type LLMConfig struct {
 	Provider string `mapstructure:"provider"`
 	APIKey   string `mapstructure:"apiKey"`
 	Model    string `mapstructure:"model"`
-	// BaseURL is optional; only used when provider is openai (custom/Azure-compatible API).
+	// BaseURL is optional; used by openai and deepseek providers to override the API endpoint
+	// (custom/Azure-compatible proxies). For deepseek, leave empty to use its default endpoint.
 	BaseURL string `mapstructure:"baseURL"`
 }
 
@@ -315,6 +317,11 @@ func NewLLMClient(cfg *Config, lgr logger.Logger) (interfaces.LLMClient, error) 
 		return openai.NewClient(opts...)
 	case interfaces.LLMProviderGemini:
 		return gemini.NewClient(opts...)
+	case interfaces.LLMProviderDeepSeek:
+		if cfg.LLM.BaseURL != "" {
+			opts = append(opts, llm.WithBaseURL(cfg.LLM.BaseURL))
+		}
+		return deepseek.NewClient(opts...)
 	default:
 		if cfg.LLM.BaseURL != "" {
 			opts = append(opts, llm.WithBaseURL(cfg.LLM.BaseURL))

--- a/cmd/config.sample.yaml
+++ b/cmd/config.sample.yaml
@@ -22,12 +22,12 @@ temporal:
   namespace: default     # Temporal namespace
   taskQueue: agent-sdk-go   # Task queue for agent workflows
 
-# LLM provider (OpenAI, Anthropic, or Gemini)
+# LLM provider (OpenAI, Anthropic, Gemini, or DeepSeek)
 llm:
-  provider: openai      # openai | anthropic | gemini
+  provider: openai      # openai | anthropic | gemini | deepseek
   apiKey: ""            # Set here or via AGENT_LLM_APIKEY (preferred for secrets)
-  model: gpt-4o         # Model name, e.g. gpt-4o, gpt-4o-mini, claude-haiku-4-5, gemini-2.5-flash
-  baseURL: https://api.openai.com/v1   # Optional; used for OpenAI-compatible proxies
+  model: gpt-4o         # Model name, e.g. gpt-4o, claude-haiku-4-5, gemini-2.5-flash, deepseek-chat
+  baseURL: https://api.openai.com/v1   # Optional; OpenAI-compatible proxies. For deepseek, leave unset to use https://api.deepseek.com
 
 # Logger: file by default (JSON + caller). Prompts/responses use fmt in main, not this logger.
 logger:

--- a/docs/getting-started/llm-providers.mdx
+++ b/docs/getting-started/llm-providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "LLM Providers"
-description: "Configure OpenAI, Anthropic, or Gemini — or bring your own LLM client"
+description: "Configure OpenAI, Anthropic, Gemini, or DeepSeek — or bring your own LLM client"
 ---
 
 Every agent requires an [`interfaces.LLMClient`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/interfaces#LLMClient). Pass it to [`NewAgent`](/getting-started/quickstart) with [`WithLLMClient`](/getting-started/configuration).
@@ -18,8 +18,9 @@ import "github.com/agenticenv/agent-sdk-go/pkg/llm"
 | OpenAI | `pkg/llm/openai` | `openai` |
 | Anthropic | `pkg/llm/anthropic` | `anthropic` |
 | Gemini | `pkg/llm/gemini` | `gemini` |
+| DeepSeek | `pkg/llm/deepseek` | `deepseek` |
 
-All three implement the same interface:
+They all implement the same interface:
 
 ```go
 type LLMClient interface {
@@ -85,6 +86,28 @@ llmClient, err := gemini.NewClient(
 `llm.WithAPIKey` takes precedence. If you omit it, the Gemini client falls back to the `GOOGLE_API_KEY` environment variable automatically.
 </Note>
 
+## DeepSeek
+
+DeepSeek exposes an OpenAI-compatible API. The base URL defaults to `https://api.deepseek.com`, so `WithBaseURL` is optional.
+
+```go
+import (
+    "github.com/agenticenv/agent-sdk-go/pkg/llm"
+    "github.com/agenticenv/agent-sdk-go/pkg/llm/deepseek"
+)
+
+llmClient, err := deepseek.NewClient(
+    llm.WithAPIKey(os.Getenv("DEEPSEEK_API_KEY")),
+    llm.WithModel("deepseek-chat"), // or "deepseek-reasoner"
+)
+```
+
+Common models: `deepseek-chat` and `deepseek-reasoner`. Reasoning is not configured via the `Reasoning` field — `deepseek-reasoner` reasons automatically, and its trace surfaces via the streaming `LLMStreamChunk.ThinkingDelta` and, for non-streaming responses, `LLMResponse.Metadata["reasoning_content"]`.
+
+<Note>
+DeepSeek supports only plain JSON mode, not schema-constrained output. A [response format](/features/response-format) with `Type: ResponseFormatJSON` maps to DeepSeek's `json_object`; any `Schema` is ignored (not enforced by the API), so prompt the model for the shape you want, and include the word "json" in the conversation.
+</Note>
+
 ## Shared LLM options
 
 All built-in clients accept functional options from `pkg/llm`:
@@ -112,13 +135,13 @@ a, err := agent.NewAgent(
 
 Field support varies by provider:
 
-| Field | OpenAI | Anthropic | Gemini |
-|---|---|---|---|
-| `Temperature` | ✓ | ✓ | ✓ |
-| `MaxTokens` | ✓ | ✓ | ✓ |
-| `TopP` | ✓ | — | ✓ |
-| `TopK` | — | ✓ | — |
-| `Reasoning` | Partial | ✓ | ✓ |
+| Field | OpenAI | Anthropic | Gemini | DeepSeek |
+|---|---|---|---|---|
+| `Temperature` | ✓ | ✓ | ✓ | ✓ |
+| `MaxTokens` | ✓ | ✓ | ✓ | ✓ |
+| `TopP` | ✓ | — | ✓ | ✓ |
+| `TopK` | — | ✓ | — | — |
+| `Reasoning` | Partial | ✓ | ✓ | — |
 
 See [Reasoning](/features/reasoning) for extended thinking configuration per provider.
 

--- a/examples/.env.defaults
+++ b/examples/.env.defaults
@@ -27,7 +27,9 @@ TEMPORAL_NAMESPACE=default
 TEMPORAL_TASKQUEUE=agent-sdk-go
 
 # --- LLM (all examples) ---
-# Provider: openai | anthropic | gemini. Set LLM_APIKEY in examples/.env.
+# Provider: openai | anthropic | gemini | deepseek. Set LLM_APIKEY in examples/.env.
+# For deepseek, also set LLM_BASEURL=https://api.deepseek.com in examples/.env (it overrides
+# the OpenAI default below) and LLM_MODEL=deepseek-chat (or deepseek-reasoner).
 LLM_PROVIDER=openai
 LLM_APIKEY=
 LLM_MODEL=gpt-4o

--- a/examples/config.go
+++ b/examples/config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/anthropic"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm/deepseek"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/gemini"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/openai"
 	"github.com/agenticenv/agent-sdk-go/pkg/logger"
@@ -548,7 +549,8 @@ func NewLoggerFromLogConfig(cfg *Config) logger.Logger {
 }
 
 // NewLLMClientFromConfig creates an LLM client from config using the new llm.Option-based API.
-// BaseURL is applied only for OpenAI; set LLM_BASEURL when using a non-default OpenAI-compatible API.
+// BaseURL applies to the OpenAI and DeepSeek providers; set LLM_BASEURL for a non-default
+// OpenAI-compatible endpoint. DeepSeek defaults to its own endpoint when LLM_BASEURL is unset.
 func NewLLMClientFromConfig(cfg *Config) (interfaces.LLMClient, error) {
 	opts := []llm.Option{
 		llm.WithAPIKey(cfg.APIKey),
@@ -565,6 +567,11 @@ func NewLLMClientFromConfig(cfg *Config) (interfaces.LLMClient, error) {
 		return openai.NewClient(opts...)
 	case interfaces.LLMProviderGemini:
 		return gemini.NewClient(opts...)
+	case interfaces.LLMProviderDeepSeek:
+		if cfg.BaseURL != "" {
+			opts = append(opts, llm.WithBaseURL(cfg.BaseURL))
+		}
+		return deepseek.NewClient(opts...)
 	default:
 		if cfg.BaseURL != "" {
 			opts = append(opts, llm.WithBaseURL(cfg.BaseURL))

--- a/pkg/interfaces/llm.go
+++ b/pkg/interfaces/llm.go
@@ -14,6 +14,7 @@ const (
 	LLMProviderOpenAI    LLMProvider = "openai"
 	LLMProviderAnthropic LLMProvider = "anthropic"
 	LLMProviderGemini    LLMProvider = "gemini"
+	LLMProviderDeepSeek  LLMProvider = "deepseek"
 )
 
 type LLMClient interface {

--- a/pkg/llm/deepseek/client.go
+++ b/pkg/llm/deepseek/client.go
@@ -1,0 +1,334 @@
+// Package deepseek provides an interfaces.LLMClient for DeepSeek.
+//
+// DeepSeek exposes an OpenAI-compatible Chat Completions API, so this client uses the
+// openai-go SDK as its transport but implements the interface independently: it defaults
+// to DeepSeek's base URL, sends system prompts with the "system" role (DeepSeek does not
+// accept OpenAI's "developer" role), and maps the deepseek-reasoner "reasoning_content"
+// field into LLMResponse.Metadata["reasoning_content"] and streaming ThinkingDelta.
+//
+// Common models: "deepseek-chat" and "deepseek-reasoner".
+package deepseek
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/packages/respjson"
+	"github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/openai/openai-go/v3/shared/constant"
+)
+
+// DefaultBaseURL is DeepSeek's OpenAI-compatible API endpoint.
+const DefaultBaseURL = "https://api.deepseek.com"
+
+// reasoningContentField is the non-standard field deepseek-reasoner returns its chain of
+// thought in; the openai-go SDK captures it in JSON.ExtraFields.
+const reasoningContentField = "reasoning_content"
+
+var _ interfaces.LLMClient = (*Client)(nil)
+
+// Client implements interfaces.LLMClient for DeepSeek.
+type Client struct {
+	llm.LLMConfig
+	client openai.Client
+}
+
+// NewClient creates a new DeepSeek LLM client. The base URL defaults to DefaultBaseURL;
+// a caller-supplied llm.WithBaseURL overrides it.
+func NewClient(opts ...llm.Option) (*Client, error) {
+	config, err := llm.BuildConfig(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if config.BaseURL == "" {
+		config.BaseURL = DefaultBaseURL
+	}
+	c := &Client{LLMConfig: *config}
+	c.client = openai.NewClient(
+		option.WithAPIKey(c.APIKey),
+		option.WithBaseURL(c.BaseURL),
+	)
+	return c, nil
+}
+
+func (c *Client) GetProvider() interfaces.LLMProvider {
+	return interfaces.LLMProviderDeepSeek
+}
+
+func (c *Client) GetModel() string {
+	return c.Model
+}
+
+func (c *Client) IsStreamSupported() bool {
+	return true
+}
+
+// buildCompletionParams builds ChatCompletionNewParams. Sampling (Temperature, MaxTokens,
+// TopP) is taken from req when set. DeepSeek does not use OpenAI's reasoning_effort param;
+// deepseek-reasoner reasons automatically, so req.Reasoning is not mapped to a request field.
+func (c *Client) buildCompletionParams(messages []openai.ChatCompletionMessageParamUnion, req *interfaces.LLMRequest) openai.ChatCompletionNewParams {
+	params := openai.ChatCompletionNewParams{
+		Messages: messages,
+		Model:    c.Model,
+	}
+	if req.Temperature != nil {
+		params.Temperature = param.NewOpt(*req.Temperature)
+	}
+	if req.MaxTokens > 0 {
+		params.MaxTokens = param.NewOpt(int64(req.MaxTokens))
+	}
+	if req.TopP != nil {
+		params.TopP = param.NewOpt(*req.TopP)
+	}
+	if len(req.Tools) > 0 {
+		params.Tools = toolsToDeepSeek(req.Tools)
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("auto"),
+		}
+	}
+	if req.ResponseFormat != nil {
+		params.ResponseFormat = responseFormatToDeepSeek(req.ResponseFormat)
+	}
+	return params
+}
+
+// responseFormatToDeepSeek maps the generic ResponseFormat to DeepSeek's supported set.
+// DeepSeek supports only json_object (plain JSON mode), not OpenAI's schema-constrained
+// json_schema, so a ResponseFormatJSON always maps to json_object and any Schema is ignored
+// (the schema is not enforced by the API). To get JSON output, the prompt should still ask
+// for it (DeepSeek requires the word "json" to appear in the conversation).
+func responseFormatToDeepSeek(rf *interfaces.ResponseFormat) openai.ChatCompletionNewParamsResponseFormatUnion {
+	switch rf.Type {
+	case interfaces.ResponseFormatText:
+		return openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfText: &shared.ResponseFormatTextParam{Type: constant.Text("text")},
+		}
+	case interfaces.ResponseFormatJSON:
+		return openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONObject: &shared.ResponseFormatJSONObjectParam{Type: constant.JSONObject("json_object")},
+		}
+	default:
+		return openai.ChatCompletionNewParamsResponseFormatUnion{}
+	}
+}
+
+func (c *Client) Generate(ctx context.Context, req *interfaces.LLMRequest) (*interfaces.LLMResponse, error) {
+	messages := messagesToDeepSeek(req)
+	params := c.buildCompletionParams(messages, req)
+
+	// Log safe debug info only (no messages/content to avoid leaking sensitive data).
+	c.Logger.Debug(ctx, "generating deepseek response",
+		slog.String("model", c.Model),
+		slog.Int("messageCount", len(req.Messages)),
+		slog.Int("toolCount", len(req.Tools)),
+		slog.Bool("hasSystemMessage", req.SystemMessage != ""))
+	resp, err := c.client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	var contentLen int
+	var toolNames []string
+	if len(resp.Choices) > 0 {
+		m := resp.Choices[0].Message
+		contentLen = len(m.Content)
+		toolNames = make([]string, 0, len(m.ToolCalls))
+		for _, tc := range m.ToolCalls {
+			if tc.Function.Name != "" {
+				toolNames = append(toolNames, tc.Function.Name)
+			}
+		}
+	}
+	c.Logger.Debug(ctx, "deepseek response generated",
+		slog.String("model", resp.Model),
+		slog.Int("contentLen", contentLen),
+		slog.Int("toolCallCount", len(toolNames)),
+		slog.Any("toolNames", toolNames))
+	return deepSeekResponseToLLM(resp), nil
+}
+
+func (c *Client) GenerateStream(ctx context.Context, req *interfaces.LLMRequest) (interfaces.LLMStream, error) {
+	c.Logger.Debug(ctx, "starting deepseek stream",
+		slog.String("model", c.Model),
+		slog.Int("messageCount", len(req.Messages)),
+		slog.Int("toolCount", len(req.Tools)))
+	messages := messagesToDeepSeek(req)
+	params := c.buildCompletionParams(messages, req)
+	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{
+		IncludeUsage: openai.Bool(true),
+	}
+	stream := c.client.Chat.Completions.NewStreaming(ctx, params)
+	acc := &openai.ChatCompletionAccumulator{}
+	return &deepSeekStreamAdapter{stream: stream, acc: acc}, nil
+}
+
+// deepSeekStreamAdapter adapts DeepSeek's OpenAI-compatible streaming API to interfaces.LLMStream.
+type deepSeekStreamAdapter struct {
+	stream *ssestream.Stream[openai.ChatCompletionChunk]
+	acc    *openai.ChatCompletionAccumulator
+}
+
+func (a *deepSeekStreamAdapter) Next() bool { return a.stream.Next() }
+func (a *deepSeekStreamAdapter) Err() error { return a.stream.Err() }
+func (a *deepSeekStreamAdapter) Current() *interfaces.LLMStreamChunk {
+	chunk := a.stream.Current()
+	a.acc.AddChunk(chunk)
+	out := &interfaces.LLMStreamChunk{}
+	if len(chunk.Choices) > 0 {
+		delta := chunk.Choices[0].Delta
+		out.ContentDelta = delta.Content
+		// deepseek-reasoner streams its chain of thought in reasoning_content.
+		out.ThinkingDelta = extractReasoning(delta.JSON.ExtraFields)
+	}
+	return out
+}
+func (a *deepSeekStreamAdapter) GetResult() *interfaces.LLMResponse {
+	if len(a.acc.Choices) == 0 {
+		return nil
+	}
+	return deepSeekResponseToLLM(&a.acc.ChatCompletion)
+}
+
+func deepSeekResponseToLLM(resp *openai.ChatCompletion) *interfaces.LLMResponse {
+	out := &interfaces.LLMResponse{
+		Content: resp.Choices[0].Message.Content,
+		Metadata: map[string]any{
+			"model": resp.Model,
+		},
+		Usage: deepSeekUsageToLLM(resp.Usage),
+	}
+	msg := resp.Choices[0].Message
+	if reasoning := extractReasoning(msg.JSON.ExtraFields); reasoning != "" {
+		out.Metadata[reasoningContentField] = reasoning
+	}
+	for _, tc := range msg.ToolCalls {
+		if tc.Function.Name == "" {
+			continue
+		}
+		args := make(map[string]any)
+		if tc.Function.Arguments != "" {
+			_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+		}
+		out.ToolCalls = append(out.ToolCalls, &interfaces.ToolCall{
+			ToolCallID: tc.ID,
+			ToolName:   tc.Function.Name,
+			Args:       args,
+		})
+	}
+	return out
+}
+
+// extractReasoning returns the decoded reasoning_content extra field, or "".
+// deepseek-reasoner returns reasoning under this non-standard field; the openai-go SDK
+// captures it in JSON.ExtraFields. Note Valid() is false for extra fields, so guard on Raw().
+func extractReasoning(extra map[string]respjson.Field) string {
+	f, ok := extra[reasoningContentField]
+	if !ok {
+		return ""
+	}
+	raw := f.Raw() // JSON-encoded
+	if raw == "" || raw == "null" {
+		return ""
+	}
+	var s string
+	_ = json.Unmarshal([]byte(raw), &s)
+	return s
+}
+
+// deepSeekUsageToLLM maps OpenAI-shaped CompletionUsage to interfaces.LLMUsage.
+func deepSeekUsageToLLM(u openai.CompletionUsage) *interfaces.LLMUsage {
+	if u.PromptTokens == 0 && u.CompletionTokens == 0 && u.TotalTokens == 0 {
+		return nil
+	}
+	out := &interfaces.LLMUsage{
+		PromptTokens:     u.PromptTokens,
+		CompletionTokens: u.CompletionTokens,
+		TotalTokens:      u.TotalTokens,
+	}
+	if u.PromptTokensDetails.CachedTokens != 0 {
+		out.CachedPromptTokens = u.PromptTokensDetails.CachedTokens
+	}
+	if u.CompletionTokensDetails.ReasoningTokens != 0 {
+		out.ReasoningTokens = u.CompletionTokensDetails.ReasoningTokens
+	}
+	return out
+}
+
+func messagesToDeepSeek(req *interfaces.LLMRequest) []openai.ChatCompletionMessageParamUnion {
+	var out []openai.ChatCompletionMessageParamUnion
+	if req.SystemMessage != "" {
+		// DeepSeek expects the "system" role (not OpenAI's "developer" role).
+		out = append(out, openai.SystemMessage(req.SystemMessage))
+	}
+	if len(req.Messages) == 0 {
+		return out
+	}
+	for _, m := range req.Messages {
+		switch m.Role {
+		case "user":
+			out = append(out, openai.UserMessage(m.Content))
+		case "assistant":
+			if len(m.ToolCalls) > 0 {
+				toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, len(m.ToolCalls))
+				for i, tc := range m.ToolCalls {
+					argsBytes, _ := json.Marshal(tc.Args)
+					argsStr := "{}"
+					if len(argsBytes) > 0 {
+						argsStr = string(argsBytes)
+					}
+					name := strings.TrimSpace(tc.ToolName)
+					if name == "" {
+						name = "tool"
+					}
+					toolCalls[i] = openai.ChatCompletionMessageToolCallUnionParam{
+						OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+							ID: tc.ToolCallID,
+							Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+								Arguments: argsStr,
+								Name:      name,
+							},
+						},
+					}
+				}
+				out = append(out, openai.ChatCompletionMessageParamUnion{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+						Content:   openai.ChatCompletionAssistantMessageParamContentUnion{OfString: openai.String(m.Content)},
+						ToolCalls: toolCalls,
+					},
+				})
+			} else {
+				out = append(out, openai.AssistantMessage(m.Content))
+			}
+		case "tool":
+			out = append(out, openai.ToolMessage(m.Content, m.ToolCallID))
+		}
+	}
+	return out
+}
+
+func toolsToDeepSeek(specs []interfaces.ToolSpec) []openai.ChatCompletionToolUnionParam {
+	out := make([]openai.ChatCompletionToolUnionParam, len(specs))
+	for i, s := range specs {
+		params := shared.FunctionParameters(map[string]any(s.Parameters))
+		if params == nil {
+			params = shared.FunctionParameters{"type": "object", "properties": map[string]any{}}
+		}
+		out[i] = openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: shared.FunctionDefinitionParam{
+					Name:        s.Name,
+					Description: openai.String(s.Description),
+					Parameters:  params,
+				},
+			},
+		}
+	}
+	return out
+}

--- a/pkg/llm/deepseek/client_test.go
+++ b/pkg/llm/deepseek/client_test.go
@@ -1,0 +1,261 @@
+package deepseek
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm"
+	"github.com/openai/openai-go/v3"
+)
+
+// compile-time check mirrors the assertion in client.go.
+var _ interfaces.LLMClient = (*Client)(nil)
+
+func newTestClient(t *testing.T, opts ...llm.Option) *Client {
+	t.Helper()
+	c, err := NewClient(append([]llm.Option{llm.WithAPIKey("test-key")}, opts...)...)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestClient_Getters(t *testing.T) {
+	c := newTestClient(t, llm.WithModel("deepseek-reasoner"))
+	if c.GetProvider() != interfaces.LLMProviderDeepSeek {
+		t.Fatalf("GetProvider() = %q, want deepseek", c.GetProvider())
+	}
+	if c.GetModel() != "deepseek-reasoner" {
+		t.Fatalf("GetModel() = %q", c.GetModel())
+	}
+	if !c.IsStreamSupported() {
+		t.Fatal("IsStreamSupported() = false, want true")
+	}
+}
+
+func TestNewClient_RequiresAPIKey(t *testing.T) {
+	if _, err := NewClient(llm.WithModel("deepseek-chat")); err == nil {
+		t.Fatal("NewClient without APIKey: expected error, got nil")
+	}
+}
+
+func TestNewClient_DefaultBaseURL(t *testing.T) {
+	c := newTestClient(t)
+	if c.BaseURL != DefaultBaseURL {
+		t.Fatalf("BaseURL = %q, want default %q", c.BaseURL, DefaultBaseURL)
+	}
+}
+
+func TestNewClient_BaseURLOverride(t *testing.T) {
+	const custom = "https://proxy.example.com/v1"
+	c := newTestClient(t, llm.WithBaseURL(custom))
+	if c.BaseURL != custom {
+		t.Fatalf("BaseURL = %q, want override %q", c.BaseURL, custom)
+	}
+}
+
+func TestExtractReasoning(t *testing.T) {
+	// nil map -> "".
+	if got := extractReasoning(nil); got != "" {
+		t.Fatalf("nil -> %q", got)
+	}
+	// Missing reasoning_content -> "" (e.g. deepseek-chat).
+	var msg openai.ChatCompletionMessage
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"hi"}`), &msg); err != nil {
+		t.Fatal(err)
+	}
+	if got := extractReasoning(msg.JSON.ExtraFields); got != "" {
+		t.Fatalf("missing -> %q", got)
+	}
+	// Present reasoning_content (deepseek-reasoner) -> decoded string.
+	var rmsg openai.ChatCompletionMessage
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"4","reasoning_content":"2+2=4"}`), &rmsg); err != nil {
+		t.Fatal(err)
+	}
+	if got := extractReasoning(rmsg.JSON.ExtraFields); got != "2+2=4" {
+		t.Fatalf("present -> %q", got)
+	}
+}
+
+func TestDeepSeekResponseToLLM(t *testing.T) {
+	resp := &openai.ChatCompletion{
+		Model: "deepseek-chat",
+		Choices: []openai.ChatCompletionChoice{{
+			Message: openai.ChatCompletionMessage{
+				Content: "hello",
+				ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
+					ID:   "tc1",
+					Type: "function",
+					Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+						Name:      "fn",
+						Arguments: `{"x":1}`,
+					},
+				}},
+			},
+		}},
+		Usage: openai.CompletionUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3},
+	}
+	out := deepSeekResponseToLLM(resp)
+	if out.Content != "hello" || len(out.ToolCalls) != 1 || out.ToolCalls[0].ToolName != "fn" {
+		t.Fatalf("%#v", out)
+	}
+	if out.ToolCalls[0].Args["x"] != float64(1) {
+		t.Fatalf("args = %#v", out.ToolCalls[0].Args)
+	}
+	if out.Usage == nil || out.Usage.TotalTokens != 3 {
+		t.Fatalf("usage %#v", out.Usage)
+	}
+	if _, ok := out.Metadata[reasoningContentField]; ok {
+		t.Fatal("no reasoning expected for deepseek-chat response")
+	}
+}
+
+func TestDeepSeekResponseToLLM_Reasoning(t *testing.T) {
+	var msg openai.ChatCompletionMessage
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"4","reasoning_content":"2+2"}`), &msg); err != nil {
+		t.Fatal(err)
+	}
+	resp := &openai.ChatCompletion{
+		Model:   "deepseek-reasoner",
+		Choices: []openai.ChatCompletionChoice{{Message: msg}},
+	}
+	out := deepSeekResponseToLLM(resp)
+	if out.Metadata[reasoningContentField] != "2+2" {
+		t.Fatalf("metadata reasoning = %v", out.Metadata[reasoningContentField])
+	}
+}
+
+func TestDeepSeekUsageToLLM(t *testing.T) {
+	if deepSeekUsageToLLM(openai.CompletionUsage{}) != nil {
+		t.Fatal("zero usage -> nil")
+	}
+	u := openai.CompletionUsage{
+		PromptTokens:            10,
+		CompletionTokens:        20,
+		TotalTokens:             30,
+		PromptTokensDetails:     openai.CompletionUsagePromptTokensDetails{CachedTokens: 5},
+		CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{ReasoningTokens: 3},
+	}
+	out := deepSeekUsageToLLM(u)
+	if out == nil || out.CachedPromptTokens != 5 || out.ReasoningTokens != 3 || out.TotalTokens != 30 {
+		t.Fatalf("%#v", out)
+	}
+}
+
+// messagesToDeepSeek must use the "system" role for the system prompt (DeepSeek rejects
+// OpenAI's "developer" role) and translate user/assistant/tool turns.
+func TestMessagesToDeepSeek_SystemRole(t *testing.T) {
+	req := &interfaces.LLMRequest{
+		SystemMessage: "be terse",
+		Messages: []interfaces.Message{
+			{Role: "user", Content: "hi"},
+		},
+	}
+	msgs := messagesToDeepSeek(req)
+	if len(msgs) != 2 {
+		t.Fatalf("len = %d, want 2", len(msgs))
+	}
+	if msgs[0].OfSystem == nil {
+		t.Fatalf("first message should use the system role, got %#v", msgs[0])
+	}
+	if msgs[1].OfUser == nil {
+		t.Fatal("second message should be a user message")
+	}
+}
+
+func TestMessagesToDeepSeek_AssistantToolCallsAndToolResult(t *testing.T) {
+	req := &interfaces.LLMRequest{
+		Messages: []interfaces.Message{
+			{Role: "assistant", Content: "", ToolCalls: []*interfaces.ToolCall{
+				{ToolCallID: "tc1", ToolName: "get_weather", Args: map[string]any{"city": "SF"}},
+			}},
+			{Role: "tool", Content: "sunny", ToolCallID: "tc1"},
+		},
+	}
+	msgs := messagesToDeepSeek(req)
+	if len(msgs) != 2 {
+		t.Fatalf("len = %d, want 2", len(msgs))
+	}
+	if msgs[0].OfAssistant == nil || len(msgs[0].OfAssistant.ToolCalls) != 1 {
+		t.Fatalf("assistant tool calls not mapped: %#v", msgs[0])
+	}
+	if msgs[1].OfTool == nil {
+		t.Fatalf("tool result not mapped: %#v", msgs[1])
+	}
+}
+
+func TestToolsToDeepSeek(t *testing.T) {
+	specs := []interfaces.ToolSpec{
+		{Name: "search", Description: "search the web", Parameters: interfaces.JSONSchema{"type": "object"}},
+		{Name: "noparams"}, // nil Parameters -> defaulted object schema
+	}
+	tools := toolsToDeepSeek(specs)
+	if len(tools) != 2 {
+		t.Fatalf("len = %d, want 2", len(tools))
+	}
+	if tools[0].OfFunction == nil || tools[0].OfFunction.Function.Name != "search" {
+		t.Fatalf("tool 0 = %#v", tools[0])
+	}
+	if tools[1].OfFunction.Function.Parameters == nil {
+		t.Fatal("nil parameters should be defaulted to an object schema")
+	}
+}
+
+// DeepSeek supports only json_object: a JSON request maps to json_object with or without a
+// Schema (the schema is dropped, since DeepSeek rejects OpenAI's json_schema type).
+func TestResponseFormatToDeepSeek(t *testing.T) {
+	// Text.
+	if rf := responseFormatToDeepSeek(&interfaces.ResponseFormat{Type: interfaces.ResponseFormatText}); rf.OfText == nil {
+		t.Fatal("text -> OfText expected")
+	}
+	// JSON without schema -> json_object.
+	if rf := responseFormatToDeepSeek(&interfaces.ResponseFormat{Type: interfaces.ResponseFormatJSON}); rf.OfJSONObject == nil {
+		t.Fatal("json (no schema) -> OfJSONObject expected")
+	}
+	// JSON *with* schema -> still json_object (schema ignored), never json_schema.
+	withSchema := &interfaces.ResponseFormat{
+		Type:   interfaces.ResponseFormatJSON,
+		Name:   "FactAnswer",
+		Schema: interfaces.JSONSchema{"type": "object"},
+	}
+	rf := responseFormatToDeepSeek(withSchema)
+	if rf.OfJSONObject == nil {
+		t.Fatal("json (with schema) -> OfJSONObject expected")
+	}
+	if rf.OfJSONSchema != nil {
+		t.Fatal("DeepSeek must not emit json_schema (unsupported)")
+	}
+}
+
+func TestBuildCompletionParams(t *testing.T) {
+	c := newTestClient(t, llm.WithModel("deepseek-chat"))
+	temp, topP := 0.3, 0.9
+	req := &interfaces.LLMRequest{
+		Messages:       []interfaces.Message{{Role: "user", Content: "hi"}},
+		Temperature:    &temp,
+		TopP:           &topP,
+		MaxTokens:      50,
+		Tools:          []interfaces.ToolSpec{{Name: "fn"}},
+		ResponseFormat: &interfaces.ResponseFormat{Type: interfaces.ResponseFormatJSON},
+	}
+	params := c.buildCompletionParams(messagesToDeepSeek(req), req)
+	if params.Model != "deepseek-chat" {
+		t.Fatalf("model = %q", params.Model)
+	}
+	if params.Temperature.Value != 0.3 {
+		t.Fatalf("temperature = %v", params.Temperature.Value)
+	}
+	if params.TopP.Value != 0.9 {
+		t.Fatalf("topP = %v", params.TopP.Value)
+	}
+	if params.MaxTokens.Value != 50 {
+		t.Fatalf("maxTokens = %v", params.MaxTokens.Value)
+	}
+	if len(params.Tools) != 1 {
+		t.Fatalf("tools = %d", len(params.Tools))
+	}
+	if params.ResponseFormat.OfJSONObject == nil {
+		t.Fatal("response format should be json_object")
+	}
+}


### PR DESCRIPTION
## Description

Adds DeepSeek as a built-in LLM provider (pkg/llm/deepseek) implementing interfaces.LLMClient, alongside the existing OpenAI, Anthropic, and Gemini clients.
DeepSeek exposes an OpenAI-compatible Chat Completions API, so the client uses the openai-go SDK purely as transport (no new dependency) but implements the interface independently.

- Defaults the base URL to https://api.deepseek.com (overridable via llm.WithBaseURL).
- Sends system prompts with the system role (DeepSeek rejects OpenAI's developer role).
- Maps deepseek-reasoner's reasoning_content to LLMStreamChunk.ThinkingDelta (streaming) and LLMResponse.Metadata["reasoning_content"] (non-streaming).
- Maps ResponseFormatJSON to json_object (DeepSeek doesn't support OpenAI's json_schema type; any Schema is ignored).

Registers the LLMProviderDeepSeek constant and wires the provider into the cmd and examples config factories. Supports deepseek-chat and deepseek-reasoner models.

## Type of change

New feature (non-breaking change which adds functionality)

## Related issues

Fixes #37 

## Checklist

- [ Y ] I have run `make check`
- [ Y ] I have run `task examples:all`
- [ Y ] I have run `make tidy` if I added or removed dependencies
- [ Y ] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [ Y ] I have added/updated tests for my changes
- [ Y ] Documentation is updated if needed
