### PR TITLE
feat/ollama llm provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fmt.Println(result.Content)
 
 ## Features
 
-- **LLM providers** — OpenAI, Anthropic, Gemini, DeepSeek + custom via `interfaces.LLMClient`
+- **LLM providers** — OpenAI, Anthropic, Gemini, DeepSeek, Ollama (local) + custom via `interfaces.LLMClient`
 - **Tools & MCP** — built-in and custom tools; MCP servers over stdio or streamable HTTP
 - **A2A** — expose agents as A2A servers or connect remote A2A agents as tools
 - **Sub-agents** — delegate to specialist agents with independent LLMs, tools, and task queues

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/anthropic"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/deepseek"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/gemini"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm/ollama"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/openai"
 	"github.com/agenticenv/agent-sdk-go/pkg/logger"
 	"github.com/agenticenv/agent-sdk-go/pkg/mcp"
@@ -328,6 +329,12 @@ func NewLLMClient(cfg *Config, lgr logger.Logger) (interfaces.LLMClient, error) 
 			opts = append(opts, llm.WithBaseURL(cfg.LLM.BaseURL))
 		}
 		return deepseek.NewClient(opts...)
+	case interfaces.LLMProviderOllama:
+		// Ollama needs no API key; its client defaults BaseURL to http://localhost:11434/v1.
+		if cfg.LLM.BaseURL != "" {
+			opts = append(opts, llm.WithBaseURL(cfg.LLM.BaseURL))
+		}
+		return ollama.NewClient(opts...)
 	default:
 		if cfg.LLM.BaseURL != "" {
 			opts = append(opts, llm.WithBaseURL(cfg.LLM.BaseURL))

--- a/cmd/config.sample.yaml
+++ b/cmd/config.sample.yaml
@@ -25,9 +25,9 @@ temporal:
 # LLM provider (OpenAI, Anthropic, Gemini, DeepSeek, or Ollama)
 llm:
   provider: openai      # openai | anthropic | gemini | deepseek | ollama
-  apiKey: ""            # Set here or via AGENT_LLM_APIKEY (preferred for secrets). Not needed for ollama (local).
-  model: gpt-4o         # Model name, e.g. gpt-4o, claude-haiku-4-5, gemini-2.5-flash, deepseek-chat, llama3.2
-  baseURL: https://api.openai.com/v1   # Optional; OpenAI-compatible proxies. Leave unset for deepseek (https://api.deepseek.com) or ollama (http://localhost:11434/v1).
+  apiKey: ""            # Set here or via AGENT_LLM_APIKEY (preferred for secrets). Not needed for ollama (local); set to an ollama.com key (or OLLAMA_API_KEY) for Ollama Cloud.
+  model: gpt-4o         # Model name, e.g. gpt-4o, claude-haiku-4-5, gemini-2.5-flash, deepseek-chat, llama3.2, qwen3-coder:480b-cloud
+  baseURL: https://api.openai.com/v1   # Optional; OpenAI-compatible proxies. Leave unset for deepseek (https://api.deepseek.com) or ollama (http://localhost:11434/v1, or https://ollama.com/v1 automatically when apiKey is set).
 
 # Logger: file by default (JSON + caller). Prompts/responses use fmt in main, not this logger.
 logger:

--- a/cmd/config.sample.yaml
+++ b/cmd/config.sample.yaml
@@ -22,12 +22,12 @@ temporal:
   namespace: default     # Temporal namespace
   taskQueue: agent-sdk-go   # Task queue for agent workflows
 
-# LLM provider (OpenAI, Anthropic, Gemini, or DeepSeek)
+# LLM provider (OpenAI, Anthropic, Gemini, DeepSeek, or Ollama)
 llm:
-  provider: openai      # openai | anthropic | gemini | deepseek
-  apiKey: ""            # Set here or via AGENT_LLM_APIKEY (preferred for secrets)
-  model: gpt-4o         # Model name, e.g. gpt-4o, claude-haiku-4-5, gemini-2.5-flash, deepseek-chat
-  baseURL: https://api.openai.com/v1   # Optional; OpenAI-compatible proxies. For deepseek, leave unset to use https://api.deepseek.com
+  provider: openai      # openai | anthropic | gemini | deepseek | ollama
+  apiKey: ""            # Set here or via AGENT_LLM_APIKEY (preferred for secrets). Not needed for ollama (local).
+  model: gpt-4o         # Model name, e.g. gpt-4o, claude-haiku-4-5, gemini-2.5-flash, deepseek-chat, llama3.2
+  baseURL: https://api.openai.com/v1   # Optional; OpenAI-compatible proxies. Leave unset for deepseek (https://api.deepseek.com) or ollama (http://localhost:11434/v1).
 
 # Logger: file by default (JSON + caller). Prompts/responses use fmt in main, not this logger.
 logger:

--- a/docs/getting-started/llm-providers.mdx
+++ b/docs/getting-started/llm-providers.mdx
@@ -143,8 +143,21 @@ llmClient, err := ollama.NewClient(
 
 Common models: any model you have pulled with `ollama pull`, e.g. `llama3.2`, `qwen2.5`, `mistral`. Start the daemon with `ollama serve`. Reasoning models such as `deepseek-r1` and `qwen3` surface their trace via the streaming `LLMStreamChunk.ThinkingDelta` and, for non-streaming responses, `LLMResponse.Metadata["reasoning_content"]`.
 
+### Ollama Cloud
+
+[Ollama Cloud](https://ollama.com) hosts larger models behind an API key, for machines that can't run them locally. Supplying an API key — via `llm.WithAPIKey` or the `OLLAMA_API_KEY` environment variable — automatically switches the default base URL to Ollama Cloud's endpoint (`https://ollama.com/v1`); no other code change is needed. `llm.WithBaseURL` still overrides either default, e.g. for a self-hosted daemon behind an auth proxy.
+
+```go
+llmClient, err := ollama.NewClient(
+    llm.WithAPIKey(os.Getenv("OLLAMA_API_KEY")), // omit to fall back to the OLLAMA_API_KEY env var
+    llm.WithModel("qwen3-coder:480b-cloud"),      // cloud models are suffixed "-cloud"
+)
+```
+
+Generate a key at [ollama.com/settings/keys](https://ollama.com/settings/keys).
+
 <Note>
-Not every Ollama model supports tool-calling or JSON mode, so tool use and response formats behave differently depending on which model you pull. As with DeepSeek, a [response format](/features/response-format) with `Type: ResponseFormatJSON` maps to `json_object`; any `Schema` is ignored, so prompt the model for the shape you want.
+Not every Ollama model supports tool-calling or JSON mode, so tool use and response formats behave differently depending on which model you pull or select on Cloud. As with DeepSeek, a [response format](/features/response-format) with `Type: ResponseFormatJSON` maps to `json_object`; any `Schema` is ignored, so prompt the model for the shape you want.
 </Note>
 
 ## Shared LLM options

--- a/docs/getting-started/llm-providers.mdx
+++ b/docs/getting-started/llm-providers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "LLM Providers"
-description: "Configure OpenAI, Anthropic, Gemini, or DeepSeek — or bring your own LLM client"
+description: "Configure OpenAI, Anthropic, Gemini, DeepSeek, or Ollama — or bring your own LLM client"
 ---
 
 Every agent requires an [`interfaces.LLMClient`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/interfaces#LLMClient). Pass it to [`NewAgent`](/getting-started/quickstart) with [`WithLLMClient`](/getting-started/configuration).
@@ -19,6 +19,7 @@ import "github.com/agenticenv/agent-sdk-go/pkg/llm"
 | Anthropic | `pkg/llm/anthropic` | `anthropic` |
 | Gemini | `pkg/llm/gemini` | `gemini` |
 | DeepSeek | `pkg/llm/deepseek` | `deepseek` |
+| Ollama | `pkg/llm/ollama` | `ollama` |
 
 They all implement the same interface:
 
@@ -124,6 +125,28 @@ Common models: `deepseek-chat` and `deepseek-reasoner`. Reasoning is not configu
 DeepSeek supports only plain JSON mode, not schema-constrained output. A [response format](/features/response-format) with `Type: ResponseFormatJSON` maps to DeepSeek's `json_object`; any `Schema` is ignored (not enforced by the API), so prompt the model for the shape you want, and include the word "json" in the conversation.
 </Note>
 
+## Ollama
+
+Ollama runs open models locally and exposes an OpenAI-compatible API, so no API key is needed. The base URL defaults to `http://localhost:11434/v1`; pass `WithBaseURL` to reach a remote host.
+
+```go
+import (
+    "github.com/agenticenv/agent-sdk-go/pkg/llm"
+    "github.com/agenticenv/agent-sdk-go/pkg/llm/ollama"
+)
+
+llmClient, err := ollama.NewClient(
+    llm.WithModel("llama3.2"), // any locally pulled model
+    // llm.WithBaseURL("http://remote-host:11434/v1"), // optional
+)
+```
+
+Common models: any model you have pulled with `ollama pull`, e.g. `llama3.2`, `qwen2.5`, `mistral`. Start the daemon with `ollama serve`. Reasoning models such as `deepseek-r1` and `qwen3` surface their trace via the streaming `LLMStreamChunk.ThinkingDelta` and, for non-streaming responses, `LLMResponse.Metadata["reasoning_content"]`.
+
+<Note>
+Not every Ollama model supports tool-calling or JSON mode, so tool use and response formats behave differently depending on which model you pull. As with DeepSeek, a [response format](/features/response-format) with `Type: ResponseFormatJSON` maps to `json_object`; any `Schema` is ignored, so prompt the model for the shape you want.
+</Note>
+
 ## Shared LLM options
 
 All built-in clients accept functional options from `pkg/llm`:
@@ -151,13 +174,13 @@ a, err := agent.NewAgent(
 
 Field support varies by provider:
 
-| Field | OpenAI | Anthropic | Gemini | DeepSeek |
-|---|---|---|---|---|
-| `Temperature` | ✓ | ✓ | ✓ | ✓ |
-| `MaxTokens` | ✓ | ✓ | ✓ | ✓ |
-| `TopP` | ✓ | — | ✓ | ✓ |
-| `TopK` | — | ✓ | — | — |
-| `Reasoning` | Partial | ✓ | ✓ | — |
+| Field | OpenAI | Anthropic | Gemini | DeepSeek | Ollama |
+|---|---|---|---|---|---|
+| `Temperature` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `MaxTokens` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `TopP` | ✓ | — | ✓ | ✓ | ✓ |
+| `TopK` | — | ✓ | — | — | — |
+| `Reasoning` | Partial | ✓ | ✓ | — | — |
 
 See [Reasoning](/features/reasoning) for extended thinking configuration per provider.
 

--- a/examples/.env.defaults
+++ b/examples/.env.defaults
@@ -27,9 +27,11 @@ TEMPORAL_NAMESPACE=default
 TEMPORAL_TASKQUEUE=agent-sdk-go
 
 # --- LLM (all examples) ---
-# Provider: openai | anthropic | gemini | deepseek. Set LLM_APIKEY in examples/.env.
+# Provider: openai | anthropic | gemini | deepseek | ollama. Set LLM_APIKEY in examples/.env.
 # For deepseek, also set LLM_BASEURL=https://api.deepseek.com in examples/.env (it overrides
 # the OpenAI default below) and LLM_MODEL=deepseek-chat (or deepseek-reasoner).
+# For ollama (local, no API key needed): set LLM_PROVIDER=ollama, LLM_MODEL=llama3.2 (or any
+# pulled model), and LLM_BASEURL=http://localhost:11434/v1 in examples/.env; leave LLM_APIKEY empty.
 LLM_PROVIDER=openai
 LLM_APIKEY=
 LLM_MODEL=gpt-4o

--- a/examples/.env.defaults
+++ b/examples/.env.defaults
@@ -32,6 +32,9 @@ TEMPORAL_TASKQUEUE=agent-sdk-go
 # the OpenAI default below) and LLM_MODEL=deepseek-chat (or deepseek-reasoner).
 # For ollama (local, no API key needed): set LLM_PROVIDER=ollama, LLM_MODEL=llama3.2 (or any
 # pulled model), and LLM_BASEURL=http://localhost:11434/v1 in examples/.env; leave LLM_APIKEY empty.
+# For Ollama Cloud: set LLM_PROVIDER=ollama, LLM_APIKEY=<key from ollama.com/settings/keys>
+# (or export OLLAMA_API_KEY instead), and LLM_MODEL=qwen3-coder:480b-cloud (or another "-cloud"
+# model); leave LLM_BASEURL unset — it defaults to https://ollama.com/v1 once LLM_APIKEY is set.
 LLM_PROVIDER=openai
 LLM_APIKEY=
 LLM_MODEL=gpt-4o

--- a/examples/config.go
+++ b/examples/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/anthropic"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/deepseek"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/gemini"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm/ollama"
 	"github.com/agenticenv/agent-sdk-go/pkg/llm/openai"
 	"github.com/agenticenv/agent-sdk-go/pkg/logger"
 	"github.com/agenticenv/agent-sdk-go/pkg/mcp"
@@ -549,8 +550,9 @@ func NewLoggerFromLogConfig(cfg *Config) logger.Logger {
 }
 
 // NewLLMClientFromConfig creates an LLM client from config using the new llm.Option-based API.
-// BaseURL applies to the OpenAI and DeepSeek providers; set LLM_BASEURL for a non-default
-// OpenAI-compatible endpoint. DeepSeek defaults to its own endpoint when LLM_BASEURL is unset.
+// BaseURL applies to the OpenAI, DeepSeek, and Ollama providers; set LLM_BASEURL for a
+// non-default OpenAI-compatible endpoint. DeepSeek and Ollama default to their own endpoints
+// when LLM_BASEURL is unset (Ollama to http://localhost:11434/v1, requiring no API key).
 func NewLLMClientFromConfig(cfg *Config) (interfaces.LLMClient, error) {
 	opts := []llm.Option{
 		llm.WithAPIKey(cfg.APIKey),
@@ -572,6 +574,12 @@ func NewLLMClientFromConfig(cfg *Config) (interfaces.LLMClient, error) {
 			opts = append(opts, llm.WithBaseURL(cfg.BaseURL))
 		}
 		return deepseek.NewClient(opts...)
+	case interfaces.LLMProviderOllama:
+		// Ollama needs no API key; its client defaults BaseURL to http://localhost:11434/v1.
+		if cfg.BaseURL != "" {
+			opts = append(opts, llm.WithBaseURL(cfg.BaseURL))
+		}
+		return ollama.NewClient(opts...)
 	default:
 		if cfg.BaseURL != "" {
 			opts = append(opts, llm.WithBaseURL(cfg.BaseURL))

--- a/pkg/interfaces/llm.go
+++ b/pkg/interfaces/llm.go
@@ -15,6 +15,7 @@ const (
 	LLMProviderAnthropic LLMProvider = "anthropic"
 	LLMProviderGemini    LLMProvider = "gemini"
 	LLMProviderDeepSeek  LLMProvider = "deepseek"
+	LLMProviderOllama    LLMProvider = "ollama"
 )
 
 type LLMClient interface {

--- a/pkg/llm/config.go
+++ b/pkg/llm/config.go
@@ -48,12 +48,14 @@ func WithPromptCaching(enabled bool) Option {
 // DefaultMaxTokens is used when MaxTokens is 0 and the provider requires it (e.g. Anthropic).
 const DefaultMaxTokens = 1024
 
-// BuildConfig builds LLMConfig from options. Defaults when not set:
+// BuildConfigKeyless builds LLMConfig from options without requiring an APIKey.
+// It is for keyless/local providers (e.g. Ollama) whose transport ignores auth.
+// Defaults when not set:
 //   - LogLevel: "error"
 //   - Logger: stderr slog logger at LogLevel
 //
 // Sampling (Temperature, MaxTokens, TopP, TopK) is per-agent—use agent.WithTemperature etc.
-func BuildConfig(opts ...Option) (*LLMConfig, error) {
+func BuildConfigKeyless(opts ...Option) (*LLMConfig, error) {
 	c := &LLMConfig{}
 	for _, opt := range opts {
 		opt(c)
@@ -63,6 +65,20 @@ func BuildConfig(opts ...Option) (*LLMConfig, error) {
 	}
 	if c.Logger == nil {
 		c.Logger = logger.DefaultLogger(c.LogLevel)
+	}
+	return c, nil
+}
+
+// BuildConfig builds LLMConfig from options, requiring a non-empty APIKey.
+// For keyless/local providers use BuildConfigKeyless. Defaults when not set:
+//   - LogLevel: "error"
+//   - Logger: stderr slog logger at LogLevel
+//
+// Sampling (Temperature, MaxTokens, TopP, TopK) is per-agent—use agent.WithTemperature etc.
+func BuildConfig(opts ...Option) (*LLMConfig, error) {
+	c, err := BuildConfigKeyless(opts...)
+	if err != nil {
+		return nil, err
 	}
 	if c.APIKey == "" {
 		return nil, errors.New("APIKey is required")

--- a/pkg/llm/config_test.go
+++ b/pkg/llm/config_test.go
@@ -16,6 +16,22 @@ func TestBuildConfig_RequiresAPIKey(t *testing.T) {
 	}
 }
 
+func TestBuildConfigKeyless_AllowsEmptyAPIKey(t *testing.T) {
+	c, err := BuildConfigKeyless(WithModel("llama3.2"))
+	if err != nil {
+		t.Fatalf("BuildConfigKeyless: expected success with no APIKey, got %v", err)
+	}
+	if c.APIKey != "" {
+		t.Fatalf("APIKey = %q, want empty", c.APIKey)
+	}
+	if c.LogLevel != "error" {
+		t.Fatalf("LogLevel = %q, want default", c.LogLevel)
+	}
+	if c.Logger == nil {
+		t.Fatal("expected default logger")
+	}
+}
+
 func TestBuildConfig_DefaultsLogLevelAndLogger(t *testing.T) {
 	c, err := BuildConfig(WithAPIKey("k"))
 	if err != nil {

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -1,14 +1,26 @@
-// Package ollama provides an interfaces.LLMClient for Ollama.
+// Package ollama provides an interfaces.LLMClient for Ollama, covering both a local daemon
+// and Ollama Cloud (ollama.com).
 //
-// Ollama exposes an OpenAI-compatible Chat Completions API (default
-// http://localhost:11434/v1), so this client uses the openai-go SDK as its transport but
-// implements the interface independently: it defaults to Ollama's local base URL, requires
-// no API key (Ollama ignores auth, so a placeholder key is injected for the transport),
-// sends system prompts with the "system" role, and maps a "reasoning_content" field—emitted
-// by thinking models such as deepseek-r1 and qwen3 through Ollama—into
-// LLMResponse.Metadata["reasoning_content"] and streaming ThinkingDelta.
+// Ollama exposes an OpenAI-compatible Chat Completions API, so this client uses the
+// openai-go SDK as its transport but implements the interface independently: it sends
+// system prompts with the "system" role, and maps a "reasoning_content" field—emitted by
+// thinking models such as deepseek-r1 and qwen3—into LLMResponse.Metadata["reasoning_content"]
+// and streaming ThinkingDelta.
 //
+// # Local
+//
+// The local daemon requires no API key (Ollama ignores auth, so a placeholder key is
+// injected for the transport) and defaults to DefaultBaseURL (http://localhost:11434/v1).
 // Common models are any locally pulled model, e.g. "llama3.2", "qwen2.5", "mistral".
+//
+// # Cloud
+//
+// Ollama Cloud (https://ollama.com) hosts larger models behind an API key from
+// https://ollama.com/settings/keys. Supplying an API key—via llm.WithAPIKey or the
+// OLLAMA_API_KEY environment variable—switches the default base URL to DefaultCloudBaseURL
+// (https://ollama.com/v1); pass llm.WithBaseURL explicitly to override either default (e.g. a
+// self-hosted Ollama behind an auth proxy). Cloud models are suffixed "-cloud", e.g.
+// "qwen3-coder:480b-cloud".
 //
 // Model caveat: not every Ollama model supports tool-calling or JSON mode, so tool use and
 // response_format behavior varies by model.
@@ -18,6 +30,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
@@ -34,8 +47,16 @@ import (
 // DefaultBaseURL is Ollama's local OpenAI-compatible API endpoint.
 const DefaultBaseURL = "http://localhost:11434/v1"
 
-// placeholderAPIKey is injected as the transport auth token. Ollama ignores auth, but the
-// openai-go SDK requires a non-empty key.
+// DefaultCloudBaseURL is Ollama Cloud's OpenAI-compatible API endpoint. It is used automatically
+// when an API key is set (via llm.WithAPIKey or OLLAMA_API_KEY) and llm.WithBaseURL is not.
+const DefaultCloudBaseURL = "https://ollama.com/v1"
+
+// cloudAPIKeyEnvVar is read as a fallback when llm.WithAPIKey is not supplied, matching the
+// Ollama CLI's own convention for Ollama Cloud authentication.
+const cloudAPIKeyEnvVar = "OLLAMA_API_KEY"
+
+// placeholderAPIKey is injected as the local transport's auth token. The local daemon ignores
+// auth, but the openai-go SDK requires a non-empty key.
 const placeholderAPIKey = "ollama"
 
 // reasoningContentField is the non-standard field thinking models (deepseek-r1, qwen3) return
@@ -50,24 +71,34 @@ type Client struct {
 	client openai.Client
 }
 
-// NewClient creates a new Ollama LLM client. No API key is required: the base URL defaults to
-// DefaultBaseURL (a caller-supplied llm.WithBaseURL overrides it for remote hosts), and a
-// placeholder key is injected for the transport since Ollama ignores auth.
+// NewClient creates a new Ollama LLM client, targeting a local daemon by default.
+//
+// No API key is required for local use. Supplying one—via llm.WithAPIKey or the
+// OLLAMA_API_KEY environment variable (checked when llm.WithAPIKey is not set)—switches the
+// default base URL to Ollama Cloud (DefaultCloudBaseURL). llm.WithBaseURL always overrides
+// the default, local or cloud, e.g. for a remote self-hosted daemon or an auth proxy.
 func NewClient(opts ...llm.Option) (*Client, error) {
 	config, err := llm.BuildConfigKeyless(opts...)
 	if err != nil {
 		return nil, err
 	}
-	if config.BaseURL == "" {
-		config.BaseURL = DefaultBaseURL
+	if config.APIKey == "" {
+		config.APIKey = os.Getenv(cloudAPIKeyEnvVar)
 	}
-	apiKey := config.APIKey
-	if apiKey == "" {
-		apiKey = placeholderAPIKey
+	if config.BaseURL == "" {
+		if config.APIKey != "" {
+			config.BaseURL = DefaultCloudBaseURL
+		} else {
+			config.BaseURL = DefaultBaseURL
+		}
+	}
+	transportKey := config.APIKey
+	if transportKey == "" {
+		transportKey = placeholderAPIKey
 	}
 	c := &Client{LLMConfig: *config}
 	c.client = openai.NewClient(
-		option.WithAPIKey(apiKey),
+		option.WithAPIKey(transportKey),
 		option.WithBaseURL(c.BaseURL),
 	)
 	return c, nil

--- a/pkg/llm/ollama/client.go
+++ b/pkg/llm/ollama/client.go
@@ -1,0 +1,347 @@
+// Package ollama provides an interfaces.LLMClient for Ollama.
+//
+// Ollama exposes an OpenAI-compatible Chat Completions API (default
+// http://localhost:11434/v1), so this client uses the openai-go SDK as its transport but
+// implements the interface independently: it defaults to Ollama's local base URL, requires
+// no API key (Ollama ignores auth, so a placeholder key is injected for the transport),
+// sends system prompts with the "system" role, and maps a "reasoning_content" field—emitted
+// by thinking models such as deepseek-r1 and qwen3 through Ollama—into
+// LLMResponse.Metadata["reasoning_content"] and streaming ThinkingDelta.
+//
+// Common models are any locally pulled model, e.g. "llama3.2", "qwen2.5", "mistral".
+//
+// Model caveat: not every Ollama model supports tool-calling or JSON mode, so tool use and
+// response_format behavior varies by model.
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+	"github.com/openai/openai-go/v3/packages/param"
+	"github.com/openai/openai-go/v3/packages/respjson"
+	"github.com/openai/openai-go/v3/packages/ssestream"
+	"github.com/openai/openai-go/v3/shared"
+	"github.com/openai/openai-go/v3/shared/constant"
+)
+
+// DefaultBaseURL is Ollama's local OpenAI-compatible API endpoint.
+const DefaultBaseURL = "http://localhost:11434/v1"
+
+// placeholderAPIKey is injected as the transport auth token. Ollama ignores auth, but the
+// openai-go SDK requires a non-empty key.
+const placeholderAPIKey = "ollama"
+
+// reasoningContentField is the non-standard field thinking models (deepseek-r1, qwen3) return
+// their chain of thought in; the openai-go SDK captures it in JSON.ExtraFields.
+const reasoningContentField = "reasoning_content"
+
+var _ interfaces.LLMClient = (*Client)(nil)
+
+// Client implements interfaces.LLMClient for Ollama.
+type Client struct {
+	llm.LLMConfig
+	client openai.Client
+}
+
+// NewClient creates a new Ollama LLM client. No API key is required: the base URL defaults to
+// DefaultBaseURL (a caller-supplied llm.WithBaseURL overrides it for remote hosts), and a
+// placeholder key is injected for the transport since Ollama ignores auth.
+func NewClient(opts ...llm.Option) (*Client, error) {
+	config, err := llm.BuildConfigKeyless(opts...)
+	if err != nil {
+		return nil, err
+	}
+	if config.BaseURL == "" {
+		config.BaseURL = DefaultBaseURL
+	}
+	apiKey := config.APIKey
+	if apiKey == "" {
+		apiKey = placeholderAPIKey
+	}
+	c := &Client{LLMConfig: *config}
+	c.client = openai.NewClient(
+		option.WithAPIKey(apiKey),
+		option.WithBaseURL(c.BaseURL),
+	)
+	return c, nil
+}
+
+func (c *Client) GetProvider() interfaces.LLMProvider {
+	return interfaces.LLMProviderOllama
+}
+
+func (c *Client) GetModel() string {
+	return c.Model
+}
+
+func (c *Client) IsStreamSupported() bool {
+	return true
+}
+
+// buildCompletionParams builds ChatCompletionNewParams. Sampling (Temperature, MaxTokens,
+// TopP) is taken from req when set. Thinking models reason automatically, so req.Reasoning is
+// not mapped to a request field.
+func (c *Client) buildCompletionParams(messages []openai.ChatCompletionMessageParamUnion, req *interfaces.LLMRequest) openai.ChatCompletionNewParams {
+	params := openai.ChatCompletionNewParams{
+		Messages: messages,
+		Model:    c.Model,
+	}
+	if req.Temperature != nil {
+		params.Temperature = param.NewOpt(*req.Temperature)
+	}
+	if req.MaxTokens > 0 {
+		params.MaxTokens = param.NewOpt(int64(req.MaxTokens))
+	}
+	if req.TopP != nil {
+		params.TopP = param.NewOpt(*req.TopP)
+	}
+	if len(req.Tools) > 0 {
+		params.Tools = toolsToOllama(req.Tools)
+		params.ToolChoice = openai.ChatCompletionToolChoiceOptionUnionParam{
+			OfAuto: openai.String("auto"),
+		}
+	}
+	if req.ResponseFormat != nil {
+		params.ResponseFormat = responseFormatToOllama(req.ResponseFormat)
+	}
+	return params
+}
+
+// responseFormatToOllama maps the generic ResponseFormat to Ollama's supported set.
+// Ollama's OpenAI layer supports plain JSON mode (json_object), not OpenAI's schema-constrained
+// json_schema, so a ResponseFormatJSON always maps to json_object and any Schema is ignored
+// (not enforced by the API). To get JSON output, the prompt should still ask for it.
+func responseFormatToOllama(rf *interfaces.ResponseFormat) openai.ChatCompletionNewParamsResponseFormatUnion {
+	switch rf.Type {
+	case interfaces.ResponseFormatText:
+		return openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfText: &shared.ResponseFormatTextParam{Type: constant.Text("text")},
+		}
+	case interfaces.ResponseFormatJSON:
+		return openai.ChatCompletionNewParamsResponseFormatUnion{
+			OfJSONObject: &shared.ResponseFormatJSONObjectParam{Type: constant.JSONObject("json_object")},
+		}
+	default:
+		return openai.ChatCompletionNewParamsResponseFormatUnion{}
+	}
+}
+
+func (c *Client) Generate(ctx context.Context, req *interfaces.LLMRequest) (*interfaces.LLMResponse, error) {
+	messages := messagesToOllama(req)
+	params := c.buildCompletionParams(messages, req)
+
+	// Log safe debug info only (no messages/content to avoid leaking sensitive data).
+	c.Logger.Debug(ctx, "generating ollama response",
+		slog.String("model", c.Model),
+		slog.Int("messageCount", len(req.Messages)),
+		slog.Int("toolCount", len(req.Tools)),
+		slog.Bool("hasSystemMessage", req.SystemMessage != ""))
+	resp, err := c.client.Chat.Completions.New(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	var contentLen int
+	var toolNames []string
+	if len(resp.Choices) > 0 {
+		m := resp.Choices[0].Message
+		contentLen = len(m.Content)
+		toolNames = make([]string, 0, len(m.ToolCalls))
+		for _, tc := range m.ToolCalls {
+			if tc.Function.Name != "" {
+				toolNames = append(toolNames, tc.Function.Name)
+			}
+		}
+	}
+	c.Logger.Debug(ctx, "ollama response generated",
+		slog.String("model", resp.Model),
+		slog.Int("contentLen", contentLen),
+		slog.Int("toolCallCount", len(toolNames)),
+		slog.Any("toolNames", toolNames))
+	return ollamaResponseToLLM(resp), nil
+}
+
+func (c *Client) GenerateStream(ctx context.Context, req *interfaces.LLMRequest) (interfaces.LLMStream, error) {
+	c.Logger.Debug(ctx, "starting ollama stream",
+		slog.String("model", c.Model),
+		slog.Int("messageCount", len(req.Messages)),
+		slog.Int("toolCount", len(req.Tools)))
+	messages := messagesToOllama(req)
+	params := c.buildCompletionParams(messages, req)
+	params.StreamOptions = openai.ChatCompletionStreamOptionsParam{
+		IncludeUsage: openai.Bool(true),
+	}
+	stream := c.client.Chat.Completions.NewStreaming(ctx, params)
+	acc := &openai.ChatCompletionAccumulator{}
+	return &ollamaStreamAdapter{stream: stream, acc: acc}, nil
+}
+
+// ollamaStreamAdapter adapts Ollama's OpenAI-compatible streaming API to interfaces.LLMStream.
+type ollamaStreamAdapter struct {
+	stream *ssestream.Stream[openai.ChatCompletionChunk]
+	acc    *openai.ChatCompletionAccumulator
+}
+
+func (a *ollamaStreamAdapter) Next() bool { return a.stream.Next() }
+func (a *ollamaStreamAdapter) Err() error { return a.stream.Err() }
+func (a *ollamaStreamAdapter) Current() *interfaces.LLMStreamChunk {
+	chunk := a.stream.Current()
+	a.acc.AddChunk(chunk)
+	out := &interfaces.LLMStreamChunk{}
+	if len(chunk.Choices) > 0 {
+		delta := chunk.Choices[0].Delta
+		out.ContentDelta = delta.Content
+		// Thinking models stream their chain of thought in reasoning_content.
+		out.ThinkingDelta = extractReasoning(delta.JSON.ExtraFields)
+	}
+	return out
+}
+func (a *ollamaStreamAdapter) GetResult() *interfaces.LLMResponse {
+	if len(a.acc.Choices) == 0 {
+		return nil
+	}
+	return ollamaResponseToLLM(&a.acc.ChatCompletion)
+}
+
+func ollamaResponseToLLM(resp *openai.ChatCompletion) *interfaces.LLMResponse {
+	out := &interfaces.LLMResponse{
+		Content: resp.Choices[0].Message.Content,
+		Metadata: map[string]any{
+			"model": resp.Model,
+		},
+		Usage: ollamaUsageToLLM(resp.Usage),
+	}
+	msg := resp.Choices[0].Message
+	if reasoning := extractReasoning(msg.JSON.ExtraFields); reasoning != "" {
+		out.Metadata[reasoningContentField] = reasoning
+	}
+	for _, tc := range msg.ToolCalls {
+		if tc.Function.Name == "" {
+			continue
+		}
+		args := make(map[string]any)
+		if tc.Function.Arguments != "" {
+			_ = json.Unmarshal([]byte(tc.Function.Arguments), &args)
+		}
+		out.ToolCalls = append(out.ToolCalls, &interfaces.ToolCall{
+			ToolCallID: tc.ID,
+			ToolName:   tc.Function.Name,
+			Args:       args,
+		})
+	}
+	return out
+}
+
+// extractReasoning returns the decoded reasoning_content extra field, or "".
+// Thinking models return reasoning under this non-standard field; the openai-go SDK captures
+// it in JSON.ExtraFields. Note Valid() is false for extra fields, so guard on Raw().
+func extractReasoning(extra map[string]respjson.Field) string {
+	f, ok := extra[reasoningContentField]
+	if !ok {
+		return ""
+	}
+	raw := f.Raw() // JSON-encoded
+	if raw == "" || raw == "null" {
+		return ""
+	}
+	var s string
+	_ = json.Unmarshal([]byte(raw), &s)
+	return s
+}
+
+// ollamaUsageToLLM maps OpenAI-shaped CompletionUsage to interfaces.LLMUsage.
+func ollamaUsageToLLM(u openai.CompletionUsage) *interfaces.LLMUsage {
+	if u.PromptTokens == 0 && u.CompletionTokens == 0 && u.TotalTokens == 0 {
+		return nil
+	}
+	out := &interfaces.LLMUsage{
+		PromptTokens:     u.PromptTokens,
+		CompletionTokens: u.CompletionTokens,
+		TotalTokens:      u.TotalTokens,
+	}
+	if u.PromptTokensDetails.CachedTokens != 0 {
+		out.CachedPromptTokens = u.PromptTokensDetails.CachedTokens
+	}
+	if u.CompletionTokensDetails.ReasoningTokens != 0 {
+		out.ReasoningTokens = u.CompletionTokensDetails.ReasoningTokens
+	}
+	return out
+}
+
+func messagesToOllama(req *interfaces.LLMRequest) []openai.ChatCompletionMessageParamUnion {
+	var out []openai.ChatCompletionMessageParamUnion
+	if req.SystemMessage != "" {
+		// Ollama's OpenAI layer expects the "system" role (not OpenAI's "developer" role).
+		out = append(out, openai.SystemMessage(req.SystemMessage))
+	}
+	if len(req.Messages) == 0 {
+		return out
+	}
+	for _, m := range req.Messages {
+		switch m.Role {
+		case "user":
+			out = append(out, openai.UserMessage(m.Content))
+		case "assistant":
+			if len(m.ToolCalls) > 0 {
+				toolCalls := make([]openai.ChatCompletionMessageToolCallUnionParam, len(m.ToolCalls))
+				for i, tc := range m.ToolCalls {
+					argsBytes, _ := json.Marshal(tc.Args)
+					argsStr := "{}"
+					if len(argsBytes) > 0 {
+						argsStr = string(argsBytes)
+					}
+					name := strings.TrimSpace(tc.ToolName)
+					if name == "" {
+						name = "tool"
+					}
+					toolCalls[i] = openai.ChatCompletionMessageToolCallUnionParam{
+						OfFunction: &openai.ChatCompletionMessageFunctionToolCallParam{
+							ID: tc.ToolCallID,
+							Function: openai.ChatCompletionMessageFunctionToolCallFunctionParam{
+								Arguments: argsStr,
+								Name:      name,
+							},
+						},
+					}
+				}
+				out = append(out, openai.ChatCompletionMessageParamUnion{
+					OfAssistant: &openai.ChatCompletionAssistantMessageParam{
+						Content:   openai.ChatCompletionAssistantMessageParamContentUnion{OfString: openai.String(m.Content)},
+						ToolCalls: toolCalls,
+					},
+				})
+			} else {
+				out = append(out, openai.AssistantMessage(m.Content))
+			}
+		case "tool":
+			out = append(out, openai.ToolMessage(m.Content, m.ToolCallID))
+		}
+	}
+	return out
+}
+
+func toolsToOllama(specs []interfaces.ToolSpec) []openai.ChatCompletionToolUnionParam {
+	out := make([]openai.ChatCompletionToolUnionParam, len(specs))
+	for i, s := range specs {
+		params := shared.FunctionParameters(map[string]any(s.Parameters))
+		if params == nil {
+			params = shared.FunctionParameters{"type": "object", "properties": map[string]any{}}
+		}
+		out[i] = openai.ChatCompletionToolUnionParam{
+			OfFunction: &openai.ChatCompletionFunctionToolParam{
+				Function: shared.FunctionDefinitionParam{
+					Name:        s.Name,
+					Description: openai.String(s.Description),
+					Parameters:  params,
+				},
+			},
+		}
+	}
+	return out
+}

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -1,0 +1,262 @@
+package ollama
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/llm"
+	"github.com/openai/openai-go/v3"
+)
+
+// compile-time check mirrors the assertion in client.go.
+var _ interfaces.LLMClient = (*Client)(nil)
+
+func newTestClient(t *testing.T, opts ...llm.Option) *Client {
+	t.Helper()
+	c, err := NewClient(opts...)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestClient_Getters(t *testing.T) {
+	c := newTestClient(t, llm.WithModel("llama3.2"))
+	if c.GetProvider() != interfaces.LLMProviderOllama {
+		t.Fatalf("GetProvider() = %q, want ollama", c.GetProvider())
+	}
+	if c.GetModel() != "llama3.2" {
+		t.Fatalf("GetModel() = %q", c.GetModel())
+	}
+	if !c.IsStreamSupported() {
+		t.Fatal("IsStreamSupported() = false, want true")
+	}
+}
+
+// Unlike the hosted providers, Ollama needs no API key: NewClient must succeed without one.
+func TestNewClient_NoAPIKey(t *testing.T) {
+	if _, err := NewClient(llm.WithModel("llama3.2")); err != nil {
+		t.Fatalf("NewClient without APIKey: expected success, got %v", err)
+	}
+}
+
+func TestNewClient_DefaultBaseURL(t *testing.T) {
+	c := newTestClient(t)
+	if c.BaseURL != DefaultBaseURL {
+		t.Fatalf("BaseURL = %q, want default %q", c.BaseURL, DefaultBaseURL)
+	}
+}
+
+func TestNewClient_BaseURLOverride(t *testing.T) {
+	const custom = "http://remote-host:11434/v1"
+	c := newTestClient(t, llm.WithBaseURL(custom))
+	if c.BaseURL != custom {
+		t.Fatalf("BaseURL = %q, want override %q", c.BaseURL, custom)
+	}
+}
+
+func TestExtractReasoning(t *testing.T) {
+	// nil map -> "".
+	if got := extractReasoning(nil); got != "" {
+		t.Fatalf("nil -> %q", got)
+	}
+	// Missing reasoning_content -> "" (e.g. llama3.2).
+	var msg openai.ChatCompletionMessage
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"hi"}`), &msg); err != nil {
+		t.Fatal(err)
+	}
+	if got := extractReasoning(msg.JSON.ExtraFields); got != "" {
+		t.Fatalf("missing -> %q", got)
+	}
+	// Present reasoning_content (e.g. deepseek-r1 via Ollama) -> decoded string.
+	var rmsg openai.ChatCompletionMessage
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"4","reasoning_content":"2+2=4"}`), &rmsg); err != nil {
+		t.Fatal(err)
+	}
+	if got := extractReasoning(rmsg.JSON.ExtraFields); got != "2+2=4" {
+		t.Fatalf("present -> %q", got)
+	}
+}
+
+func TestOllamaResponseToLLM(t *testing.T) {
+	resp := &openai.ChatCompletion{
+		Model: "llama3.2",
+		Choices: []openai.ChatCompletionChoice{{
+			Message: openai.ChatCompletionMessage{
+				Content: "hello",
+				ToolCalls: []openai.ChatCompletionMessageToolCallUnion{{
+					ID:   "tc1",
+					Type: "function",
+					Function: openai.ChatCompletionMessageFunctionToolCallFunction{
+						Name:      "fn",
+						Arguments: `{"x":1}`,
+					},
+				}},
+			},
+		}},
+		Usage: openai.CompletionUsage{PromptTokens: 1, CompletionTokens: 2, TotalTokens: 3},
+	}
+	out := ollamaResponseToLLM(resp)
+	if out.Content != "hello" || len(out.ToolCalls) != 1 || out.ToolCalls[0].ToolName != "fn" {
+		t.Fatalf("%#v", out)
+	}
+	if out.ToolCalls[0].Args["x"] != float64(1) {
+		t.Fatalf("args = %#v", out.ToolCalls[0].Args)
+	}
+	if out.Usage == nil || out.Usage.TotalTokens != 3 {
+		t.Fatalf("usage %#v", out.Usage)
+	}
+	if _, ok := out.Metadata[reasoningContentField]; ok {
+		t.Fatal("no reasoning expected for a non-thinking response")
+	}
+}
+
+func TestOllamaResponseToLLM_Reasoning(t *testing.T) {
+	var msg openai.ChatCompletionMessage
+	if err := json.Unmarshal([]byte(`{"role":"assistant","content":"4","reasoning_content":"2+2"}`), &msg); err != nil {
+		t.Fatal(err)
+	}
+	resp := &openai.ChatCompletion{
+		Model:   "deepseek-r1",
+		Choices: []openai.ChatCompletionChoice{{Message: msg}},
+	}
+	out := ollamaResponseToLLM(resp)
+	if out.Metadata[reasoningContentField] != "2+2" {
+		t.Fatalf("metadata reasoning = %v", out.Metadata[reasoningContentField])
+	}
+}
+
+func TestOllamaUsageToLLM(t *testing.T) {
+	if ollamaUsageToLLM(openai.CompletionUsage{}) != nil {
+		t.Fatal("zero usage -> nil")
+	}
+	u := openai.CompletionUsage{
+		PromptTokens:            10,
+		CompletionTokens:        20,
+		TotalTokens:             30,
+		PromptTokensDetails:     openai.CompletionUsagePromptTokensDetails{CachedTokens: 5},
+		CompletionTokensDetails: openai.CompletionUsageCompletionTokensDetails{ReasoningTokens: 3},
+	}
+	out := ollamaUsageToLLM(u)
+	if out == nil || out.CachedPromptTokens != 5 || out.ReasoningTokens != 3 || out.TotalTokens != 30 {
+		t.Fatalf("%#v", out)
+	}
+}
+
+// messagesToOllama must use the "system" role for the system prompt and translate
+// user/assistant/tool turns.
+func TestMessagesToOllama_SystemRole(t *testing.T) {
+	req := &interfaces.LLMRequest{
+		SystemMessage: "be terse",
+		Messages: []interfaces.Message{
+			{Role: "user", Content: "hi"},
+		},
+	}
+	msgs := messagesToOllama(req)
+	if len(msgs) != 2 {
+		t.Fatalf("len = %d, want 2", len(msgs))
+	}
+	if msgs[0].OfSystem == nil {
+		t.Fatalf("first message should use the system role, got %#v", msgs[0])
+	}
+	if msgs[1].OfUser == nil {
+		t.Fatal("second message should be a user message")
+	}
+}
+
+func TestMessagesToOllama_AssistantToolCallsAndToolResult(t *testing.T) {
+	req := &interfaces.LLMRequest{
+		Messages: []interfaces.Message{
+			{Role: "assistant", Content: "", ToolCalls: []*interfaces.ToolCall{
+				{ToolCallID: "tc1", ToolName: "get_weather", Args: map[string]any{"city": "SF"}},
+			}},
+			{Role: "tool", Content: "sunny", ToolCallID: "tc1"},
+		},
+	}
+	msgs := messagesToOllama(req)
+	if len(msgs) != 2 {
+		t.Fatalf("len = %d, want 2", len(msgs))
+	}
+	if msgs[0].OfAssistant == nil || len(msgs[0].OfAssistant.ToolCalls) != 1 {
+		t.Fatalf("assistant tool calls not mapped: %#v", msgs[0])
+	}
+	if msgs[1].OfTool == nil {
+		t.Fatalf("tool result not mapped: %#v", msgs[1])
+	}
+}
+
+func TestToolsToOllama(t *testing.T) {
+	specs := []interfaces.ToolSpec{
+		{Name: "search", Description: "search the web", Parameters: interfaces.JSONSchema{"type": "object"}},
+		{Name: "noparams"}, // nil Parameters -> defaulted object schema
+	}
+	tools := toolsToOllama(specs)
+	if len(tools) != 2 {
+		t.Fatalf("len = %d, want 2", len(tools))
+	}
+	if tools[0].OfFunction == nil || tools[0].OfFunction.Function.Name != "search" {
+		t.Fatalf("tool 0 = %#v", tools[0])
+	}
+	if tools[1].OfFunction.Function.Parameters == nil {
+		t.Fatal("nil parameters should be defaulted to an object schema")
+	}
+}
+
+// Ollama's OpenAI layer supports only json_object: a JSON request maps to json_object with or
+// without a Schema (the schema is dropped, since json_schema is unsupported).
+func TestResponseFormatToOllama(t *testing.T) {
+	// Text.
+	if rf := responseFormatToOllama(&interfaces.ResponseFormat{Type: interfaces.ResponseFormatText}); rf.OfText == nil {
+		t.Fatal("text -> OfText expected")
+	}
+	// JSON without schema -> json_object.
+	if rf := responseFormatToOllama(&interfaces.ResponseFormat{Type: interfaces.ResponseFormatJSON}); rf.OfJSONObject == nil {
+		t.Fatal("json (no schema) -> OfJSONObject expected")
+	}
+	// JSON *with* schema -> still json_object (schema ignored), never json_schema.
+	withSchema := &interfaces.ResponseFormat{
+		Type:   interfaces.ResponseFormatJSON,
+		Name:   "FactAnswer",
+		Schema: interfaces.JSONSchema{"type": "object"},
+	}
+	rf := responseFormatToOllama(withSchema)
+	if rf.OfJSONObject == nil {
+		t.Fatal("json (with schema) -> OfJSONObject expected")
+	}
+	if rf.OfJSONSchema != nil {
+		t.Fatal("Ollama must not emit json_schema (unsupported)")
+	}
+}
+
+func TestBuildCompletionParams(t *testing.T) {
+	c := newTestClient(t, llm.WithModel("llama3.2"))
+	temp, topP := 0.3, 0.9
+	req := &interfaces.LLMRequest{
+		Messages:       []interfaces.Message{{Role: "user", Content: "hi"}},
+		Temperature:    &temp,
+		TopP:           &topP,
+		MaxTokens:      50,
+		Tools:          []interfaces.ToolSpec{{Name: "fn"}},
+		ResponseFormat: &interfaces.ResponseFormat{Type: interfaces.ResponseFormatJSON},
+	}
+	params := c.buildCompletionParams(messagesToOllama(req), req)
+	if params.Model != "llama3.2" {
+		t.Fatalf("model = %q", params.Model)
+	}
+	if params.Temperature.Value != 0.3 {
+		t.Fatalf("temperature = %v", params.Temperature.Value)
+	}
+	if params.TopP.Value != 0.9 {
+		t.Fatalf("topP = %v", params.TopP.Value)
+	}
+	if params.MaxTokens.Value != 50 {
+		t.Fatalf("maxTokens = %v", params.MaxTokens.Value)
+	}
+	if len(params.Tools) != 1 {
+		t.Fatalf("tools = %d", len(params.Tools))
+	}
+	if params.ResponseFormat.OfJSONObject == nil {
+		t.Fatal("response format should be json_object")
+	}
+}

--- a/pkg/llm/ollama/client_test.go
+++ b/pkg/llm/ollama/client_test.go
@@ -14,6 +14,9 @@ var _ interfaces.LLMClient = (*Client)(nil)
 
 func newTestClient(t *testing.T, opts ...llm.Option) *Client {
 	t.Helper()
+	// Isolate from the environment: an OLLAMA_API_KEY set on the host/CI must not silently
+	// change local-default tests to the cloud default. Cloud-specific tests set it back.
+	t.Setenv(cloudAPIKeyEnvVar, "")
 	c, err := NewClient(opts...)
 	if err != nil {
 		t.Fatalf("NewClient: %v", err)
@@ -51,6 +54,56 @@ func TestNewClient_DefaultBaseURL(t *testing.T) {
 func TestNewClient_BaseURLOverride(t *testing.T) {
 	const custom = "http://remote-host:11434/v1"
 	c := newTestClient(t, llm.WithBaseURL(custom))
+	if c.BaseURL != custom {
+		t.Fatalf("BaseURL = %q, want override %q", c.BaseURL, custom)
+	}
+}
+
+// Supplying an API key (no explicit base URL) switches the default to Ollama Cloud.
+func TestNewClient_CloudBaseURL_WithAPIKeyOption(t *testing.T) {
+	c := newTestClient(t, llm.WithAPIKey("cloud-key"), llm.WithModel("qwen3-coder:480b-cloud"))
+	if c.BaseURL != DefaultCloudBaseURL {
+		t.Fatalf("BaseURL = %q, want cloud default %q", c.BaseURL, DefaultCloudBaseURL)
+	}
+	if c.APIKey != "cloud-key" {
+		t.Fatalf("APIKey = %q, want %q", c.APIKey, "cloud-key")
+	}
+}
+
+// OLLAMA_API_KEY is a fallback when llm.WithAPIKey is not supplied, matching the Ollama CLI's
+// own convention, and it also switches the default base URL to Ollama Cloud.
+func TestNewClient_CloudBaseURL_FromEnvVar(t *testing.T) {
+	t.Setenv(cloudAPIKeyEnvVar, "env-key")
+	c, err := NewClient(llm.WithModel("llama3.2"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c.BaseURL != DefaultCloudBaseURL {
+		t.Fatalf("BaseURL = %q, want cloud default %q", c.BaseURL, DefaultCloudBaseURL)
+	}
+	if c.APIKey != "env-key" {
+		t.Fatalf("APIKey = %q, want %q", c.APIKey, "env-key")
+	}
+}
+
+// llm.WithAPIKey always takes precedence over OLLAMA_API_KEY, mirroring the Gemini client's
+// WithAPIKey/GOOGLE_API_KEY precedence.
+func TestNewClient_APIKeyOptionTakesPrecedenceOverEnv(t *testing.T) {
+	t.Setenv(cloudAPIKeyEnvVar, "env-key")
+	c, err := NewClient(llm.WithAPIKey("explicit-key"), llm.WithModel("llama3.2"))
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if c.APIKey != "explicit-key" {
+		t.Fatalf("APIKey = %q, want %q", c.APIKey, "explicit-key")
+	}
+}
+
+// An explicit base URL always wins over the cloud default, e.g. a self-hosted daemon behind
+// an auth proxy that still needs a real API key.
+func TestNewClient_ExplicitBaseURLOverridesCloudDefault(t *testing.T) {
+	const custom = "https://proxy.example.com/v1"
+	c := newTestClient(t, llm.WithAPIKey("cloud-key"), llm.WithBaseURL(custom))
 	if c.BaseURL != custom {
 		t.Fatalf("BaseURL = %q, want override %q", c.BaseURL, custom)
 	}


### PR DESCRIPTION
## Description

Adds Ollama as a built-in LLM provider under `pkg/llm/ollama`, implementing `interfaces.LLMClient` alongside the existing providers. Supports both a local Ollama daemon and Ollama Cloud:

- **Local** — no API key required. `llm.BuildConfigKeyless` (new, additive) lets the client construct without an APIKey; defaults to `http://localhost:11434/v1`.
- **Ollama Cloud** — supplying an API key (`llm.WithAPIKey` or the `OLLAMA_API_KEY` env var) auto-switches the default base URL to `https://ollama.com/v1`. `llm.WithBaseURL` always overrides, for remote/self-hosted daemons or auth proxies.
- Standalone client using `openai-go` as OpenAI-compatible transport (no new dependency), following the DeepSeek pattern — the OpenAI adapter is untouched.
- New `interfaces.LLMProviderOllama` constant, wired into the `cmd` and `examples` config factories (`provider: ollama` / `LLM_PROVIDER=ollama`).

## Type of change

New feature (non-breaking change which adds functionality)

## Related issues

Fixes #38

## Checklist

- [ Y ] I have run `make check`
- [ Y ] I have run `task examples:all`
- [ Y ] I have run `make tidy` if I added or removed dependencies
- [ Y ] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [ Y ] I have added/updated tests for my changes
- [ Y ] Documentation is updated if needed
