### PR TITLE
Add workflows and code-execution examples with pluggable runners, advanced docs, and example task/docs wiring.

### DIFF
--- a/docs/advanced/code-execution.mdx
+++ b/docs/advanced/code-execution.mdx
@@ -1,0 +1,121 @@
+---
+title: "Code Execution in Agents"
+sidebarTitle: "Code Execution"
+description: "Let the LLM write and run code safely — plug in any sandbox behind a single interface"
+---
+
+**The problem:** You want the agent to answer questions by running real code — computations, data transformations, script verification — without trusting LLM-hallucinated output and without bloating the context window with raw data.
+
+**The solution:** Expose a custom `execute_code` tool backed by a `SandboxRuntime` interface. The LLM writes a short self-contained script, passes it to the tool, and reads the actual output. The sandbox handles isolation — the SDK never runs code itself.
+
+## What the LLM does vs. what the sandbox does
+
+| LLM | Your sandbox |
+|---|---|
+| Decide when to run code | Execute the script |
+| Write a self-contained script | Enforce resource limits |
+| Read `output` and explain it to the user | Isolate from host filesystem and network |
+| Retry with a fixed script on non-zero `exit_code` | Return stdout + stderr and exit code |
+
+The LLM never invents output — it always calls `execute_code` first.
+
+Example: [Code Execution](/examples/code-execution).
+
+## Tool pattern
+
+```go
+type SandboxRuntime interface {
+    Execute(ctx context.Context, language, code string) (ExecutionResult, error)
+}
+
+a, _ := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithTools(NewCodeTool(yourRuntime)),
+)
+```
+
+`Execute` blocks until the sandbox returns `ExecutionResult{Output, ExitCode}`. The LLM reads `output` from the result and replies to the user.
+
+## Sandbox options
+
+Implement `SandboxRuntime` once per environment. The example ships two; add more by following the same pattern:
+
+| Sandbox | Use case | Activate |
+|---|---|---|
+| **Local os/exec** | Development, CI, trusted scripts | default (no env var) |
+| **Docker** | Isolated execution on your host | `SANDBOX_ENV=docker` |
+| **AWS Lambda** | Serverless, per-request isolation | implement `LambdaRuntime` |
+| **Modal / E2B** | Cloud sandboxes with language images | implement `ModalRuntime` / `E2BRuntime` |
+| **Firecracker / microVMs** | Maximum isolation, low latency | implement `FirecrackerRuntime` |
+
+Only `main.go` changes when you swap runtimes — `code_tool.go` and the agent config stay the same.
+
+## Docker sandbox isolation
+
+The example Docker runner passes safety flags to `docker run`:
+
+```
+--rm              remove container after exit (no state between calls)
+--network none    block all outbound network access from LLM-generated code
+--memory 128m     cap memory to prevent runaway scripts
+```
+
+Adjust these to match your security policy. In production, also add `--cpus`, `--read-only`, and a non-root user.
+
+## Timeout layers
+
+| Layer | What it limits | Configure |
+|---|---|---|
+| **Per `Run` context** | Entire agent call | `context.WithTimeout` — **always wins** |
+| **Agent run** | Whole turn | [`WithTimeout`](/advanced/timeouts-and-modes) |
+| **Tool execute** | Single `execute_code` call | [`WithToolExecutionConfig`](/features/execution-config) |
+| **Sandbox** | Script execution wall time | Your runtime config / Docker `--stop-timeout` |
+
+```go
+a, _ := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithTools(NewCodeTool(runtime)),
+    agent.WithAgentMode(agent.AgentModeAutonomous),
+    agent.WithToolExecutionConfig(agent.ExecutionConfig{
+        Timeout:     2 * time.Minute, // covers Docker image pull on first run
+        MaxAttempts: 1,               // do not silently re-run side-effectful code
+    }),
+)
+```
+
+## System prompt guidance
+
+Tell the LLM not to make up output — it must call the tool first:
+
+```
+"When the user asks to compute or verify something with code, write a short
+self-contained script and call execute_code. Read the output and explain the
+result. Do not make up output — always run the code first."
+```
+
+Example: [Code Execution](/examples/code-execution).
+
+## Examples
+
+<CardGroup cols={2}>
+  <Card title="Code Execution" icon="play" href="/examples/code-execution" horizontal>
+    execute_code tool with local and Docker runtimes
+  </Card>
+  <Card title="Execution config" icon="play" href="/examples/execution-config" horizontal>
+    Per-operation timeout overrides
+  </Card>
+</CardGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Execution config" icon="sliders" href="/features/execution-config" horizontal>
+    Tool execute timeout and max attempts
+  </Card>
+  <Card title="Deterministic Execution" icon="diagram-project" href="/advanced/deterministic-execution" horizontal>
+    Running predefined workflows from the agent
+  </Card>
+  <Card title="Tools" icon="wrench" href="/features/tools" horizontal>
+    Custom tool implementation
+  </Card>
+</CardGroup>

