### PR TITLE
feat: Optimize LLM request layout for provider caching and add opt-in Anthropic prompt caching with CLI session usage summary.

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -28,6 +28,8 @@ Interactive conversation mode. Type prompts, get responses. Type `exit`, `quit`,
 
 The CLI uses `temporal.host`, `temporal.port`, and `temporal.namespace` from `config.yaml` (default: localhost, 7233, default). Override with `AGENT_TEMPORAL_HOST`, `AGENT_TEMPORAL_PORT`, and `AGENT_TEMPORAL_NAMESPACE` if Temporal runs elsewhere.
 
+**Anthropic prompt caching:** when `llm.provider: anthropic`, the CLI always enables `llm.WithPromptCaching(true)` — this differs from the SDK library default, which is caching **off** unless you opt in explicitly (see [LLM Providers](../docs/getting-started/llm-providers.mdx#prompt-caching)). Set `show_llm_usage: true` to see `cached_prompt` in the exit summary and confirm cache hits.
+
 ## Run
 
 ```bash
@@ -81,6 +83,7 @@ Config is loaded from `cmd/config.yaml` (default). If the file does not exist, d
 | `AGENT_LLM_BASEURL` | Optional; for OpenAI-compatible proxies |
 | `AGENT_LOGGER_LEVEL` | `error` (default), `warn`, `info`, `debug` |
 | `AGENT_LOGGER_OUTPUT` | Log file path; default `cmd/logs/agent.log` |
+| `AGENT_SHOW_LLM_USAGE` | When `true`, print accumulated session token usage on exit (`show_llm_usage` in config) |
 
 ### MCP (optional)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	LLM      *LLMConfig      `mapstructure:"llm"`
 	Logger   *LoggerConfig   `mapstructure:"logger"`
 	MCP      *MCPRootConfig  `mapstructure:"mcp"`
+	// ShowLLMUsage prints a session token-usage summary when the conversation ends (exit/quit/bye).
+	// Override with AGENT_SHOW_LLM_USAGE=true.
+	ShowLLMUsage bool `mapstructure:"show_llm_usage"`
 }
 
 // UseTemporalRuntime reports whether the temporal backend is selected.
@@ -246,6 +249,7 @@ func LoadConfig(path string) (*Config, error) {
 	_ = v.BindEnv("logger.format", "AGENT_LOGGER_FORMAT")
 	_ = v.BindEnv("logger.add_source", "AGENT_LOGGER_ADD_SOURCE")
 	_ = v.BindEnv("logger.tee_stderr", "AGENT_LOGGER_TEE_STDERR")
+	_ = v.BindEnv("show_llm_usage", "AGENT_SHOW_LLM_USAGE")
 
 	// Set defaults so env can override even when file is missing or key absent
 	v.SetDefault("runtime", "local")
@@ -261,6 +265,7 @@ func LoadConfig(path string) (*Config, error) {
 	v.SetDefault("logger.format", "json")
 	v.SetDefault("logger.add_source", true)
 	v.SetDefault("logger.tee_stderr", false)
+	v.SetDefault("show_llm_usage", false)
 
 	_ = v.ReadInConfig() // ignore: file not found uses defaults + env
 	var cfg Config
@@ -309,6 +314,7 @@ func NewLLMClient(cfg *Config, lgr logger.Logger) (interfaces.LLMClient, error) 
 	}
 	switch interfaces.LLMProvider(cfg.LLM.Provider) {
 	case interfaces.LLMProviderAnthropic:
+		opts = append(opts, llm.WithPromptCaching(true))
 		return anthropic.NewClient(opts...)
 	case interfaces.LLMProviderOpenAI:
 		if cfg.LLM.BaseURL != "" {

--- a/cmd/config.sample.yaml
+++ b/cmd/config.sample.yaml
@@ -37,6 +37,10 @@ logger:
   add_source: false
   tee_stderr: false
 
+# When true, accumulate token usage across turns and print a summary on exit (exit/quit/bye).
+# Override: AGENT_SHOW_LLM_USAGE=true
+show_llm_usage: false
+
 # Optional MCP servers. Set enabled: true on entries you use.
 # When any server is enabled, the CLI uses auto tool approval (same pattern as examples with MCP).
 # Transports: stdio | local (subprocess); streamable_http | http | remote | streamable (URL).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,6 +81,9 @@ func main() {
 	lineCh := make(chan string)
 	go func() {
 		scanner := bufio.NewScanner(os.Stdin)
+		if err := scanner.Err(); err != nil {
+			log.Printf("error reading stdin: %v", err)
+		}
 		for scanner.Scan() {
 			lineCh <- scanner.Text()
 		}
@@ -112,6 +115,7 @@ func main() {
 
 	fmt.Println("Conversation mode. " + exitPrompt)
 
+	var sessionUsage *agent.LLMUsage
 	for {
 		fmt.Print("\nYou: ")
 		line, ok := <-lineCh
@@ -202,13 +206,22 @@ func main() {
 					fmt.Print(t.Delta)
 				}
 			}
-			if res := runResultFromFinishedEvent(ev); res != nil && res.Content != "" {
-				finalContent = res.Content
+			if res := runResultFromFinishedEvent(ev); res != nil {
+				if res.Content != "" {
+					finalContent = res.Content
+				}
+				if cfg.ShowLLMUsage {
+					sessionUsage = mergeLLMUsage(sessionUsage, res.LLMUsage)
+				}
 			}
 		}
 		if finalContent != "" {
 			fmt.Println()
 		}
+	}
+
+	if cfg.ShowLLMUsage {
+		printSessionUsageSummary(sessionUsage)
 	}
 }
 
@@ -316,6 +329,42 @@ func isExitCommand(s string) bool {
 		return true
 	}
 	return false
+}
+
+// mergeLLMUsage accumulates add into acc. Either argument may be nil.
+func mergeLLMUsage(acc, add *agent.LLMUsage) *agent.LLMUsage {
+	if add == nil {
+		return acc
+	}
+	if acc == nil {
+		cp := *add
+		return &cp
+	}
+	return &agent.LLMUsage{
+		PromptTokens:       acc.PromptTokens + add.PromptTokens,
+		CompletionTokens:   acc.CompletionTokens + add.CompletionTokens,
+		TotalTokens:        acc.TotalTokens + add.TotalTokens,
+		CachedPromptTokens: acc.CachedPromptTokens + add.CachedPromptTokens,
+		ReasoningTokens:    acc.ReasoningTokens + add.ReasoningTokens,
+	}
+}
+
+// printSessionUsageSummary prints accumulated session token usage, or a short note when none was reported.
+func printSessionUsageSummary(u *agent.LLMUsage) {
+	if u == nil {
+		fmt.Println("\n[USAGE] no token usage reported this session")
+		return
+	}
+	fmt.Println("\n[USAGE] session total")
+	fmt.Printf("  prompt_tokens:     %d\n", u.PromptTokens)
+	fmt.Printf("  completion_tokens: %d\n", u.CompletionTokens)
+	fmt.Printf("  total_tokens:      %d\n", u.TotalTokens)
+	if u.CachedPromptTokens > 0 {
+		fmt.Printf("  cached_prompt:     %d\n", u.CachedPromptTokens)
+	}
+	if u.ReasoningTokens > 0 {
+		fmt.Printf("  reasoning_tokens:  %d\n", u.ReasoningTokens)
+	}
 }
 
 func formatNewAgentCreateErr(err error) string {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -6,7 +6,24 @@ import (
 
 	"github.com/agenticenv/agent-sdk-go/internal/events"
 	"github.com/agenticenv/agent-sdk-go/internal/types"
+	"github.com/agenticenv/agent-sdk-go/pkg/agent"
 )
+
+func TestMergeLLMUsage(t *testing.T) {
+	if mergeLLMUsage(nil, nil) != nil {
+		t.Fatal("expected nil")
+	}
+	a := &agent.LLMUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3, CachedPromptTokens: 4}
+	got := mergeLLMUsage(nil, a)
+	if got == nil || got.PromptTokens != 1 || got.CachedPromptTokens != 4 {
+		t.Fatalf("nil+add = %#v", got)
+	}
+	b := &agent.LLMUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30, ReasoningTokens: 5}
+	got = mergeLLMUsage(a, b)
+	if got.PromptTokens != 11 || got.CompletionTokens != 22 || got.TotalTokens != 33 || got.CachedPromptTokens != 4 || got.ReasoningTokens != 5 {
+		t.Fatalf("merge = %#v", got)
+	}
+}
 
 func TestIsExitCommand(t *testing.T) {
 	// main() trims input before calling isExitCommand; the helper itself is case-insensitive, not TrimSpace.

--- a/docs/features/memory.mdx
+++ b/docs/features/memory.mdx
@@ -5,7 +5,7 @@ description: "Store and recall long-term memories scoped by user or tenant using
 
 Memory lets agents **remember facts and preferences across separate runs** — scoped per user, tenant, or custom tags — without relying on conversation history alone.
 
-At the start of each run, the SDK performs a semantic search against the memory store using the incoming prompt as a query. Matching memories are **injected as context** into the LLM request — ahead of the system prompt — so the model can reference past facts without the caller having to pass them explicitly. The agent also stores new memories during or after the run depending on the store mode.
+At the start of each run, the SDK performs a semantic search against the memory store using the incoming prompt as a query. Matching memories are **injected as a labeled "Relevant Memories" message** ahead of conversation history (the system prompt itself is left untouched) — so the model can reference past facts without the caller having to pass them explicitly. When both memory and [retrieval](/features/retrieval) prefetch are active, memory is placed first, RAG context second, keeping the request's stable prefix (system prompt, tools) unaffected by either. The agent also stores new memories during or after the run depending on the store mode.
 
 Use it when users return across sessions, when preferences should persist beyond a single conversation, or when you need tenant- or project-scoped memory separate from chat history.
 

--- a/docs/features/retrieval.mdx
+++ b/docs/features/retrieval.mdx
@@ -5,7 +5,7 @@ description: "Connect agents to external knowledge bases with agentic, prefetch,
 
 Retrieval-Augmented Generation (RAG) lets agents query external knowledge bases and ground responses in up-to-date or domain-specific content — without hardcoding it into the prompt.
 
-When a retrieval fires, the SDK calls `Search(ctx, query)` on your retriever, collects the returned `[]Document`, and **injects the document content into the LLM request** — either as context prepended to the system message (prefetch) or as a tool result the model requested (agentic). The LLM then sees the retrieved text alongside the user prompt when generating its response.
+When a retrieval fires, the SDK calls `Search(ctx, query)` on your retriever, collects the returned `[]Document`, and **injects the document content into the LLM request** — either as a labeled "Relevant Context" message ahead of conversation history (prefetch) or as a tool result the model requested (agentic). The system prompt itself is never modified. The LLM then sees the retrieved text alongside the user prompt when generating its response.
 
 Built-in retriever implementations are in `pkg/retriever/weaviate` and `pkg/retriever/pgvector`. Bring your own by implementing [`interfaces.Retriever`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/interfaces#Retriever).
 

--- a/docs/features/token-usage.mdx
+++ b/docs/features/token-usage.mdx
@@ -17,6 +17,8 @@ An agent run can involve **multiple LLM calls** — the initial generation, then
 | `CachedPromptTokens` | Prompt cache hits (when supported) |
 | `ReasoningTokens` | Extended thinking tokens (when supported) |
 
+`CachedPromptTokens` is populated by OpenAI automatically (server-side caching, no client option needed) and by Anthropic only when [`llm.WithPromptCaching(true)`](/getting-started/llm-providers#prompt-caching) is set — it's `0` for Anthropic otherwise, since caching is disabled by default there.
+
 ## Run
 
 [`AgentRunResult.LLMUsage`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/agent#AgentRunResult) is the **sum across all LLM calls** in that run — including tool rounds. Use it for cost estimates, quotas, and logging:

--- a/docs/getting-started/cli.mdx
+++ b/docs/getting-started/cli.mdx
@@ -123,6 +123,7 @@ Environment variables override config file values. Prefer them for secrets.
 | `AGENT_LLM_BASEURL` | Optional base URL for OpenAI-compatible proxies |
 | `AGENT_LOGGER_LEVEL` | `error`, `warn`, `info`, `debug` |
 | `AGENT_LOGGER_OUTPUT` | Log file path, `stdout`, or `stderr` |
+| `AGENT_SHOW_LLM_USAGE` | Print session token usage summary on exit |
 
 ```bash
 export AGENT_LLM_APIKEY=sk-your-key
@@ -148,6 +149,20 @@ mcp:
 Each entry supports: `enabled`, `name`, `transport` (`stdio` or `streamable_http`), `command`/`args` (stdio) or `url`/`bearer_token` (HTTP), and optional `timeout_seconds`, `retry_attempts`, `allow_tools`, `block_tools`.
 
 See `cmd/config.sample.yaml` for HTTP transport, OAuth, and tool filter examples.
+
+## Token usage summary
+
+When `show_llm_usage: true` is set in `config.yaml` (or `AGENT_SHOW_LLM_USAGE=true`), the CLI accumulates `LLMUsage` across every turn of the session and prints one summary on exit (`exit`/`quit`/`bye`):
+
+```
+[USAGE] session total
+  prompt_tokens:     12120
+  completion_tokens: 262
+  total_tokens:      12382
+  cached_prompt:     12541
+```
+
+Use this to measure cost across a full interactive session. `cached_prompt` reflects provider cache hits when the LLM reports them (for Anthropic, only when prompt caching is enabled — the CLI enables it automatically for Anthropic).
 
 ## SDK vs CLI
 

--- a/docs/getting-started/llm-providers.mdx
+++ b/docs/getting-started/llm-providers.mdx
@@ -68,6 +68,22 @@ llmClient, err := anthropic.NewClient(
 
 Anthropic supports extended thinking via [`WithLLMSampling`](/features/reasoning). See [Reasoning](/features/reasoning).
 
+### Prompt caching
+
+Anthropic supports prompt-cache breakpoints (`cache_control`) that let the provider reuse the KV-cache for the stable part of a request — system prompt, tool definitions, and everything up to the second-to-last message — instead of reprocessing it every call. Enable it with `llm.WithPromptCaching`:
+
+```go
+llmClient, err := anthropic.NewClient(
+    llm.WithAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
+    llm.WithModel("claude-sonnet-4-20250514"),
+    llm.WithPromptCaching(true),
+)
+```
+
+**Disabled by default.** Anthropic's cache writes cost more than a normal input token and have a short (default 5-minute) TTL, so it's only worth enabling once request volume is high enough that repeated calls reliably land inside that window. `WithPromptCaching` is Anthropic-only — OpenAI, Gemini, and DeepSeek ignore it (OpenAI caches automatically server-side with no client-side option needed; Gemini/DeepSeek have no equivalent in this SDK today).
+
+See [Token Usage](/features/token-usage) for how to measure `CachedPromptTokens` and confirm caching is actually being hit.
+
 ## Gemini
 
 ```go

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -43,6 +43,7 @@ Go 1.26+. OpenAI API key required for the example above; Anthropic and Gemini ar
 - **Concurrent by default** — one `Agent` instance handles parallel `Run`, `RunAsync`, and `Stream` calls; Temporal issues each a unique workflow automatically.
 - **Protocol-native integrations** — MCP tool servers, A2A agent-to-agent delegation, and AG-UI streaming events are first-class, not adapters bolted on after the fact.
 - **Middleware hooks** — intercept LLM calls, tool use, retrieval, and memory at any lifecycle point for logging, PII scrubbing, and guardrails without touching agent logic.
+- **Cache-aware requests** — LLM requests are structured for provider caching, with Anthropic prompt-cache breakpoints to reduce cost on multi-turn runs.
 
 ## Runtimes
 

--- a/examples/agent_with_memory/common/opts.go
+++ b/examples/agent_with_memory/common/opts.go
@@ -37,7 +37,7 @@ func AgentOptions(
 	}
 	prompt := fmt.Sprintf(
 		"You are a helpful assistant with long-term memory backed by %s (%s). "+
-			"When the system prompt includes a Relevant Memories section, treat those as facts from prior runs and answer from them.",
+			"When a Relevant Memories section appears in the conversation messages, treat those as facts from prior runs and answer from them.",
 		backendLabel,
 		recallNote,
 	)

--- a/internal/runtime/base/runtime.go
+++ b/internal/runtime/base/runtime.go
@@ -48,20 +48,32 @@ type ExecuteLLMInput struct {
 }
 
 // BuildLLMRequest constructs an LLMRequest from the given messages and options.
-// When memoryContext or retrieverContext is non-empty each is appended to the system prompt.
-// tools is the per-run resolved tool list from [runtime.ExecuteRequest] or activity resolve.
+// SystemMessage is the static system prompt only. When memoryContext or retrieverContext
+// is non-empty each is prepended as a labeled user message (memory then RAG) before the
+// conversation messages. Message content is sanitized for the LLM copy only; the caller's
+// slice is not modified. tools is the per-run resolved tool list from [runtime.ExecuteRequest]
+// or activity resolve.
 func (rt *Runtime) BuildLLMRequest(messages []interfaces.Message, skipTools bool, memoryContext, retrieverContext string, tools []interfaces.Tool) *interfaces.LLMRequest {
-	systemMessage := rt.AgentSpec.SystemPrompt
+	sanitized := sanitizeMessages(messages)
+	outMsgs := make([]interfaces.Message, 0, len(sanitized)+2)
 	if memoryContext != "" {
-		systemMessage = fmt.Sprintf("%s\n\nRelevant Memories:\n%s", systemMessage, memoryContext)
+		outMsgs = append(outMsgs, interfaces.Message{
+			Role:    interfaces.MessageRoleUser,
+			Content: "Relevant Memories:\n" + memoryContext,
+		})
 	}
 	if retrieverContext != "" {
-		systemMessage = fmt.Sprintf("%s\n\nRelevant Context:\n%s", systemMessage, retrieverContext)
+		outMsgs = append(outMsgs, interfaces.Message{
+			Role:    interfaces.MessageRoleUser,
+			Content: "Relevant Context:\n" + retrieverContext,
+		})
 	}
+	outMsgs = append(outMsgs, sanitized...)
+
 	req := &interfaces.LLMRequest{
-		SystemMessage:  systemMessage,
+		SystemMessage:  rt.AgentSpec.SystemPrompt,
 		ResponseFormat: rt.AgentSpec.ResponseFormat,
-		Messages:       messages,
+		Messages:       outMsgs,
 	}
 	ApplyLLMSampling(rt.AgentConfig.LLM.Sampling, req)
 	if skipTools {

--- a/internal/runtime/base/runtime_test.go
+++ b/internal/runtime/base/runtime_test.go
@@ -102,20 +102,41 @@ func TestBuildLLMRequest_WithRetrieverContext(t *testing.T) {
 	rt := newTestRuntime(sdkruntime.AgentConfig{
 		LLM: sdkruntime.AgentLLM{Client: stubLLMClient{}},
 	})
-	req := rt.BuildLLMRequest(nil, false, "", "extra context", nil)
-	require.Contains(t, req.SystemMessage, "you are helpful")
-	require.Contains(t, req.SystemMessage, "extra context")
+	user := []interfaces.Message{{Role: interfaces.MessageRoleUser, Content: "q"}}
+	req := rt.BuildLLMRequest(user, false, "", "extra context", nil)
+	require.Equal(t, "you are helpful", req.SystemMessage)
+	require.Len(t, req.Messages, 2)
+	require.Equal(t, interfaces.MessageRoleUser, req.Messages[0].Role)
+	require.Contains(t, req.Messages[0].Content, "Relevant Context")
+	require.Contains(t, req.Messages[0].Content, "extra context")
+	require.Equal(t, "q", req.Messages[1].Content)
 }
 
 func TestBuildLLMRequest_WithMemoryContext(t *testing.T) {
 	rt := newTestRuntime(sdkruntime.AgentConfig{
 		LLM: sdkruntime.AgentLLM{Client: stubLLMClient{}},
 	})
-	req := rt.BuildLLMRequest(nil, false, "memory fact", "retriever doc", nil)
-	require.Contains(t, req.SystemMessage, "Relevant Memories")
-	require.Contains(t, req.SystemMessage, "memory fact")
-	require.Contains(t, req.SystemMessage, "Relevant Context")
-	require.Contains(t, req.SystemMessage, "retriever doc")
+	user := []interfaces.Message{{Role: interfaces.MessageRoleUser, Content: "q"}}
+	req := rt.BuildLLMRequest(user, false, "memory fact", "retriever doc", nil)
+	require.Equal(t, "you are helpful", req.SystemMessage)
+	require.Len(t, req.Messages, 3)
+	require.Contains(t, req.Messages[0].Content, "Relevant Memories")
+	require.Contains(t, req.Messages[0].Content, "memory fact")
+	require.Contains(t, req.Messages[1].Content, "Relevant Context")
+	require.Contains(t, req.Messages[1].Content, "retriever doc")
+	require.Equal(t, "q", req.Messages[2].Content)
+	// Input slice must not be mutated / aliased when context is prepended.
+	require.Len(t, user, 1)
+}
+
+func TestBuildLLMRequest_DoesNotMutateInput(t *testing.T) {
+	rt := newTestRuntime(sdkruntime.AgentConfig{
+		LLM: sdkruntime.AgentLLM{Client: stubLLMClient{}},
+	})
+	msgs := []interfaces.Message{{Role: interfaces.MessageRoleUser, Content: "  hello   world  "}}
+	req := rt.BuildLLMRequest(msgs, false, "mem", "", nil)
+	require.Equal(t, "  hello   world  ", msgs[0].Content)
+	require.Equal(t, "hello world", req.Messages[1].Content)
 }
 
 func TestBuildLLMRequest_SkipTools(t *testing.T) {

--- a/internal/runtime/base/sanitize.go
+++ b/internal/runtime/base/sanitize.go
@@ -1,0 +1,50 @@
+package base
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+)
+
+// Patterns for volatile tokens that hurt prompt-prefix cache stability when injected into content.
+var (
+	sanitizeTimestampRe = regexp.MustCompile(
+		`\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?\b` +
+			`|\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d{4}\b`,
+	)
+	sanitizeSessionIDRe = regexp.MustCompile(
+		`(?i)\b(?:session[_-]?id|conversation[_-]?id|run[_-]?id|request[_-]?id)\s*[:=]\s*["']?[A-Za-z0-9_-]+["']?` +
+			`|\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b`,
+	)
+	sanitizeWhitespaceRe = regexp.MustCompile(`[ \t]+`)
+)
+
+// sanitizeMessages returns a new message slice with volatile content stripped for LLM calls.
+// The input slice is not modified (conversation stores stay unchanged).
+func sanitizeMessages(msgs []interfaces.Message) []interfaces.Message {
+	if len(msgs) == 0 {
+		return msgs
+	}
+	out := make([]interfaces.Message, len(msgs))
+	for i, msg := range msgs {
+		msg.Content = sanitizeContent(msg.Content)
+		out[i] = msg
+	}
+	return out
+}
+
+func sanitizeContent(s string) string {
+	if s == "" {
+		return s
+	}
+	s = sanitizeTimestampRe.ReplaceAllString(s, "")
+	s = sanitizeSessionIDRe.ReplaceAllString(s, "")
+	s = sanitizeWhitespaceRe.ReplaceAllString(s, " ")
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	// Collapse blank lines introduced by removals.
+	for strings.Contains(s, "\n\n\n") {
+		s = strings.ReplaceAll(s, "\n\n\n", "\n\n")
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/runtime/base/sanitize_test.go
+++ b/internal/runtime/base/sanitize_test.go
@@ -1,0 +1,28 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSanitizeMessages_stripsVolatileContent(t *testing.T) {
+	in := []interfaces.Message{{
+		Role:    interfaces.MessageRoleUser,
+		Content: "Hello  world  at 2024-06-01T12:00:00Z session_id=abc-123 and uuid 550e8400-e29b-41d4-a716-446655440000",
+	}}
+	out := sanitizeMessages(in)
+	require.Len(t, out, 1)
+	require.NotContains(t, out[0].Content, "2024-06-01")
+	require.NotContains(t, out[0].Content, "session_id")
+	require.NotContains(t, out[0].Content, "550e8400")
+	require.Contains(t, out[0].Content, "Hello world")
+	// Input unchanged.
+	require.Contains(t, in[0].Content, "2024-06-01")
+}
+
+func TestSanitizeMessages_empty(t *testing.T) {
+	require.Nil(t, sanitizeMessages(nil))
+	require.Empty(t, sanitizeMessages([]interfaces.Message{}))
+}

--- a/internal/runtime/temporal/agent_workflow.go
+++ b/internal/runtime/temporal/agent_workflow.go
@@ -139,7 +139,8 @@ type AgentRetrieverInput struct {
 
 // AgentRetrieverResult is the return value of AgentRetrieverActivity.
 // RetrieverContext is the combined, formatted document context from all retrievers; empty when no
-// documents were found. It is injected into the system prompt by AgentLLMActivity and AgentLLMStreamActivity.
+// documents were found. BuildLLMRequest injects it as a labeled "Relevant Context" message ahead
+// of conversation history; the system prompt itself is left untouched.
 type AgentRetrieverResult struct {
 	RetrieverContext string `json:"retriever_context,omitempty"`
 	TotalSearches    int64  `json:"total_searches,omitempty"`

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -1162,6 +1162,8 @@ func (cfg *agentConfig) buildAgentRuntime(remoteWorker bool) (runtime.Runtime, e
 }
 
 // resolveTools builds the merged tool list for one run from registries and resolution.
+// Order is stable-first for prompt-cache friendliness:
+// native → MCP → A2A → sub-agents → save_memory → RAG/retriever tools last.
 func (c *agentConfig) resolveTools(ctx context.Context) ([]interfaces.Tool, error) {
 	tools := c.toolRegistry.List()
 
@@ -1183,17 +1185,17 @@ func (c *agentConfig) resolveTools(ctx context.Context) ([]interfaces.Tool, erro
 	}
 	tools = append(tools, subAgentTools...)
 
-	retrieverTools, err := c.resolveRetrieverTools()
-	if err != nil {
-		return nil, err
-	}
-	tools = append(tools, retrieverTools...)
-
 	memoryTools, err := c.resolveMemoryTools()
 	if err != nil {
 		return nil, err
 	}
 	tools = append(tools, memoryTools...)
+
+	retrieverTools, err := c.resolveRetrieverTools()
+	if err != nil {
+		return nil, err
+	}
+	tools = append(tools, retrieverTools...)
 
 	if err := validateToolNames(tools); err != nil {
 		return nil, err

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -1183,6 +1183,37 @@ func TestBuildAgentConfig_toolsList_includesRetrieverTools_hybrid(t *testing.T) 
 	}
 }
 
+func TestResolveTools_order_nativeMemoryThenRAG(t *testing.T) {
+	cfg, err := buildAgentConfig([]Option{
+		WithName("test"),
+		WithTemporalConfig(&TemporalConfig{TaskQueue: "q"}),
+		WithLLMClient(stubLLM{}),
+		WithTools(mockTool{name: "echo"}),
+		WithMemory(memory.DefaultConfig(stubMemoryBackend{})),
+		WithRetrievers(stubRetriever{}),
+		WithRetrieverMode(RetrieverModeAgentic),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, err := cfg.resolveTools(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("len=%d want 3", len(list))
+	}
+	if list[0].Name() != "echo" {
+		t.Fatalf("tool[0]=%q want echo", list[0].Name())
+	}
+	if list[1].Name() != types.SaveMemoryToolName {
+		t.Fatalf("tool[1]=%q want %s", list[1].Name(), types.SaveMemoryToolName)
+	}
+	if list[2].Name() != "retriever_stub" {
+		t.Fatalf("tool[2]=%q want retriever_stub (RAG last)", list[2].Name())
+	}
+}
+
 func TestAgentConfigFingerprint_AgenticRetrieverNamesChangesDigest(t *testing.T) {
 	baseOpts := []Option{
 		WithName("test"),

--- a/pkg/llm/anthropic/client.go
+++ b/pkg/llm/anthropic/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"log/slog"
+
 	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm"
 	"github.com/anthropics/anthropic-sdk-go"
@@ -12,7 +14,6 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/packages/param"
 	"github.com/anthropics/anthropic-sdk-go/packages/ssestream"
 	"github.com/anthropics/anthropic-sdk-go/shared/constant"
-	"log/slog"
 )
 
 var _ interfaces.LLMClient = (*Client)(nil)
@@ -20,17 +21,23 @@ var _ interfaces.LLMClient = (*Client)(nil)
 // Client implements interfaces.LLMClient for Anthropic Claude.
 type Client struct {
 	llm.LLMConfig
-	client anthropic.Client
+	client        anthropic.Client
+	promptCaching bool // default false
 }
 
 // NewClient creates a new Anthropic LLM client.
+// Prompt caching is disabled by default; enable with llm.WithPromptCaching(true).
 func NewClient(opts ...llm.Option) (*Client, error) {
 	config, err := llm.BuildConfig(opts...)
 	if err != nil {
 		return nil, err
 	}
 	c := &Client{
-		LLMConfig: *config,
+		LLMConfig:     *config,
+		promptCaching: false,
+	}
+	if config.PromptCaching != nil {
+		c.promptCaching = *config.PromptCaching
 	}
 	options := []option.RequestOption{option.WithAPIKey(c.APIKey)}
 	if c.BaseURL != "" {
@@ -69,12 +76,14 @@ func (c *Client) buildMessageParams(messages []anthropic.MessageParam, req *inte
 		params.TopK = param.NewOpt(int64(*req.TopK))
 	}
 	if req.SystemMessage != "" {
-		params.System = []anthropic.TextBlockParam{
-			{Text: req.SystemMessage},
+		sys := anthropic.TextBlockParam{Text: req.SystemMessage}
+		if c.promptCaching {
+			sys.CacheControl = anthropic.NewCacheControlEphemeralParam()
 		}
+		params.System = []anthropic.TextBlockParam{sys}
 	}
 	if len(req.Tools) > 0 {
-		params.Tools = toolsToAnthropic(req.Tools)
+		params.Tools = c.toolsToAnthropic(req.Tools)
 		params.ToolChoice = anthropic.ToolChoiceUnionParam{
 			OfAuto: &anthropic.ToolChoiceAutoParam{},
 		}
@@ -124,7 +133,7 @@ func responseFormatToAnthropic(rf *interfaces.ResponseFormat) anthropic.OutputCo
 }
 
 func (c *Client) Generate(ctx context.Context, req *interfaces.LLMRequest) (*interfaces.LLMResponse, error) {
-	messages := messagesToAnthropic(req)
+	messages := c.messagesToAnthropic(req)
 
 	params := c.buildMessageParams(messages, req)
 
@@ -133,7 +142,8 @@ func (c *Client) Generate(ctx context.Context, req *interfaces.LLMRequest) (*int
 		slog.String("model", c.Model),
 		slog.Int("messageCount", len(req.Messages)),
 		slog.Int("toolCount", len(req.Tools)),
-		slog.Bool("hasSystemMessage", req.SystemMessage != ""))
+		slog.Bool("hasSystemMessage", req.SystemMessage != ""),
+		slog.Bool("promptCaching", c.promptCaching))
 	msg, err := c.client.Messages.New(ctx, params)
 	if err != nil {
 		return nil, err
@@ -166,8 +176,9 @@ func (c *Client) GenerateStream(ctx context.Context, req *interfaces.LLMRequest)
 	c.Logger.Debug(ctx, "starting anthropic stream",
 		slog.String("model", c.Model),
 		slog.Int("messageCount", len(req.Messages)),
-		slog.Int("toolCount", len(req.Tools)))
-	messages := messagesToAnthropic(req)
+		slog.Int("toolCount", len(req.Tools)),
+		slog.Bool("promptCaching", c.promptCaching))
+	messages := c.messagesToAnthropic(req)
 	params := c.buildMessageParams(messages, req)
 	stream := c.client.Messages.NewStreaming(ctx, params)
 	acc := &anthropic.Message{}
@@ -228,16 +239,24 @@ func anthropicUsageToLLM(u anthropic.Usage) *interfaces.LLMUsage {
 	}
 }
 
-func messagesToAnthropic(req *interfaces.LLMRequest) []anthropic.MessageParam {
-	if len(req.Messages) == 0 {
-		return []anthropic.MessageParam{
-			anthropic.NewUserMessage(anthropic.NewTextBlock("")),
-		}
+func (c *Client) messagesToAnthropic(req *interfaces.LLMRequest) []anthropic.MessageParam {
+	out := convertToAnthropicMessages(req.Messages)
+	if c.promptCaching {
+		markStableMessageForCaching(out)
+	}
+	return out
+}
+
+// convertToAnthropicMessages maps SDK messages onto Anthropic's alternating user/assistant
+// format. Consecutive "tool" role messages are merged into a single user message, since
+// Anthropic expects tool results as content blocks within one user turn.
+func convertToAnthropicMessages(messages []interfaces.Message) []anthropic.MessageParam {
+	if len(messages) == 0 {
+		return []anthropic.MessageParam{anthropic.NewUserMessage(anthropic.NewTextBlock(""))}
 	}
 	var out []anthropic.MessageParam
-	i := 0
-	for i < len(req.Messages) {
-		m := req.Messages[i]
+	for i := 0; i < len(messages); i++ {
+		m := messages[i]
 		switch m.Role {
 		case "user":
 			out = append(out, anthropic.NewUserMessage(anthropic.NewTextBlock(m.Content)))
@@ -261,19 +280,42 @@ func messagesToAnthropic(req *interfaces.LLMRequest) []anthropic.MessageParam {
 			}
 		case "tool":
 			var toolBlocks []anthropic.ContentBlockParamUnion
-			for i < len(req.Messages) && req.Messages[i].Role == "tool" {
-				t := req.Messages[i]
+			for ; i < len(messages) && messages[i].Role == "tool"; i++ {
+				t := messages[i]
 				toolBlocks = append(toolBlocks, anthropic.NewToolResultBlock(t.ToolCallID, t.Content, false))
-				i++
 			}
+			i--
 			if len(toolBlocks) > 0 {
 				out = append(out, anthropic.NewUserMessage(toolBlocks...))
 			}
-			continue
 		}
-		i++
 	}
 	return out
+}
+
+// markStableMessageForCaching adds an Anthropic cache breakpoint to the last content block of
+// the second-to-last message, so the model can reuse the cached prefix for every turn except
+// the newest (most dynamic) one.
+func markStableMessageForCaching(messages []anthropic.MessageParam) {
+	if len(messages) < 2 {
+		return
+	}
+	content := messages[len(messages)-2].Content
+	if len(content) == 0 {
+		return
+	}
+	setCacheControl(&content[len(content)-1])
+}
+
+func setCacheControl(block *anthropic.ContentBlockParamUnion) {
+	switch {
+	case block.OfText != nil:
+		block.OfText.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	case block.OfToolUse != nil:
+		block.OfToolUse.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	case block.OfToolResult != nil:
+		block.OfToolResult.CacheControl = anthropic.NewCacheControlEphemeralParam()
+	}
 }
 
 func extractContentAndToolCalls(blocks []anthropic.ContentBlockUnion) (string, []*interfaces.ToolCall) {
@@ -298,17 +340,20 @@ func extractContentAndToolCalls(blocks []anthropic.ContentBlockUnion) (string, [
 	return content, toolCalls
 }
 
-func toolsToAnthropic(specs []interfaces.ToolSpec) []anthropic.ToolUnionParam {
+func (c *Client) toolsToAnthropic(specs []interfaces.ToolSpec) []anthropic.ToolUnionParam {
 	out := make([]anthropic.ToolUnionParam, len(specs))
 	for i, s := range specs {
 		schema := toolInputSchema(s.Parameters)
-		out[i] = anthropic.ToolUnionParam{
-			OfTool: &anthropic.ToolParam{
-				Name:        s.Name,
-				Description: anthropic.String(s.Description),
-				InputSchema: schema,
-			},
+		tool := &anthropic.ToolParam{
+			Name:        s.Name,
+			Description: anthropic.String(s.Description),
+			InputSchema: schema,
 		}
+		// Last tool gets the breakpoint so the full tools list is one cacheable prefix (max 4 breakpoints).
+		if c.promptCaching && i == len(specs)-1 {
+			tool.CacheControl = anthropic.NewCacheControlEphemeralParam()
+		}
+		out[i] = anthropic.ToolUnionParam{OfTool: tool}
 	}
 	return out
 }

--- a/pkg/llm/anthropic/client_test.go
+++ b/pkg/llm/anthropic/client_test.go
@@ -13,11 +13,11 @@ import (
 
 func testClient(t *testing.T) *Client {
 	t.Helper()
-	cfg, err := llm.BuildConfig(llm.WithAPIKey("test-key"), llm.WithModel("claude-3-5-haiku-20241022"))
+	c, err := NewClient(llm.WithAPIKey("test-key"), llm.WithModel("claude-3-5-haiku-20241022"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &Client{LLMConfig: *cfg}
+	return c
 }
 
 func TestClient_Getters(t *testing.T) {
@@ -66,7 +66,7 @@ func TestBuildMessageParams_smoke(t *testing.T) {
 		ResponseFormat: &interfaces.ResponseFormat{Type: interfaces.ResponseFormatJSON, Schema: map[string]any{"type": "object"}},
 		Reasoning:      &interfaces.LLMReasoning{BudgetTokens: 2048},
 	}
-	msgs := messagesToAnthropic(req)
+	msgs := c.messagesToAnthropic(req)
 	p := c.buildMessageParams(msgs, req)
 	if p.Model == "" || p.MaxTokens == 0 || len(p.Messages) == 0 {
 		t.Fatalf("params: %+v", p)
@@ -109,13 +109,87 @@ func TestToolInputSchema(t *testing.T) {
 }
 
 func TestToolsToAnthropic(t *testing.T) {
-	out := toolsToAnthropic([]interfaces.ToolSpec{{
+	c := testClient(t)
+	out := c.toolsToAnthropic([]interfaces.ToolSpec{{
 		Name:        "t1",
 		Description: "d",
 		Parameters:  interfaces.JSONSchema{"type": "object", "properties": map[string]any{}},
 	}})
 	if len(out) != 1 || out[0].OfTool == nil || out[0].OfTool.Name != "t1" {
 		t.Fatalf("%#v", out)
+	}
+	if out[0].OfTool.CacheControl.Type != "" {
+		t.Fatal("default: no cache_control on tools")
+	}
+}
+
+func TestPromptCaching_disabledByDefault(t *testing.T) {
+	c := testClient(t)
+	if c.promptCaching {
+		t.Fatal("expected prompt caching disabled by default")
+	}
+	req := &interfaces.LLMRequest{
+		SystemMessage: "sys",
+		Tools: []interfaces.ToolSpec{
+			{Name: "a", Description: "d", Parameters: interfaces.JSONSchema{"type": "object"}},
+		},
+		Messages: []interfaces.Message{
+			{Role: interfaces.MessageRoleUser, Content: "a"},
+			{Role: interfaces.MessageRoleUser, Content: "b"},
+		},
+	}
+	params := c.buildMessageParams(c.messagesToAnthropic(req), req)
+	if params.System[0].CacheControl.Type != "" {
+		t.Fatal("system should not have cache_control by default")
+	}
+	tools := c.toolsToAnthropic(req.Tools)
+	if tools[0].OfTool.CacheControl.Type != "" {
+		t.Fatal("tools should not have cache_control by default")
+	}
+}
+
+func TestPromptCaching_enabled(t *testing.T) {
+	c, err := NewClient(llm.WithAPIKey("test-key"), llm.WithModel("claude-3-5-haiku-20241022"), llm.WithPromptCaching(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.promptCaching {
+		t.Fatal("expected enabled")
+	}
+	req := &interfaces.LLMRequest{
+		SystemMessage: "sys",
+		Tools: []interfaces.ToolSpec{
+			{Name: "a", Description: "d", Parameters: interfaces.JSONSchema{"type": "object"}},
+			{Name: "b", Description: "d", Parameters: interfaces.JSONSchema{"type": "object"}},
+		},
+		Messages: []interfaces.Message{
+			{Role: interfaces.MessageRoleUser, Content: "earlier"},
+			{Role: interfaces.MessageRoleAssistant, Content: "mid"},
+			{Role: interfaces.MessageRoleUser, Content: "latest"},
+		},
+	}
+	tools := c.toolsToAnthropic(req.Tools)
+	if tools[0].OfTool.CacheControl.Type != "" {
+		t.Fatal("only last tool should carry cache_control")
+	}
+	if tools[1].OfTool.CacheControl.Type == "" {
+		t.Fatal("last tool must carry cache_control")
+	}
+	params := c.buildMessageParams(c.messagesToAnthropic(req), req)
+	if len(params.System) != 1 || params.System[0].CacheControl.Type == "" {
+		t.Fatalf("system cache params: %#v", params.System)
+	}
+	msgs := c.messagesToAnthropic(req)
+	if len(msgs) != 3 {
+		t.Fatalf("msgs len=%d", len(msgs))
+	}
+	mid := msgs[1]
+	if len(mid.Content) == 0 || mid.Content[0].OfText == nil || mid.Content[0].OfText.CacheControl.Type == "" {
+		t.Fatalf("expected cache on second-to-last message: %#v", mid.Content)
+	}
+	latest := msgs[2]
+	if len(latest.Content) > 0 && latest.Content[0].OfText != nil && latest.Content[0].OfText.CacheControl.Type != "" {
+		t.Fatal("latest message must not have cache_control")
 	}
 }
 
@@ -144,9 +218,9 @@ func TestAnthropicUsageToLLM(t *testing.T) {
 // always set a non-empty tool name on assistant tool_use content.
 func TestMessagesToAnthropic_toolUseNamesNeverEmpty(t *testing.T) {
 	t.Parallel()
+	c := testClient(t)
 
 	t.Run("preserves non-empty tool name", func(t *testing.T) {
-		t.Parallel()
 		req := &interfaces.LLMRequest{
 			Messages: []interfaces.Message{
 				{Role: interfaces.MessageRoleUser, Content: "add 1 and 2"},
@@ -167,7 +241,7 @@ func TestMessagesToAnthropic_toolUseNamesNeverEmpty(t *testing.T) {
 				},
 			},
 		}
-		for _, name := range toolUseNamesFromMessages(messagesToAnthropic(req)) {
+		for _, name := range toolUseNamesFromMessages(c.messagesToAnthropic(req)) {
 			if name != "add" {
 				t.Fatalf("expected tool_use name 'add', got %q", name)
 			}
@@ -175,7 +249,6 @@ func TestMessagesToAnthropic_toolUseNamesNeverEmpty(t *testing.T) {
 	})
 
 	t.Run("empty tool name falls back so request is valid", func(t *testing.T) {
-		t.Parallel()
 		req := &interfaces.LLMRequest{
 			Messages: []interfaces.Message{
 				{Role: interfaces.MessageRoleUser, Content: "add 1 and 2"},
@@ -196,7 +269,7 @@ func TestMessagesToAnthropic_toolUseNamesNeverEmpty(t *testing.T) {
 				},
 			},
 		}
-		names := toolUseNamesFromMessages(messagesToAnthropic(req))
+		names := toolUseNamesFromMessages(c.messagesToAnthropic(req))
 		if len(names) != 1 {
 			t.Fatalf("expected one tool_use block, got %d", len(names))
 		}

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -12,6 +12,8 @@ type LLMConfig struct {
 	BaseURL  string
 	Logger   logger.Logger
 	LogLevel string
+	// PromptCaching is Anthropic-only; nil means disabled. Set via WithPromptCaching.
+	PromptCaching *bool
 }
 
 type Option func(*LLMConfig)
@@ -34,6 +36,13 @@ func WithModel(model string) Option {
 
 func WithBaseURL(baseURL string) Option {
 	return func(c *LLMConfig) { c.BaseURL = baseURL }
+}
+
+// WithPromptCaching enables or disables Anthropic prompt-cache breakpoints.
+// Default when unset is disabled (write cost / short TTL are a poor fit at low volume).
+// OpenAI/Gemini/DeepSeek ignore this option.
+func WithPromptCaching(enabled bool) Option {
+	return func(c *LLMConfig) { c.PromptCaching = &enabled }
 }
 
 // DefaultMaxTokens is used when MaxTokens is 0 and the provider requires it (e.g. Anthropic).

--- a/pkg/llm/config_test.go
+++ b/pkg/llm/config_test.go
@@ -51,3 +51,13 @@ func TestBuildConfig_WithOptions(t *testing.T) {
 		t.Fatal("expected injected logger")
 	}
 }
+
+func TestBuildConfig_WithPromptCaching(t *testing.T) {
+	c, err := BuildConfig(WithAPIKey("k"), WithPromptCaching(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.PromptCaching == nil || !*c.PromptCaching {
+		t.Fatalf("PromptCaching = %#v, want true", c.PromptCaching)
+	}
+}


### PR DESCRIPTION
## Description

- Structure LLM requests for provider caching: stable system/tools prefix, memory then RAG as labeled messages, sanitized history at call time, and tool resolve order native → MCP → A2A → sub-agents → memory → RAG.
- Add Anthropic-only `llm.WithPromptCaching` (default off) so cache breakpoints stay optional; OpenAI/Gemini ignore it.
- CLI: `show_llm_usage` / `AGENT_SHOW_LLM_USAGE` accumulates session token usage and prints a summary on exit; docs updated for caching and CLI usage.

## Test plan
- [x] Unit tests: `go test ./internal/runtime/base/... ./pkg/llm/... ./pkg/agent/... ./cmd/...`
- [x] Anthropic: enable `WithPromptCaching(true)`, run multi-turn; confirm `cached_prompt` > 0 when eligible
- [x] CLI: set `show_llm_usage: true`, run a few turns, exit; confirm session usage summary
- [x] Memory/RAG prefetch still appear as labeled messages (not mutated into system prompt)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactor / chore

## Related issues

Closes #43 

## Checklist

- [x] I have run `make check`
- [x] I have run `task examples:all`
- [x] I have run `make tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