--- a/docs/advanced/deterministic-execution.mdx
+++ b/docs/advanced/deterministic-execution.mdx
@@ -1,0 +1,136 @@
+---
+title: "Deterministic Execution in Agents"
+sidebarTitle: "Deterministic Execution"
+description: "Run named user workflows from inside an agent — the LLM routes intent, your orchestration engine controls execution"
+---
+
+**The problem:** Your organization already runs multi-step procedures — onboarding, provisioning, compliance checks — in an orchestration engine. You want the LLM to trigger those procedures without re-implementing steps inside the agent loop, and without the LLM improvising or skipping steps.
+
+**The solution:** Expose workflows as a custom tool (`run_workflow`). The LLM routes user intent to `workflow_name` and `input`; your `WorkflowRunner` executes the steps deterministically and returns the result. Steps run in order, retry on failure, and produce an auditable record — entirely inside your engine.
+
+## What deterministic means here
+
+The LLM's job is **intent routing** — mapping "onboard Alice" to `workflow_name: onboarding, input: Alice`. Your orchestration engine owns the procedure:
+
+| LLM | Your orchestration engine |
+|---|---|
+| Pick `workflow_name` and `input` | Execute steps in defined order |
+| Summarize `WorkflowResult` for the user | Retry each step on failure |
+| Ask clarifying questions before calling the tool | Enforce side effects (email, provision, API calls) |
+| Never skip or reorder steps | Produce an audit trail |
+
+This is different from asking the LLM to "figure out what steps to run" — the engine always runs the same steps for the same workflow name.
+
+Example: [Workflows](/examples/workflows).
+
+## Tool pattern
+
+```go
+type WorkflowRunner interface {
+    Run(ctx context.Context, name, input string) (WorkflowResult, error)
+}
+
+a, _ := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithTools(NewWorkflowTool(yourRunner)),
+)
+```
+
+`Execute` delegates to `WorkflowRunner.Run` and returns when the workflow reaches a terminal state (or the context deadline fires).
+
+## How the agent waits
+
+```
+User prompt → LLM calls run_workflow → Execute → WorkflowRunner.Run
+  → engine starts workflow → steps run deterministically → WorkflowResult → LLM reply
+```
+
+One agent `Run` stays open until `WorkflowRunner.Run` returns — minutes or hours depending on workflow duration and any wait steps inside your engine. Pass the SDK's `ctx` from `Execute` into your wait loop so deadlines propagate.
+
+## Wait steps inside orchestration
+
+Workflows can pause on external events or human gates defined in your engine — the agent run stays open the whole time:
+
+| Engine | Wait / gate mechanism |
+|---|---|
+| **Temporal** | `workflow.AwaitWithTimeout` on a signal |
+| **Conductor** | `HUMAN` task |
+| **Argo Workflows** | `suspend` template |
+| **Step Functions** | `.waitForTaskToken` |
+
+Size [`WithToolExecutionConfig`](/features/execution-config) and [`WithTimeout`](/advanced/timeouts-and-modes) to cover the full workflow duration including any wait steps.
+
+## Timeout layers
+
+| Layer | What it limits | Configure |
+|---|---|---|
+| **Per `Run` context** | Entire agent call | `context.WithTimeout` — **always wins** |
+| **Agent run** | Whole turn (LLM + all tool waits) | [`WithTimeout`](/advanced/timeouts-and-modes) |
+| **Tool execute** | Single `run_workflow` wait | [`WithToolExecutionConfig`](/features/execution-config) |
+| **Orchestration engine** | Individual steps | Your engine config |
+
+```go
+a, _ := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithTools(NewWorkflowTool(runner)),
+    agent.WithAgentMode(agent.AgentModeAutonomous),
+    agent.WithTimeout(2 * time.Hour),
+    agent.WithToolExecutionConfig(agent.ExecutionConfig{
+        Timeout:     2 * time.Hour,
+        MaxAttempts: 1, // do not blindly re-trigger a started workflow
+    }),
+)
+```
+
+Default tool execution timeout is **30 minutes** with up to **3 attempts** if unset — raise it for workflow agents.
+
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 45*time.Minute)
+defer cancel()
+result, err := a.Run(ctx, "Run onboarding for Alice", nil)
+```
+
+If the deadline fires, `Execute` returns `context deadline exceeded` — the workflow may still be running in your engine. Use idempotent workflow IDs and a status API in your runner for recovery.
+
+## Orchestration runners
+
+Implement `WorkflowRunner` once per engine — map `workflow_name` + `input` to your API, wait until terminal, return `WorkflowResult`:
+
+| Engine | Wait until complete |
+|---|---|
+| **In-process** | Run steps directly; no infrastructure needed (default in example) |
+| **Temporal** | `ExecuteWorkflow` + `run.Get(ctx, &result)` |
+| **Conductor** | Start → poll until `COMPLETED` / `FAILED` |
+| **Argo Workflows** | Submit → watch until phase `Succeeded` / `Failed` |
+| **Step Functions** | `StartExecution` → `DescribeExecution` |
+
+The example ships two runners: `inprocess_runner.go` (default, no infra) and `temporal_runner.go` (`ORCHESTRATION_ENGINE=temporal`). Add `conductor_runner.go`, `argo_runner.go`, etc. for other engines — only `main.go` changes when you swap runners.
+
+Workflow orchestration is independent of `AGENT_RUNTIME` — the agent can run in-process while your runner uses any backend.
+
+Example: [Workflows](/examples/workflows).
+
+## Examples
+
+<CardGroup cols={2}>
+  <Card title="Workflows" icon="play" href="/examples/workflows" horizontal>
+    run_workflow tool with in-process and Temporal runners
+  </Card>
+  <Card title="Execution config" icon="play" href="/examples/execution-config" horizontal>
+    Per-operation timeout overrides
+  </Card>
+</CardGroup>
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Execution config" icon="sliders" href="/features/execution-config" horizontal>
+    Tool execute timeout and max attempts
+  </Card>
+  <Card title="Timeouts & modes" icon="clock" href="/advanced/timeouts-and-modes" horizontal>
+    Agent run timeout and interactive vs autonomous
+  </Card>
+  <Card title="Tools" icon="wrench" href="/features/tools" horizontal>
+    Custom tool implementation
+  </Card>
+</CardGroup>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,8 @@
             "group": "Advanced",
             "pages": [
               "advanced/dynamic-capabilities",
+              "advanced/deterministic-execution",
+              "advanced/code-execution",
               "advanced/worker-separation",
               "advanced/multiple-agents",
               "advanced/timeouts-and-modes"
@@ -140,6 +142,8 @@
             "group": "Tools & MCP",
             "pages": [
               "examples/tools",
+              "examples/workflows",
+              "examples/code-execution",
               "examples/mcp-config",
               "examples/mcp-client"
             ]

--- a/docs/examples/code-execution.mdx
+++ b/docs/examples/code-execution.mdx
@@ -1,0 +1,74 @@
+---
+title: "Code Execution"
+description: "Let the LLM write and run code in an isolated sandbox via a custom execute_code tool"
+---
+
+Shows how to give an agent a code execution capability using a custom `execute_code` tool. The LLM writes a short script, the sandbox runs it, and the output is returned for the LLM to explain. The sandbox is pluggable — swap the runtime without changing the tool.
+
+Source: [`examples/agent_with_code_execution/`](https://github.com/agenticenv/agent-sdk-go/tree/main/examples/agent_with_code_execution)
+
+## What it demonstrates
+
+- `execute_code` custom tool — `interfaces.Tool` with `language` and `code` parameters
+- `SandboxRuntime` interface — pluggable sandbox (local os/exec, Docker, cloud APIs)
+- LLM writes code, runs it, reads output, replies — never makes up results
+- Sandbox isolation — Docker runner uses `--network none` and memory limits
+
+## Run
+
+From `examples/`:
+
+Local sandbox — needs Python or Node installed on host:
+
+```bash
+go run ./agent_with_code_execution "Write a Python script that prints the first 10 Fibonacci numbers"
+```
+
+Docker sandbox — isolated, no host interpreter needed:
+
+```bash
+SANDBOX_ENV=docker go run ./agent_with_code_execution "Write a Python script that prints the first 10 Fibonacci numbers"
+```
+
+Requires `LLM_APIKEY` in `examples/.env`.
+
+## Key code
+
+```go
+// newSandbox picks the execution environment from SANDBOX_ENV (default: local os/exec).
+// Swap newLocalRunner for newDockerRunner, a Lambda runner, Modal, E2B, etc.
+sandbox, err := newSandbox()
+
+a, err := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithTools(NewCodeTool(sandbox)),
+    agent.WithAgentMode(agent.AgentModeAutonomous),
+    agent.WithToolExecutionConfig(agent.ExecutionConfig{
+        Timeout:     2 * time.Minute,
+        MaxAttempts: 1,
+    }),
+)
+
+result, err := a.Run(context.Background(), prompt, nil)
+```
+
+`Execute` blocks until `SandboxRuntime.Execute` returns the program output and exit code.
+
+## Expected output
+
+```
+user: Write a Python script that prints the first 10 Fibonacci numbers
+
+A: Here are the first 10 Fibonacci numbers: 0, 1, 1, 2, 3, 5, 8, 13, 21, 34.
+```
+
+## Learn more
+
+<CardGroup cols={2}>
+  <Card title="Code Execution in Agents" icon="terminal" href="/advanced/code-execution" horizontal>
+    Sandbox options, isolation, timeout config, cloud runtimes
+  </Card>
+  <Card title="Execution config" icon="sliders" href="/features/execution-config" horizontal>
+    Tool execute timeout and max attempts
+  </Card>
+</CardGroup>

--- a/docs/examples/running-examples.mdx
+++ b/docs/examples/running-examples.mdx
@@ -33,6 +33,8 @@ Examples use `LLM_APIKEY`, `LLM_PROVIDER`, and `LLM_MODEL` from `examples/.env` 
 | [JSON Response](/examples/json-response) | [Response format](/features/response-format) | Local, Temporal | — |
 | [Reasoning](/examples/reasoning) | [Reasoning](/features/reasoning) | Local, Temporal | — |
 | [Tools](/examples/tools) | [Tools](/features/tools) | Local, Temporal | — |
+| [Workflows](/examples/workflows) | [Deterministic Execution](/advanced/deterministic-execution) | Local, Temporal | — (in-process default); Temporal (ORCHESTRATION_ENGINE=temporal) |
+| [Code Execution](/examples/code-execution) | [Code Execution in Agents](/advanced/code-execution) | Local, Temporal | — (local os/exec default); Docker (SANDBOX_ENV=docker) |
 | [MCP Config](/examples/mcp-config) | [MCP](/features/mcp) | Local, Temporal | MCP server |
 | [MCP Client](/examples/mcp-client) | [MCP](/features/mcp) | Local, Temporal | MCP server |
 | [Stream](/examples/stream) | [Streaming](/getting-started/streaming) | Local, Temporal | — |
@@ -55,6 +57,8 @@ Examples use `LLM_APIKEY`, `LLM_PROVIDER`, and `LLM_MODEL` from `examples/.env` 
 ## Suggested order
 
 **Basics** — [Simple Agent](/examples/simple-agent) → [Tools](/examples/tools) → [Stream](/examples/stream)
+
+**Custom tools (advanced patterns)** — [Workflows](/examples/workflows) → [Code Execution](/examples/code-execution)
 
 **Stateful agents** — [Conversation](/examples/conversation) → [Memory](/examples/memory) or [Retrieval](/examples/retrieval)
 

--- a/docs/examples/workflows.mdx
+++ b/docs/examples/workflows.mdx
@@ -1,0 +1,79 @@
+---
+title: "Workflows"
+description: "Deterministic workflow execution inside an agent — the LLM routes intent, your orchestration engine runs steps"
+---
+
+Shows how to run deterministic multi-step workflows from inside an agent using a custom `run_workflow` tool. The LLM decides *when* to call the tool and maps user intent to `workflow_name` and `input`; your orchestration engine runs the steps in order, retries on failure, and returns a structured result.
+
+Source: [`examples/agent_with_workflows/`](https://github.com/agenticenv/agent-sdk-go/tree/main/examples/agent_with_workflows)
+
+## What it demonstrates
+
+- Deterministic workflow execution — steps defined in your engine, not improvised by the LLM
+- `WorkflowTool` + `WorkflowRunner` interface — pluggable engine (in-process, Temporal, Conductor, Argo, etc.)
+- Agent waits until the workflow finishes — `Execute` blocks on `WorkflowRunner.Run`
+- Long-running config — `AgentModeAutonomous`, `WithTimeout`, `WithToolExecutionConfig` sized for workflow duration
+
+## Run
+
+From `examples/`:
+
+In-process runner — no infrastructure needed:
+
+```bash
+go run ./agent_with_workflows "Run the onboarding workflow for user Alice"
+```
+
+Temporal runner — durable, survives restarts:
+
+```bash
+task infra:temporal:up && task infra:temporal:wait
+ORCHESTRATION_ENGINE=temporal go run ./agent_with_workflows "Run the onboarding workflow for user Alice"
+```
+
+Requires `LLM_APIKEY` in `examples/.env`.
+
+## Key code
+
+```go
+// newRunner picks the engine from RUNNER env var (default: in-process).
+// Swap inProcessRunner for NewTemporalRunner, a Conductor runner, etc.
+runner, stop, err := newRunner(cfg)
+defer stop()
+
+a, err := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithTools(NewWorkflowTool(runner)),
+
+    // Workflows can be long-running — autonomous mode + explicit tool ceiling.
+    agent.WithAgentMode(agent.AgentModeAutonomous),
+    agent.WithTimeout(10 * time.Minute),
+    agent.WithToolExecutionConfig(agent.ExecutionConfig{
+        Timeout:     10 * time.Minute,
+        MaxAttempts: 1, // do not blindly re-trigger a started workflow
+    }),
+)
+
+result, err := a.Run(context.Background(), prompt, nil)
+```
+
+`Execute` blocks on `WorkflowRunner.Run` — the agent run stays open until the workflow finishes or a timeout fires.
+
+## Expected output
+
+```
+user: Run the onboarding workflow for user Alice
+
+assistant: Onboarding for Alice is complete. A welcome email was sent and a workspace was provisioned.
+```
+
+## Learn more
+
+<CardGroup cols={2}>
+  <Card title="Deterministic Execution" icon="diagram-project" href="/advanced/deterministic-execution" horizontal>
+    What deterministic means, wait semantics, timeouts, orchestration runners
+  </Card>
+  <Card title="Execution config" icon="sliders" href="/features/execution-config" horizontal>
+    Tool execute timeout and max attempts
+  </Card>
+</CardGroup>

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,8 @@ These examples run with `AGENT_RUNTIME=local` (default) or `AGENT_RUNTIME=tempor
 | `agent_with_memory` | **`weaviate/`** or **`pgvector/`** — **[README](agent_with_memory/README.md)**; `MEMORY_STORE_MODE=always\|ondemand` | `infra:weaviate:up` or `infra:pgvector:up` |
 | `agent_with_hooks` | All middleware hooks — PII scrubbing, retrieval filtering, memory tenant checks; **[README](agent_with_hooks/README.md)** | — |
 | `agent_with_execution_config` | Execution config — `WithLLMExecutionConfig`, `WithToolExecutionConfig`, `WithSubAgentExecutionConfig`; SDK defaults and partial overrides | — |
+| `agent_with_workflows` | Deterministic workflow execution via `run_workflow` tool — `WorkflowRunner` interface; `inprocess_runner.go` (default, no infra) and `temporal_runner.go` (`ORCHESTRATION_ENGINE=temporal`) | `infra:temporal:up`, `infra:temporal:wait` (Temporal engine only) |
+| `agent_with_code_execution` | Sandboxed code execution via `execute_code` tool — `SandboxRuntime` interface; `local_runner.go` (default, needs Python/Node) and `docker_runner.go` (`SANDBOX_ENV=docker`) | Docker (Docker runner only) |
 
 ### Temporal only
 
@@ -105,6 +107,27 @@ go run ./agent_with_tools/approval "What is 15 + 27?"
 go run ./agent_with_tools/authorizer "Get the protected note for roadmap."
 go run ./agent_with_tools/custom "Reverse 'hello world'"
 go run ./agent_with_tools/dynamic_registry
+```
+
+### Agent with workflows
+
+```bash
+# in-process runner (default — no infrastructure needed)
+go run ./agent_with_workflows "Run the onboarding workflow for user Alice"
+
+# Temporal runner — durable execution
+task infra:temporal:up && task infra:temporal:wait
+ORCHESTRATION_ENGINE=temporal go run ./agent_with_workflows "Run the onboarding workflow for user Alice"
+```
+
+### Agent with code execution
+
+```bash
+# local sandbox (default — needs Python or Node installed)
+go run ./agent_with_code_execution "Write a Python script that prints the first 10 Fibonacci numbers"
+
+# Docker sandbox — isolated execution
+SANDBOX_ENV=docker go run ./agent_with_code_execution "Write a Python script that prints the first 10 Fibonacci numbers"
 ```
 
 ### Agent with hooks

--- a/examples/agent_with_code_execution/code_tool.go
+++ b/examples/agent_with_code_execution/code_tool.go
@@ -1,0 +1,88 @@
+// Package main implements a CodeTool that lets the LLM write and execute code inside
+// an agent run. The tool contract (name, parameters, SandboxRuntime interface) is
+// sandbox-agnostic — execution is handled by whatever SandboxRuntime is wired in main.go.
+//
+// local_runner.go  — default runner using os/exec (needs Python or Node installed locally)
+// docker_runner.go — isolated runner using Docker (SANDBOX_ENV=docker)
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/tools"
+)
+
+var _ interfaces.Tool = (*CodeTool)(nil)
+
+// SandboxRuntime is the sandbox-agnostic interface for executing LLM-generated code.
+// Implement one runtime per execution environment — local os/exec, Docker, AWS Lambda,
+// Modal, E2B, or any cloud sandbox API. The CodeTool delegates to this interface so the
+// LLM-facing tool contract never changes when you swap sandboxes.
+type SandboxRuntime interface {
+	Execute(ctx context.Context, language, code string) (ExecutionResult, error)
+}
+
+// ExecutionResult is returned to the LLM after code executes.
+// The LLM uses Output to answer the user and ExitCode to detect failures.
+type ExecutionResult struct {
+	Language string `json:"language"`
+	Output   string `json:"output"`
+	ExitCode int    `json:"exit_code"`
+}
+
+// CodeTool exposes sandboxed code execution to the LLM as the execute_code tool.
+// Execute blocks until SandboxRuntime.Execute returns — size timeouts for your sandbox.
+type CodeTool struct {
+	sandbox SandboxRuntime
+}
+
+// NewCodeTool returns a CodeTool backed by the given sandbox runtime.
+func NewCodeTool(sandbox SandboxRuntime) *CodeTool {
+	return &CodeTool{sandbox: sandbox}
+}
+
+func (*CodeTool) Name() string { return "execute_code" }
+
+func (*CodeTool) DisplayName() string { return "Execute Code" }
+
+func (*CodeTool) Description() string {
+	return "Write and execute a short code snippet in an isolated sandbox. " +
+		"Use when the user asks to run, compute, or verify something with code. " +
+		"Returns the program output (stdout + stderr) and exit code. " +
+		"Supported languages: python, javascript, shell."
+}
+
+func (*CodeTool) Parameters() interfaces.JSONSchema {
+	return tools.Params(
+		map[string]interfaces.JSONSchema{
+			"language": tools.ParamEnum(
+				"Language to execute the code in",
+				"python",
+				"javascript",
+				"shell",
+			),
+			"code": tools.ParamString(
+				"The code to execute. Keep scripts self-contained — no file I/O or network calls.",
+			),
+		},
+		"language", "code",
+	)
+}
+
+func (t *CodeTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	language, _ := args["language"].(string)
+	code, _ := args["code"].(string)
+	language = strings.ToLower(strings.TrimSpace(language))
+	code = strings.TrimSpace(code)
+	if language == "" {
+		return nil, fmt.Errorf("language is required")
+	}
+	if code == "" {
+		return nil, fmt.Errorf("code is required")
+	}
+	// Blocks until sandbox completes or ctx deadline fires.
+	return t.sandbox.Execute(ctx, language, code)
+}

--- a/examples/agent_with_code_execution/docker_runner.go
+++ b/examples/agent_with_code_execution/docker_runner.go
@@ -1,0 +1,102 @@
+// Package main — SandboxRuntime backed by Docker.
+//
+// This file is the Docker-specific execution layer for the agent_with_code_execution
+// example. It satisfies the SandboxRuntime interface defined in code_tool.go.
+//
+// To use a different sandbox (AWS Lambda, Modal, E2B, Firecracker, etc.), add a sibling
+// file implementing SandboxRuntime and wire it in main.go instead of newDockerRunner.
+//
+// Requires: Docker daemon running and internet access to pull language images on first run.
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// dockerRunner executes code inside an ephemeral Docker container.
+// Each Execute call starts a fresh container, runs the code, and removes the container.
+// This gives the LLM a clean, isolated environment with no state carried between calls.
+type dockerRunner struct{}
+
+// dockerImages maps languages to official Docker images used as execution sandboxes.
+// Swap these for pinned internal images in production to avoid pulling from Docker Hub.
+var dockerImages = map[string]struct {
+	image string
+	flag  string // -c for shell interpreters, -e for node
+}{
+	"python":     {image: "python:3-slim", flag: "-c"},
+	"javascript": {image: "node:alpine", flag: "-e"},
+	"shell":      {image: "alpine", flag: "-c"},
+}
+
+// dockerInterpreter maps languages to their in-container interpreter binaries.
+var dockerInterpreter = map[string]string{
+	"python":     "python3",
+	"javascript": "node",
+	"shell":      "sh",
+}
+
+func newDockerRunner() (SandboxRuntime, error) {
+	// Verify Docker is available before returning the runner.
+	if _, err := exec.LookPath("docker"); err != nil {
+		return nil, fmt.Errorf("docker not found on PATH — install Docker or use the default local sandbox")
+	}
+	return &dockerRunner{}, nil
+}
+
+// Execute runs code in a sandboxed Docker container and returns combined output.
+// The container is removed automatically (--rm). The ctx deadline propagates via
+// exec.CommandContext so a slow container does not outlive the agent tool timeout.
+func (r *dockerRunner) Execute(ctx context.Context, language, code string) (ExecutionResult, error) {
+	cfg, ok := dockerImages[language]
+	if !ok {
+		return ExecutionResult{}, fmt.Errorf("unsupported language %q (supported: python, javascript, shell)", language)
+	}
+	interpreter := dockerInterpreter[language]
+
+	// docker run --rm <image> <interpreter> <flag> <code>
+	// --rm:      remove container after exit
+	// --network none: no outbound network access from LLM-generated code
+	// --memory:  cap memory to prevent runaway scripts
+	args := []string{
+		"run", "--rm",
+		"--network", "none",
+		"--memory", "128m",
+		cfg.image,
+		interpreter, cfg.flag, code,
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	combined := strings.TrimSpace(stdout.String())
+	if stderr.Len() > 0 {
+		if combined != "" {
+			combined += "\n"
+		}
+		combined += strings.TrimSpace(stderr.String())
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return ExecutionResult{}, fmt.Errorf("docker exec: %w", runErr)
+		}
+	}
+
+	return ExecutionResult{
+		Language: language,
+		Output:   combined,
+		ExitCode: exitCode,
+	}, nil
+}

--- a/examples/agent_with_code_execution/local_runner.go
+++ b/examples/agent_with_code_execution/local_runner.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// localRunner is a SandboxRuntime that executes code directly on the host using os/exec.
+// It needs no external infrastructure — use it to understand the pattern without Docker.
+// For isolated execution swap it for docker_runner.go (SANDBOX_ENV=docker), AWS Lambda,
+// Modal, E2B, or any remote sandbox that implements SandboxRuntime.
+//
+// Requirements: Python (python3) and/or Node.js (node) installed on the host.
+type localRunner struct{}
+
+func newLocalRunner() SandboxRuntime { return &localRunner{} }
+
+func (r *localRunner) Execute(ctx context.Context, language, code string) (ExecutionResult, error) {
+	binary, ext, err := resolveInterpreter(language)
+	if err != nil {
+		return ExecutionResult{}, err
+	}
+
+	// Write code to a temp file so stack traces show a real filename.
+	tmpFile, err := os.CreateTemp("", "agent-code-*"+ext)
+	if err != nil {
+		return ExecutionResult{}, fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(code); err != nil {
+		tmpFile.Close()
+		return ExecutionResult{}, fmt.Errorf("write code: %w", err)
+	}
+	tmpFile.Close()
+
+	var stdout, stderr bytes.Buffer
+	var cmd *exec.Cmd
+	if language == "shell" {
+		cmd = exec.CommandContext(ctx, binary, tmpFile.Name())
+	} else {
+		cmd = exec.CommandContext(ctx, binary, tmpFile.Name())
+	}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Dir = filepath.Dir(tmpFile.Name())
+
+	runErr := cmd.Run()
+
+	combined := strings.TrimSpace(stdout.String())
+	if stderr.Len() > 0 {
+		if combined != "" {
+			combined += "\n"
+		}
+		combined += strings.TrimSpace(stderr.String())
+	}
+
+	exitCode := 0
+	if runErr != nil {
+		if exitErr, ok := runErr.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return ExecutionResult{}, fmt.Errorf("exec: %w", runErr)
+		}
+	}
+
+	return ExecutionResult{
+		Language: language,
+		Output:   combined,
+		ExitCode: exitCode,
+	}, nil
+}
+
+// resolveInterpreter returns the host binary and temp file extension for a language.
+func resolveInterpreter(language string) (binary, ext string, err error) {
+	switch language {
+	case "python":
+		// Prefer python3; fall back to python.
+		if path, e := exec.LookPath("python3"); e == nil {
+			return path, ".py", nil
+		}
+		if path, e := exec.LookPath("python"); e == nil {
+			return path, ".py", nil
+		}
+		return "", "", fmt.Errorf("python3 (or python) not found on PATH — install Python or use SANDBOX_ENV=docker")
+	case "javascript":
+		if path, e := exec.LookPath("node"); e == nil {
+			return path, ".js", nil
+		}
+		return "", "", fmt.Errorf("node not found on PATH — install Node.js or use SANDBOX_ENV=docker")
+	case "shell":
+		if path, e := exec.LookPath("sh"); e == nil {
+			return path, ".sh", nil
+		}
+		return "", "", fmt.Errorf("sh not found on PATH")
+	default:
+		return "", "", fmt.Errorf("unsupported language %q (supported: python, javascript, shell)", language)
+	}
+}

--- a/examples/agent_with_code_execution/local_runner.go
+++ b/examples/agent_with_code_execution/local_runner.go
@@ -31,24 +31,22 @@ func (r *localRunner) Execute(ctx context.Context, language, code string) (Execu
 	if err != nil {
 		return ExecutionResult{}, fmt.Errorf("create temp file: %w", err)
 	}
-	defer os.Remove(tmpFile.Name())
+	tmpPath := tmpFile.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	if _, err := tmpFile.WriteString(code); err != nil {
-		tmpFile.Close()
+		_ = tmpFile.Close()
 		return ExecutionResult{}, fmt.Errorf("write code: %w", err)
 	}
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		return ExecutionResult{}, fmt.Errorf("close temp file: %w", err)
+	}
 
 	var stdout, stderr bytes.Buffer
-	var cmd *exec.Cmd
-	if language == "shell" {
-		cmd = exec.CommandContext(ctx, binary, tmpFile.Name())
-	} else {
-		cmd = exec.CommandContext(ctx, binary, tmpFile.Name())
-	}
+	cmd := exec.CommandContext(ctx, binary, tmpPath)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	cmd.Dir = filepath.Dir(tmpFile.Name())
+	cmd.Dir = filepath.Dir(tmpPath)
 
 	runErr := cmd.Run()
 

--- a/examples/agent_with_code_execution/main.go
+++ b/examples/agent_with_code_execution/main.go
@@ -1,0 +1,104 @@
+// agent_with_code_execution demonstrates sandboxed code execution inside an agent.
+//
+// The goal: the LLM writes code to answer a user question; the code runs in an
+// isolated sandbox and returns the output. The LLM reads the output and replies.
+// The sandbox is pluggable — swap the runtime without changing the tool contract.
+//
+// code_tool.go    — CodeTool and SandboxRuntime interface (sandbox-agnostic)
+// local_runner.go — default runtime using os/exec (needs Python or Node on host)
+// docker_runner.go — isolated runtime using Docker; activate with SANDBOX_ENV=docker
+//
+// Run (local sandbox — needs Python or Node installed):
+//
+//	go run ./agent_with_code_execution "Write a Python script that prints the first 10 Fibonacci numbers"
+//
+// Run (Docker sandbox — needs Docker daemon):
+//
+//	SANDBOX_ENV=docker go run ./agent_with_code_execution "Write a Python script that prints the first 10 Fibonacci numbers"
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	config "github.com/agenticenv/agent-sdk-go/examples"
+	"github.com/agenticenv/agent-sdk-go/examples/shared"
+	"github.com/agenticenv/agent-sdk-go/pkg/agent"
+)
+
+func main() {
+	cfg := config.LoadFromEnv()
+
+	llmClient, err := config.NewLLMClientFromConfig(cfg)
+	if err != nil {
+		log.Fatalf("failed to create LLM client: %v", err)
+	}
+
+	// Use newLocalRunner by default (no infra required).
+	// Set SANDBOX_ENV=docker for isolated execution in a Docker container.
+	sandbox, err := newSandbox()
+	if err != nil {
+		log.Fatalf("failed to create sandbox: %v", err)
+	}
+
+	opts := []agent.Option{
+		agent.WithName("agent-with-code-execution"),
+		agent.WithDescription("Agent that writes and executes code in a sandboxed environment"),
+		agent.WithSystemPrompt(
+			"You are a helpful coding assistant with access to a code execution sandbox. " +
+				"When the user asks you to compute something, verify logic, or run code, " +
+				"write a short self-contained script and call execute_code. " +
+				"Read the output and explain the result to the user. " +
+				"Do not make up output — always run the code first.",
+		),
+		agent.WithLLMClient(llmClient),
+		agent.WithTools(NewCodeTool(sandbox)),
+		agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
+		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
+
+		// Code execution is typically fast; a 2-minute ceiling covers slow Docker pulls
+		// or heavy computation. See docs/advanced/code-execution.mdx for sizing guidance.
+		agent.WithAgentMode(agent.AgentModeAutonomous),
+		agent.WithToolExecutionConfig(agent.ExecutionConfig{
+			Timeout:     2 * time.Minute,
+			MaxAttempts: 1,
+		}),
+	}
+	opts = append(opts, config.RuntimeOption(cfg)...)
+
+	a, err := agent.NewAgent(opts...)
+	if err != nil {
+		log.Fatal(config.FormatNewAgentError("failed to create agent", err))
+	}
+	defer a.Close()
+
+	prompt := strings.Join(os.Args[1:], " ")
+	if prompt == "" {
+		prompt = "Write a Python script that prints the first 10 Fibonacci numbers"
+	}
+
+	fmt.Println("user:", prompt)
+	result, err := a.Run(context.Background(), prompt, nil)
+	if err != nil {
+		log.Printf("agent run failed: %v", err)
+		return
+	}
+	fmt.Println("assistant:", result.Content)
+	shared.PrintRunFooters(result)
+}
+
+// newSandbox selects the SandboxRuntime based on the SANDBOX_ENV env var.
+//   - unset / "local": os/exec on the host — needs Python or Node installed
+//   - "docker":        Docker container — needs SANDBOX_ENV=docker + Docker daemon
+func newSandbox() (SandboxRuntime, error) {
+	switch strings.ToLower(os.Getenv("SANDBOX_ENV")) {
+	case "docker":
+		return newDockerRunner()
+	default:
+		return newLocalRunner(), nil
+	}
+}

--- a/examples/agent_with_workflows/inprocess_runner.go
+++ b/examples/agent_with_workflows/inprocess_runner.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// inProcessRunner is a WorkflowRunner that executes workflow steps directly in-process.
+// It needs no external infrastructure — use it to understand the pattern without Temporal.
+// For production durable execution swap it for temporal_runner.go (ORCHESTRATION_ENGINE=temporal).
+type inProcessRunner struct{}
+
+func newInProcessRunner() WorkflowRunner { return &inProcessRunner{} }
+
+func (r *inProcessRunner) Run(_ context.Context, name, input string) (WorkflowResult, error) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "onboarding":
+		return r.runOnboarding(input)
+	case "status_check":
+		return r.runStatusCheck(input)
+	default:
+		return WorkflowResult{}, fmt.Errorf("unknown workflow %q (supported: onboarding, status_check)", name)
+	}
+}
+
+func (r *inProcessRunner) runOnboarding(subject string) (WorkflowResult, error) {
+	// Simulate deterministic step sequence: validate → welcome → provision.
+	// Each step runs in fixed order; results accumulate into the final summary.
+	subject = strings.TrimSpace(subject)
+	if subject == "" {
+		return WorkflowResult{}, fmt.Errorf("subject is required for onboarding workflow")
+	}
+
+	// Simulate step latency (in a real runner this is real I/O or an RPC wait).
+	time.Sleep(100 * time.Millisecond)
+	steps := []string{
+		fmt.Sprintf("welcome email sent to %s", subject),
+		fmt.Sprintf("workspace provisioned for %s", subject),
+	}
+	return WorkflowResult{
+		Workflow: "onboarding",
+		Status:   "completed",
+		Steps:    steps,
+		Summary:  fmt.Sprintf("onboarding for %s completed: %d steps", subject, len(steps)),
+	}, nil
+}
+
+func (r *inProcessRunner) runStatusCheck(target string) (WorkflowResult, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return WorkflowResult{}, fmt.Errorf("target is required for status_check workflow")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	steps := []string{fmt.Sprintf("status for %s: healthy", target)}
+	return WorkflowResult{
+		Workflow: "status_check",
+		Status:   "completed",
+		Steps:    steps,
+		Summary:  fmt.Sprintf("status check for %s: healthy", target),
+	}, nil
+}

--- a/examples/agent_with_workflows/main.go
+++ b/examples/agent_with_workflows/main.go
@@ -1,0 +1,105 @@
+// agent_with_workflows demonstrates deterministic workflow execution inside an agent.
+//
+// The goal: the LLM routes user intent to a named procedure; the procedure runs
+// step-by-step in an orchestration engine (validate → execute → return result).
+// Steps, retries, and ordering are defined by the engine — not improvised by the LLM.
+//
+// workflow_tool.go    — WorkflowTool and WorkflowRunner interface (engine-agnostic)
+// inprocess_runner.go — default runner (no infrastructure required)
+// temporal_runner.go  — sample Temporal runner; activate with ORCHESTRATION_ENGINE=temporal
+//
+// Run (in-process, no infra needed):
+//
+//	go run ./agent_with_workflows "Run the onboarding workflow for Alice"
+//
+// Run (Temporal engine):
+//
+//	task infra:temporal:up && task infra:temporal:wait
+//	ORCHESTRATION_ENGINE=temporal go run ./agent_with_workflows "Run the onboarding workflow for Alice"
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	config "github.com/agenticenv/agent-sdk-go/examples"
+	"github.com/agenticenv/agent-sdk-go/examples/shared"
+	"github.com/agenticenv/agent-sdk-go/pkg/agent"
+)
+
+func main() {
+	cfg := config.LoadFromEnv()
+
+	llmClient, err := config.NewLLMClientFromConfig(cfg)
+	if err != nil {
+		log.Fatalf("failed to create LLM client: %v", err)
+	}
+
+	runner, stop, err := newRunner(cfg)
+	if err != nil {
+		log.Fatalf("failed to create workflow runner: %v", err)
+	}
+	defer stop()
+
+	opts := []agent.Option{
+		agent.WithName("agent-with-workflows"),
+		agent.WithDescription("Agent that invokes deterministic user workflows via a custom tool"),
+		agent.WithSystemPrompt(
+			"You are a helpful operations assistant. " +
+				"When the user asks to run a named workflow (onboarding, provisioning, status checks), " +
+				"use the run_workflow tool with the matching workflow_name and input.",
+		),
+		agent.WithLLMClient(llmClient),
+		agent.WithTools(NewWorkflowTool(runner)),
+		agent.WithToolApprovalPolicy(agent.AutoToolApprovalPolicy()),
+		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
+
+		// Workflows can be long-running: autonomous mode and an explicit tool ceiling.
+		// MaxAttempts: 1 — do not blindly re-trigger an already-started workflow.
+		// See docs/advanced/deterministic-execution.mdx for timeout sizing guidance.
+		agent.WithAgentMode(agent.AgentModeAutonomous),
+		agent.WithTimeout(10 * time.Minute),
+		agent.WithToolExecutionConfig(agent.ExecutionConfig{
+			Timeout:     10 * time.Minute,
+			MaxAttempts: 1,
+		}),
+	}
+	opts = append(opts, config.RuntimeOption(cfg)...)
+
+	a, err := agent.NewAgent(opts...)
+	if err != nil {
+		log.Fatal(config.FormatNewAgentError("failed to create agent", err))
+	}
+	defer a.Close()
+
+	prompt := strings.Join(os.Args[1:], " ")
+	if prompt == "" {
+		prompt = "Run the onboarding workflow for user Alice"
+	}
+
+	fmt.Println("user:", prompt)
+	result, err := a.Run(context.Background(), prompt, nil)
+	if err != nil {
+		log.Printf("agent run failed: %v", err)
+		return
+	}
+	fmt.Println("assistant:", result.Content)
+	shared.PrintRunFooters(result)
+}
+
+// newRunner selects the WorkflowRunner based on the ORCHESTRATION_ENGINE env var.
+//   - unset / "inprocess": no infrastructure needed
+//   - "temporal":          requires ORCHESTRATION_ENGINE=temporal + Temporal server running
+func newRunner(cfg *config.Config) (WorkflowRunner, func(), error) {
+	switch strings.ToLower(os.Getenv("ORCHESTRATION_ENGINE")) {
+	case "temporal":
+		runner, stop, err := NewTemporalRunner(cfg, temporalLogAdapter(cfg))
+		return runner, stop, err
+	default:
+		return newInProcessRunner(), func() {}, nil
+	}
+}

--- a/examples/agent_with_workflows/temporal_runner.go
+++ b/examples/agent_with_workflows/temporal_runner.go
@@ -1,0 +1,192 @@
+// Package main — sample WorkflowRunner backed by Temporal.
+//
+// This file is the Temporal-specific orchestration layer for the agent_with_workflows
+// example. It satisfies the WorkflowRunner interface defined in workflow_tool.go.
+//
+// To use a different engine (Conductor, Argo Workflows, Step Functions, in-process),
+// add a sibling file (e.g. conductor_runner.go) implementing WorkflowRunner and
+// wire it in main.go instead of NewTemporalRunner.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	config "github.com/agenticenv/agent-sdk-go/examples"
+	"github.com/agenticenv/agent-sdk-go/internal/runtime/temporal"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/client"
+	sdklog "go.temporal.io/sdk/log"
+	sdktemporal "go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+)
+
+const orchestrationQueueSuffix = "-workflows"
+
+// NewTemporalRunner returns a WorkflowRunner that executes workflows via Temporal.
+// It also starts an in-process Temporal worker for the sample orchestration queue.
+// The returned stop function shuts down the worker and closes the Temporal client.
+func NewTemporalRunner(cfg *config.Config, logger sdklog.Logger) (WorkflowRunner, func(), error) {
+	hostPort := cfg.Host + ":" + strconv.Itoa(cfg.Port)
+	tc, err := client.Dial(client.Options{
+		HostPort:  hostPort,
+		Namespace: cfg.Namespace,
+		Logger:    logger,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("temporal client: %w", err)
+	}
+
+	queue := cfg.TaskQueue + orchestrationQueueSuffix
+	stop := startOrchestrationWorker(tc, queue)
+
+	return &temporalRunner{client: tc, taskQueue: queue}, func() {
+		stop()
+		tc.Close()
+	}, nil
+}
+
+type temporalRunner struct {
+	client    client.Client
+	taskQueue string
+}
+
+// Run starts a SampleWorkflow execution and blocks until it completes.
+// The ctx deadline propagates — if it fires, Run returns context.DeadlineExceeded
+// and the Temporal workflow may still be running.
+func (r *temporalRunner) Run(ctx context.Context, name, input string) (WorkflowResult, error) {
+	workflowID := fmt.Sprintf("workflow-%s-%s", name, strings.ReplaceAll(input, " ", "-"))
+	run, err := r.client.ExecuteWorkflow(ctx, client.StartWorkflowOptions{
+		ID:        workflowID,
+		TaskQueue: r.taskQueue,
+	}, SampleWorkflow, sampleWorkflowInput{
+		Name:  name,
+		Input: input,
+	})
+	if err != nil {
+		return WorkflowResult{}, fmt.Errorf("start workflow: %w", err)
+	}
+
+	var out WorkflowResult
+	if err := run.Get(ctx, &out); err != nil {
+		return WorkflowResult{}, fmt.Errorf("workflow failed: %w", err)
+	}
+	return out, nil
+}
+
+type sampleWorkflowInput struct {
+	Name  string `json:"name"`
+	Input string `json:"input"`
+}
+
+// SampleWorkflow is a Temporal workflow function that dispatches to named workflow steps.
+// It represents sample user-defined orchestration logic — replace with your own procedures.
+// Steps run deterministically: each activity executes in order, retries on failure,
+// and the workflow can survive worker restarts via Temporal's event-sourced execution.
+func SampleWorkflow(ctx workflow.Context, in sampleWorkflowInput) (WorkflowResult, error) {
+	ao := workflow.ActivityOptions{
+		StartToCloseTimeout: 30 * time.Second,
+		RetryPolicy: &sdktemporal.RetryPolicy{
+			MaximumAttempts: 3,
+		},
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	// Step 1: validate input before executing any side effects.
+	var validated string
+	if err := workflow.ExecuteActivity(ctx, validateInput, in).Get(ctx, &validated); err != nil {
+		return WorkflowResult{}, err
+	}
+
+	var steps []string
+	switch strings.ToLower(strings.TrimSpace(in.Name)) {
+	case "onboarding":
+		// Steps run in order; each is retried independently on failure.
+		var step string
+		if err := workflow.ExecuteActivity(ctx, onboardingWelcome, in.Input).Get(ctx, &step); err != nil {
+			return WorkflowResult{}, err
+		}
+		steps = append(steps, step)
+		if err := workflow.ExecuteActivity(ctx, onboardingProvision, in.Input).Get(ctx, &step); err != nil {
+			return WorkflowResult{}, err
+		}
+		steps = append(steps, step)
+	case "status_check":
+		var step string
+		if err := workflow.ExecuteActivity(ctx, statusCheck, in.Input).Get(ctx, &step); err != nil {
+			return WorkflowResult{}, err
+		}
+		steps = append(steps, step)
+	default:
+		return WorkflowResult{}, fmt.Errorf("unknown workflow %q (supported: onboarding, status_check)", in.Name)
+	}
+
+	return WorkflowResult{
+		Workflow: in.Name,
+		Status:   "completed",
+		Steps:    steps,
+		Summary:  fmt.Sprintf("workflow %q finished with %d step(s)", in.Name, len(steps)),
+	}, nil
+}
+
+func validateInput(ctx context.Context, in sampleWorkflowInput) (string, error) {
+	activity.GetLogger(ctx).Info("validating workflow input", "name", in.Name, "input", in.Input)
+	if strings.TrimSpace(in.Name) == "" {
+		return "", fmt.Errorf("workflow name is required")
+	}
+	if strings.TrimSpace(in.Input) == "" {
+		return "", fmt.Errorf("workflow input is required")
+	}
+	return fmt.Sprintf("validated %s for %q", in.Input, in.Name), nil
+}
+
+func onboardingWelcome(ctx context.Context, subject string) (string, error) {
+	activity.GetLogger(ctx).Info("onboarding: welcome", "subject", subject)
+	return fmt.Sprintf("welcome email sent to %s", strings.TrimSpace(subject)), nil
+}
+
+func onboardingProvision(ctx context.Context, subject string) (string, error) {
+	activity.GetLogger(ctx).Info("onboarding: provision", "subject", subject)
+	return fmt.Sprintf("workspace provisioned for %s", strings.TrimSpace(subject)), nil
+}
+
+func statusCheck(ctx context.Context, target string) (string, error) {
+	activity.GetLogger(ctx).Info("status check", "target", target)
+	return fmt.Sprintf("status for %s: healthy", strings.TrimSpace(target)), nil
+}
+
+// startOrchestrationWorker starts an in-process Temporal worker for the sample engine.
+// In production your orchestration worker runs as a separate process or service.
+func startOrchestrationWorker(tc client.Client, taskQueue string) func() {
+	w := worker.New(tc, taskQueue, worker.Options{})
+	w.RegisterWorkflow(SampleWorkflow)
+	w.RegisterActivity(validateInput)
+	w.RegisterActivity(onboardingWelcome)
+	w.RegisterActivity(onboardingProvision)
+	w.RegisterActivity(statusCheck)
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := w.Run(worker.InterruptCh()); err != nil {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	return func() {
+		w.Stop()
+		if err := <-errCh; err != nil {
+			log.Printf("orchestration worker stopped: %v", err)
+		}
+	}
+}
+
+// temporalLogAdapter bridges the example logger to the Temporal SDK logger interface.
+func temporalLogAdapter(cfg *config.Config) sdklog.Logger {
+	return temporal.NewLogAdapter(config.NewLoggerFromLogConfig(cfg))
+}

--- a/examples/agent_with_workflows/workflow_tool.go
+++ b/examples/agent_with_workflows/workflow_tool.go
@@ -1,0 +1,85 @@
+// Package main implements a WorkflowTool that lets the LLM invoke deterministic
+// user-defined workflows inside an agent run. The tool contract (name, parameters,
+// WorkflowRunner interface) is engine-agnostic — execution is handled by whatever
+// WorkflowRunner is wired in main.go (see temporal_runner.go for a Temporal sample).
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/tools"
+)
+
+var _ interfaces.Tool = (*WorkflowTool)(nil)
+
+// WorkflowRunner is the engine-agnostic interface for executing a named workflow.
+// Implement one runner per orchestration backend — Temporal, Conductor, Argo Workflows,
+// Step Functions, or in-process. The WorkflowTool delegates to this interface so the
+// LLM-facing tool contract never changes when you swap backends.
+type WorkflowRunner interface {
+	Run(ctx context.Context, name, input string) (WorkflowResult, error)
+}
+
+// WorkflowResult is returned to the LLM after a workflow completes.
+// The LLM uses Summary to produce a user-facing reply.
+type WorkflowResult struct {
+	Workflow string   `json:"workflow"`
+	Status   string   `json:"status"`
+	Steps    []string `json:"steps"`
+	Summary  string   `json:"summary"`
+}
+
+// WorkflowTool exposes deterministic user workflows to the LLM as the run_workflow tool.
+// Execute blocks until WorkflowRunner.Run returns — size agent and tool timeouts accordingly.
+type WorkflowTool struct {
+	runner WorkflowRunner
+}
+
+// NewWorkflowTool returns a WorkflowTool backed by the given runner.
+func NewWorkflowTool(runner WorkflowRunner) *WorkflowTool {
+	return &WorkflowTool{runner: runner}
+}
+
+func (*WorkflowTool) Name() string { return "run_workflow" }
+
+func (*WorkflowTool) DisplayName() string { return "Run Workflow" }
+
+func (*WorkflowTool) Description() string {
+	return "Run a predefined, deterministic workflow. " +
+		"Use when the user asks to execute a named multi-step procedure such as onboarding, provisioning, or status checks. " +
+		"Supported workflows: onboarding, status_check."
+}
+
+func (*WorkflowTool) Parameters() interfaces.JSONSchema {
+	return tools.Params(
+		map[string]interfaces.JSONSchema{
+			"workflow_name": tools.ParamEnum(
+				"Name of the workflow to run",
+				"onboarding",
+				"status_check",
+			),
+			"input": tools.ParamString(
+				"Primary subject for the workflow (user name, service id, or target to act on)",
+			),
+		},
+		"workflow_name", "input",
+	)
+}
+
+func (t *WorkflowTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+	name, _ := args["workflow_name"].(string)
+	input, _ := args["input"].(string)
+	name = strings.TrimSpace(name)
+	input = strings.TrimSpace(input)
+	if name == "" {
+		return nil, fmt.Errorf("workflow_name is required")
+	}
+	if input == "" {
+		return nil, fmt.Errorf("input is required")
+	}
+	// Blocks until the workflow reaches a terminal state or ctx deadline fires.
+	return t.runner.Run(ctx, name, input)
+}

--- a/taskfiles/examples.yml
+++ b/taskfiles/examples.yml
@@ -123,7 +123,9 @@ tasks:
       PROMPT: '{{.PROMPT | default ""}}'
       SKIP_RUN: '{{.SKIP_RUN | default "false"}}'
       MEMORY_STORE_MODE: '{{.MEMORY_STORE_MODE | default ""}}'
-      RUN_LABEL: '{{.NAME}}{{if .MEMORY_STORE_MODE}} store={{.MEMORY_STORE_MODE}}{{end}}'
+      ORCHESTRATION_ENGINE: '{{.ORCHESTRATION_ENGINE | default ""}}'
+      SANDBOX_ENV: '{{.SANDBOX_ENV | default ""}}'
+      RUN_LABEL: '{{.NAME}}{{if .MEMORY_STORE_MODE}} store={{.MEMORY_STORE_MODE}}{{end}}{{if .ORCHESTRATION_ENGINE}} engine={{.ORCHESTRATION_ENGINE}}{{end}}{{if .SANDBOX_ENV}} sandbox={{.SANDBOX_ENV}}{{end}}'
     cmds:
       - |
         if [ "{{.SKIP_RUN}}" = "true" ]; then
@@ -185,6 +187,8 @@ tasks:
       # Batch only — not in .env.defaults; manual go run leaves unset (interactive y/n).
       EXAMPLES_AUTO_APPROVE: '{{.EXAMPLES_AUTO_APPROVE | default "true"}}'
       MEMORY_STORE_MODE: '{{.MEMORY_STORE_MODE}}'
+      ORCHESTRATION_ENGINE: '{{.ORCHESTRATION_ENGINE}}'
+      SANDBOX_ENV: '{{.SANDBOX_ENV}}'
 
   exec:examples:
     internal: true
@@ -195,29 +199,33 @@ tasks:
       WRITE_SUMMARY: '{{.WRITE_SUMMARY | default "true"}}'
       FAIL_ON_ERROR: '{{.FAIL_ON_ERROR | default "true"}}'
       EXAMPLES:
-        - simple_agent
-        - agent_with_tools/basic
-        - agent_with_tools/custom
-        - agent_with_tools/dynamic_registry
-        - agent_with_hooks
-        - agent_with_execution_config
-        - agent_with_tools/authorizer
-        - agent_with_json_response
-        - agent_with_stream
-        - agent_with_reasoning
-        - multiple_agents
-        - agent_with_mcp_config
-        - agent_with_mcp_client
-        - agent_with_a2a_config
-        - agent_with_a2a_client
-        - agent_with_retriever/weaviate
-        - agent_with_retriever/pgvector
-        - agent_with_observability/config
-        - agent_with_observability/objects
-        - agent_with_subagents
-        - agent_with_tools/approval
-        - agent_with_run_async
-        - agent_with_concurrent_runs
+        - NAME: simple_agent
+        - NAME: agent_with_tools/basic
+        - NAME: agent_with_tools/custom
+        - NAME: agent_with_tools/dynamic_registry
+        - NAME: agent_with_hooks
+        - NAME: agent_with_execution_config
+        - NAME: agent_with_tools/authorizer
+        - NAME: agent_with_json_response
+        - NAME: agent_with_stream
+        - NAME: agent_with_reasoning
+        - NAME: multiple_agents
+        - NAME: agent_with_mcp_config
+        - NAME: agent_with_mcp_client
+        - NAME: agent_with_a2a_config
+        - NAME: agent_with_a2a_client
+        - NAME: agent_with_retriever/weaviate
+        - NAME: agent_with_retriever/pgvector
+        - NAME: agent_with_observability/config
+        - NAME: agent_with_observability/objects
+        - NAME: agent_with_subagents
+        - NAME: agent_with_tools/approval
+        - NAME: agent_with_run_async
+        - NAME: agent_with_concurrent_runs
+        - NAME: agent_with_workflows
+        - NAME: agent_with_code_execution
+        - NAME: agent_with_code_execution
+          SANDBOX_ENV: docker
       EXAMPLES_MEMORY:
         - NAME: agent_with_memory/weaviate
           MEMORY_STORE_MODE: always
@@ -231,12 +239,14 @@ tasks:
         - agent_with_conversation
         - agent_with_stream_conversation
       EXAMPLES_TEMPORAL:
-        - agent_with_temporal_client
+        - NAME: agent_with_temporal_client
+        - NAME: agent_with_workflows
+          ORCHESTRATION_ENGINE: temporal
         # TODO: enable — split worker + agent REPL
-        # - durable_agent/worker
-        # - durable_agent/agent
-        # - agent_with_worker/worker
-        # - agent_with_worker/agent
+        # - NAME: durable_agent/worker
+        # - NAME: durable_agent/agent
+        # - NAME: agent_with_worker/worker
+        # - NAME: agent_with_worker/agent
     cmds:
       - printf '0 0\n' > {{.COUNT_FILE}}
       - for:
@@ -244,7 +254,8 @@ tasks:
         ignore_error: true
         task: exec:example
         vars:
-          NAME: '{{.ITEM}}'
+          NAME: '{{.ITEM.NAME}}'
+          SANDBOX_ENV: '{{.ITEM.SANDBOX_ENV}}'
           RUNTIME: '{{.RUNTIME}}'
           REPORT_FILE: '{{.REPORT_FILE}}'
           LOG_FILE: '{{.LOG_FILE}}'
@@ -280,7 +291,8 @@ tasks:
         ignore_error: true
         task: exec:example
         vars:
-          NAME: '{{.ITEM}}'
+          NAME: '{{.ITEM.NAME}}'
+          ORCHESTRATION_ENGINE: '{{.ITEM.ORCHESTRATION_ENGINE}}'
           RUNTIME: '{{.RUNTIME}}'
           REPORT_FILE: '{{.REPORT_FILE}}'
           LOG_FILE: '{{.LOG_FILE}}'


### PR DESCRIPTION
## Description

Adds two example-only custom-tool patterns that show how agents can run deterministic workflows and sandboxed code without built-in SDK tools:

agent_with_workflows — run_workflow tool backed by a pluggable WorkflowRunner (in-process default, Temporal via ORCHESTRATION_ENGINE=temporal)
agent_with_code_execution — execute_code tool backed by a pluggable SandboxRuntime (local os/exec default, Docker via SANDBOX_ENV=docker)
Also adds matching docs (examples/workflows, examples/code-execution, advanced/deterministic-execution, advanced/code-execution), updates docs.json, examples/README.md, running-examples.mdx, and wires both examples into taskfiles/examples.yml for local/temporal batch runs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New examples
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / chore

## Checklist

- [x] I have run `make check`
- [ ] I have run `task examples:all`
- [ ] I have run `make tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [ ] I have added/updated tests for my changes
- [x] Documentation is updated if needed
