### PR TITLE
feat: move stream approvals to AgentStream.Approve and deprecate Agent.OnApproval

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import (
     "github.com/agenticenv/agent-sdk-go/pkg/llm/openai"
 )
 
+// errors omitted for brevity
 llmClient, _ := openai.NewClient(
     llm.WithAPIKey("sk-..."),
     llm.WithModel("gpt-4o"),
@@ -80,8 +81,8 @@ for event := range events {
         // tool / delegation approval (when approval policy requires it)
         if e.Name == string(agent.AgentCustomEventNameToolApproval) {
             if v, err := agent.ParseCustomEventApproval(e); err == nil {
-                // NOTE: replace with real approval logic — this auto-approves for demonstration
-                _ = a.OnApproval(context.Background(), v.ApprovalToken, agent.ApprovalStatusApproved)
+                // replace with real approval logic — this auto-approves for demonstration
+                _ = stream.Approve(context.Background(), v.ApprovalToken, agent.ApprovalStatusApproved)
             }
         }
     // also RunFinished, ToolCallResult, …
@@ -125,12 +126,12 @@ savedRunID := stream.ID() // persist before consuming events
 events, _ := stream.Events(context.Background())
 for event := range events {
     // persist event.Offset() before handling — needed for WithOffset on reconnect
-    // handle AG-UI events (see in-process example)
     _ = event
 }
 
 // --- Reconnect after a process crash ---
-savedOffset := int64(0) // last event Offset() persisted before handling it
+// replace with last persisted offset from your storage
+savedOffset := int64(0)
 s, _ := a.GetAgentStream(context.Background(), savedRunID)
 ch, _ := s.Events(context.Background(), agent.WithOffset(savedOffset))
 for event := range ch {

--- a/cli/internal/command/chat.go
+++ b/cli/internal/command/chat.go
@@ -158,7 +158,7 @@ func (c *ChatCmd) Run(cfg *config.Config) error {
 				if ok2 && strings.TrimSpace(strings.ToLower(line2)) == "y" {
 					status = sdkagent.ApprovalStatusApproved
 				}
-				if err := a.OnApproval(context.Background(), approvalToken, status); err != nil {
+				if err := agentStream.Approve(context.Background(), approvalToken, status); err != nil {
 					log.Printf("approval failed: %v", err)
 				}
 			default:

--- a/docs/advanced/timeouts-and-modes.mdx
+++ b/docs/advanced/timeouts-and-modes.mdx
@@ -254,7 +254,7 @@ See [Execution config](/features/execution-config) for the full defaults table a
   </Card>
 
   <Card title="Approvals" icon="shield-check" href="/features/approvals" horizontal>
-    Approval handler and OnApproval flows
+    Approval handler and AgentStream.Approve flows
   </Card>
 
   <Card title="Distributed Execution" icon="server" href="/advanced/distributed-execution" horizontal>

--- a/docs/examples/durable-agent.mdx
+++ b/docs/examples/durable-agent.mdx
@@ -26,7 +26,7 @@ The agent uses **`Stream`**. The REPL prints event types as they arrive:
 
 - `TEXT_MESSAGE_CONTENT` — token deltas
 - Tool lifecycle events
-- `CUSTOM` — tool and delegation **approvals** (respond with `OnApproval` in the sample)
+- `CUSTOM` — tool and delegation **approvals** (respond with `AgentStream.Approve` in the sample)
 - `RUN_FINISHED` / errors
 
 Events are delivered by the runtime as a durable ordered stream. Each event carries a monotonic offset.
@@ -171,7 +171,7 @@ Send a prompt from the agent. Outcome depends on timing (same as scenario 2):
 
 ## Approvals in this example
 
-`agent/main.go` handles **`CUSTOM`** approval events — parse with `ParseCustomEventApproval` / `ParseCustomEventDelegation` and call `OnApproval` with the token (same pattern as [Approvals](/features/approvals)). Shared opts in `opts/opts.go` do not register tools by default, so simple prompts usually skip this path.
+`agent/main.go` handles **`CUSTOM`** approval events — parse with `ParseCustomEventApproval` / `ParseCustomEventDelegation` and call `AgentStream.Approve` with the token (same pattern as [Approvals](/features/approvals)). Shared opts in `opts/opts.go` do not register tools by default, so simple prompts usually skip this path.
 
 If you add tools that require approval and ignore prompts, tools are skipped with a clear message rather than hanging indefinitely.
 

--- a/docs/features/ag-ui-protocol.mdx
+++ b/docs/features/ag-ui-protocol.mdx
@@ -81,6 +81,6 @@ Call `event.ToJSON()` on any [`AgentEvent`](https://pkg.go.dev/github.com/agenti
   </Card>
 
   <Card title="Approvals" icon="shield-check" href="/features/approvals" horizontal>
-    CUSTOM events and OnApproval
+    CUSTOM events and AgentStream.Approve
   </Card>
 </CardGroup>

--- a/docs/features/approvals.mdx
+++ b/docs/features/approvals.mdx
@@ -5,7 +5,7 @@ description: "Configure human-in-the-loop approval for tool calls, MCP invocatio
 
 Before registry tools, MCP tools, or sub-agent delegation execute, the SDK can pause and wait for **human approval**. One agent-level policy governs all three paths.
 
-When an approval is required, the run **pauses at that tool call** and delivers an `ApprovalRequest` to your handler (or a `CUSTOM` event on the stream). The run resumes only after `req.Respond()` or `OnApproval()` is called with `Approved` or `Rejected`. If rejected, the tool call is skipped and the LLM receives a clear refusal message, then continues generating a response without that tool result. The overall run does not fail on rejection — only on timeout.
+When an approval is required, the run **pauses at that tool call** and delivers an `ApprovalRequest` to your handler (or a `CUSTOM` event on the stream). The run resumes only after `req.Respond()` or `AgentStream.Approve()` is called with `Approved` or `Rejected`. If rejected, the tool call is skipped and the LLM receives a clear refusal message, then continues generating a response without that tool result. The overall run does not fail on rejection — only on timeout.
 
 ## Policies
 
@@ -74,7 +74,7 @@ For a **non-blocking** wait, use the same handler and select on `agentRun.Done()
 
 ### Error handling
 
-`Respond` (and stream `OnApproval`) succeed once per approval token. A second call returns `ErrApprovalAlreadyResolved` — already answered or timed out; usually safe to ignore:
+`Respond` (and stream `Approve`) succeed once per approval token. A second call returns `ErrApprovalAlreadyResolved` — already answered or timed out; usually safe to ignore:
 
 ```go
 a, err := agent.NewAgent(
@@ -91,13 +91,22 @@ a, err := agent.NewAgent(
 )
 ```
 
-On Temporal, approval state is durable across reconnects — calling `Respond` / `OnApproval` again after a crash returns the same sentinel.
+On Temporal, approval state is durable across reconnects — calling `Respond` / `Approve` again after a crash returns the same sentinel.
 
 ## Stream
 
-On `Stream`, approval and delegation requests arrive as `AgentEventTypeCustom` events — not via `WithApprovalHandler`. Parse the event, then call [`OnApproval`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/agent#Agent.OnApproval):
+On `Stream`, approval and delegation requests arrive as `AgentEventTypeCustom` events — not via `WithApprovalHandler`. Parse the event, then call [`Approve`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/agent#AgentStream.Approve) on the stream handle:
 
 ```go
+stream, err := a.Stream(ctx, prompt, nil)
+if err != nil {
+    return err
+}
+eventCh, err := stream.Events(ctx)
+if err != nil {
+    return err
+}
+
 for ev := range eventCh {
     if ev == nil || ev.Type() != agent.AgentEventTypeCustom {
         continue
@@ -107,27 +116,27 @@ for ev := range eventCh {
         continue
     }
     if v, err := agent.ParseCustomEventApproval(ce); err == nil {
-        err := a.OnApproval(ctx, v.ApprovalToken, agent.ApprovalStatusApproved)
+        err := stream.Approve(ctx, v.ApprovalToken, agent.ApprovalStatusApproved)
         if errors.Is(err, agent.ErrApprovalAlreadyResolved) {
             continue
         }
         if err != nil {
-            log.WithError(err).Error("OnApproval failed")
+            log.WithError(err).Error("Approve failed")
         }
     } else if d, err := agent.ParseCustomEventDelegation(ce); err == nil {
-        err := a.OnApproval(ctx, d.ApprovalToken, agent.ApprovalStatusApproved)
+        err := stream.Approve(ctx, d.ApprovalToken, agent.ApprovalStatusApproved)
         if errors.Is(err, agent.ErrApprovalAlreadyResolved) {
             continue
         }
         if err != nil {
-            log.WithError(err).Error("OnApproval failed")
+            log.WithError(err).Error("Approve failed")
         }
     }
 }
 ```
 
 <Warning>
-`Run` uses `req.Respond()` in `WithApprovalHandler`. `Stream` uses `OnApproval` with the token from the CUSTOM event. Do not mix the two paths.
+`Run` uses `req.Respond()` in `WithApprovalHandler`. `Stream` uses `AgentStream.Approve` with the token from the CUSTOM event. Do not mix the two paths.
 </Warning>
 
 ## Sub-agent approval
@@ -179,7 +188,7 @@ for ev := range eventCh {
         continue
     }
     if v, err := agent.ParseCustomEventApproval(ce); err == nil {
-        err := a.OnApproval(ctx, v.ApprovalToken, agent.ApprovalStatusApproved)
+        err := stream.Approve(ctx, v.ApprovalToken, agent.ApprovalStatusApproved)
         if errors.Is(err, agent.ErrApprovalAlreadyResolved) {
             continue // answered before the crash
         }
@@ -190,7 +199,7 @@ for ev := range eventCh {
 }
 ```
 
-The CUSTOM approval event is delivered once. If you already responded before the crash, `OnApproval` returns `ErrApprovalAlreadyResolved`. If you crashed before responding, the token stays open until you answer.
+The CUSTOM approval event is delivered once. If you already responded before the crash, `Approve` returns `ErrApprovalAlreadyResolved`. If you crashed before responding, the token stays open until you answer.
 
 ## Example
 

--- a/docs/getting-started/streaming.mdx
+++ b/docs/getting-started/streaming.mdx
@@ -183,7 +183,7 @@ Stream events are typed [`AgentEvent`](https://pkg.go.dev/github.com/agenticenv/
 |---|---|
 | `AgentEventTypeCustom` | Approval or delegation requests during `Stream` |
 
-Parse approval events with `ParseCustomEventApproval` / `ParseCustomEventDelegation`, then call [`OnApproval`](/features/approvals) with the `ApprovalToken`. See [Approvals](/features/approvals) for the full flow.
+Parse approval events with `ParseCustomEventApproval` / `ParseCustomEventDelegation`, then call [`AgentStream.Approve`](/features/approvals) with the `ApprovalToken`. See [Approvals](/features/approvals) for the full flow.
 
 ## Displaying streamed text
 

--- a/examples/agent_with_subagents/main.go
+++ b/examples/agent_with_subagents/main.go
@@ -149,7 +149,7 @@ func main() {
 				if approved {
 					status = agent.ApprovalStatusApproved
 				}
-				if err := mainAgent.OnApproval(context.Background(), tv.ApprovalToken, status); err != nil {
+				if err := agentStream.Approve(context.Background(), tv.ApprovalToken, status); err != nil {
 					fmt.Printf("[%s] approval error: %v\n", eventType, err)
 				}
 				continue
@@ -167,7 +167,7 @@ func main() {
 				if approved {
 					status = agent.ApprovalStatusApproved
 				}
-				if err := mainAgent.OnApproval(context.Background(), dv.ApprovalToken, status); err != nil {
+				if err := agentStream.Approve(context.Background(), dv.ApprovalToken, status); err != nil {
 					fmt.Printf("[%s] approval error: %v\n", eventType, err)
 				}
 			}

--- a/examples/agent_with_worker/agent/main.go
+++ b/examples/agent_with_worker/agent/main.go
@@ -138,11 +138,11 @@ func runStream(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner, prom
 			if v, ok := shared.ToolApprovalValueFromEvent(ev); ok {
 				args, _ := json.Marshal(v.Args)
 				fmt.Printf("\n[approval] agent=%s kind=tool target=%s args=%s\n", v.AgentName, v.ToolName, string(args))
-				handleApprovalTokenPrompt(ctx, a, scanner, v.ApprovalToken)
+				handleApprovalTokenPrompt(ctx, agentStream, scanner, v.ApprovalToken)
 			} else if v, ok := shared.DelegationApprovalValueFromEvent(ev); ok {
 				args, _ := json.Marshal(v.Args)
 				fmt.Printf("\n[approval] agent=%s kind=delegation target=delegate:%s args=%s\n", v.AgentName, v.SubAgentName, string(args))
-				handleApprovalTokenPrompt(ctx, a, scanner, v.ApprovalToken)
+				handleApprovalTokenPrompt(ctx, agentStream, scanner, v.ApprovalToken)
 			}
 
 		case agent.AgentEventTypeRunError:
@@ -169,25 +169,25 @@ func runStream(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner, prom
 	fmt.Println()
 }
 
-func handleApprovalTokenPrompt(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner, token string) {
+func handleApprovalTokenPrompt(ctx context.Context, agentStream agent.AgentStream, scanner *bufio.Scanner, token string) {
 	for {
 		fmt.Print("approve? (y/n)> ")
 		if !scanner.Scan() {
 			fmt.Println("EOF, rejecting.")
-			_ = a.OnApproval(ctx, token, agent.ApprovalStatusRejected)
+			_ = agentStream.Approve(ctx, token, agent.ApprovalStatusRejected)
 			return
 		}
 		ans := strings.ToLower(strings.TrimSpace(scanner.Text()))
 		switch ans {
 		case "y", "yes":
-			if err := a.OnApproval(ctx, token, agent.ApprovalStatusApproved); err != nil {
+			if err := agentStream.Approve(ctx, token, agent.ApprovalStatusApproved); err != nil {
 				fmt.Printf("[approval error] %v\n", err)
 			} else {
 				fmt.Println("[approved]")
 			}
 			return
 		case "n", "no":
-			if err := a.OnApproval(ctx, token, agent.ApprovalStatusRejected); err != nil {
+			if err := agentStream.Approve(ctx, token, agent.ApprovalStatusRejected); err != nil {
 				fmt.Printf("[approval error] %v\n", err)
 			} else {
 				fmt.Println("[rejected]")

--- a/examples/durable_agent/agent/main.go
+++ b/examples/durable_agent/agent/main.go
@@ -201,7 +201,7 @@ func runStream(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner, prom
 	fmt.Println(shared.RunIDLine(runID))
 
 	fmt.Println("--- stream start ---")
-	drainStreamEvents(ctx, a, scanner, prompt, runID, eventCh, 0)
+	drainStreamEvents(ctx, agentStream, scanner, prompt, runID, eventCh, 0)
 	fmt.Println("--- stream end ---")
 	fmt.Println()
 }
@@ -235,7 +235,7 @@ func reconnectStream(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner
 	}
 
 	fmt.Println("--- stream resumed ---")
-	drainStreamEvents(ctx, a, scanner, state.Prompt, state.RunID, eventCh, state.Offset)
+	drainStreamEvents(ctx, agentStream, scanner, state.Prompt, state.RunID, eventCh, state.Offset)
 	fmt.Println("--- stream end ---")
 	fmt.Println()
 }
@@ -247,7 +247,7 @@ func reconnectStream(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner
 //   - clears the state file on terminal events (RUN_FINISHED, RUN_ERROR)
 func drainStreamEvents(
 	ctx context.Context,
-	a *agent.Agent,
+	agentStream agent.AgentStream,
 	scanner *bufio.Scanner,
 	prompt string,
 	runID string,
@@ -308,11 +308,11 @@ func drainStreamEvents(
 			if v, ok := shared.ToolApprovalValueFromEvent(ev); ok {
 				args, _ := json.Marshal(v.Args)
 				fmt.Printf("\n[approval] agent=%s kind=tool target=%s args=%s\n", v.AgentName, v.ToolName, string(args))
-				handleApprovalTokenPrompt(ctx, a, scanner, v.ApprovalToken)
+				handleApprovalTokenPrompt(ctx, agentStream, scanner, v.ApprovalToken)
 			} else if v, ok := shared.DelegationApprovalValueFromEvent(ev); ok {
 				args, _ := json.Marshal(v.Args)
 				fmt.Printf("\n[approval] agent=%s kind=delegation target=delegate:%s args=%s\n", v.AgentName, v.SubAgentName, string(args))
-				handleApprovalTokenPrompt(ctx, a, scanner, v.ApprovalToken)
+				handleApprovalTokenPrompt(ctx, agentStream, scanner, v.ApprovalToken)
 			}
 
 		case agent.AgentEventTypeRunError:
@@ -339,25 +339,25 @@ func drainStreamEvents(
 	}
 }
 
-func handleApprovalTokenPrompt(ctx context.Context, a *agent.Agent, scanner *bufio.Scanner, token string) {
+func handleApprovalTokenPrompt(ctx context.Context, agentStream agent.AgentStream, scanner *bufio.Scanner, token string) {
 	for {
 		fmt.Print("approve? (y/n)> ")
 		if !scanner.Scan() {
 			fmt.Println("EOF, rejecting.")
-			_ = a.OnApproval(ctx, token, agent.ApprovalStatusRejected)
+			_ = agentStream.Approve(ctx, token, agent.ApprovalStatusRejected)
 			return
 		}
 		ans := strings.ToLower(strings.TrimSpace(scanner.Text()))
 		switch ans {
 		case "y", "yes":
-			if err := a.OnApproval(ctx, token, agent.ApprovalStatusApproved); err != nil {
+			if err := agentStream.Approve(ctx, token, agent.ApprovalStatusApproved); err != nil {
 				fmt.Printf("[approval error] %v\n", err)
 			} else {
 				fmt.Println("[approved]")
 			}
 			return
 		case "n", "no":
-			if err := a.OnApproval(ctx, token, agent.ApprovalStatusRejected); err != nil {
+			if err := agentStream.Approve(ctx, token, agent.ApprovalStatusRejected); err != nil {
 				fmt.Printf("[approval error] %v\n", err)
 			} else {
 				fmt.Println("[rejected]")

--- a/internal/runtime/local/agent_loop.go
+++ b/internal/runtime/local/agent_loop.go
@@ -563,7 +563,7 @@ func (rt *LocalRuntime) executeSingleTool(
 			defer approvalTimer.Stop()
 
 			// Generate a token and register a resolve channel so either path can unblock:
-			//   - Streaming: caller receives CUSTOM event with token, calls rt.Approve(token, status)
+			//   - Streaming: caller receives CUSTOM event with token, calls StreamHandle.Approve
 			//   - Non-streaming with handler: handler calls approvalReq.Respond(status) directly
 			token := uuid.New().String()
 			resultCh := make(chan types.ApprovalStatus, 1)
@@ -623,7 +623,7 @@ func (rt *LocalRuntime) executeSingleTool(
 					approvalCancel()
 				}
 			}
-			// Streaming path: handler is nil; caller calls rt.Approve(token, status) → resultCh.
+			// Streaming path: handler is nil; caller calls StreamHandle.Approve(token, status) → resultCh.
 
 			select {
 			case status := <-resultCh:

--- a/internal/runtime/local/agent_loop_test.go
+++ b/internal/runtime/local/agent_loop_test.go
@@ -761,7 +761,7 @@ func TestExecuteSingleTool_ApprovalHandlerRejects(t *testing.T) {
 
 func TestExecuteSingleTool_StreamingApproveUnblocks(t *testing.T) {
 	// Streaming path: ChannelName set, no ApprovalHandler.
-	// We call rt.Approve from a goroutine to unblock executeSingleTool.
+	// We call rt.approve from a goroutine to unblock executeSingleTool.
 	tool := stubTool{name: "guarded", result: "stream-ok", needsApproval: true}
 	rt, tools := newLoopRT(t, 5, &seqLLMClient{}, tool)
 
@@ -819,7 +819,7 @@ func TestExecuteSingleTool_StreamingApproveUnblocks(t *testing.T) {
 	tok := capturedToken
 	mu.Unlock()
 
-	require.NoError(t, rt.Approve(context.Background(), tok, types.ApprovalStatusApproved))
+	require.NoError(t, rt.approve(context.Background(), tok, types.ApprovalStatusApproved))
 
 	<-done
 	require.NoError(t, resultErr)

--- a/internal/runtime/local/run_handle.go
+++ b/internal/runtime/local/run_handle.go
@@ -21,6 +21,7 @@ var _ sdkruntime.RunHandle = (*runHandle)(nil)
 // when finished. Cancel only cancels the run context; markDone closes Done.
 type runHandle struct {
 	id     string
+	rt     *LocalRuntime
 	doneCh chan struct{}
 
 	cancelOnce sync.Once
@@ -35,9 +36,10 @@ type runHandle struct {
 
 // newRunHandle creates a live handle for runID. cancel aborts the run context;
 // pass a non-nil cancel from context.WithCancel (or WithTimeout).
-func newRunHandle(id string, cancel context.CancelFunc) *runHandle {
+func newRunHandle(id string, rt *LocalRuntime, cancel context.CancelFunc) *runHandle {
 	return &runHandle{
 		id:     id,
+		rt:     rt,
 		doneCh: make(chan struct{}),
 		cancel: cancel,
 		status: types.StatusRunning,

--- a/internal/runtime/local/run_handle_test.go
+++ b/internal/runtime/local/run_handle_test.go
@@ -11,19 +11,19 @@ import (
 )
 
 func TestRunHandle_ID(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	require.Equal(t, "run-1", h.ID())
 }
 
 func TestRunHandle_Status_InitiallyRunning(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	st, err := h.Status(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, types.StatusRunning, st)
 }
 
 func TestRunHandle_Complete_Success(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	want := &types.AgentRunResult{Content: "ok", RunID: "run-1"}
 
 	h.markDone(want, nil)
@@ -44,7 +44,7 @@ func TestRunHandle_Complete_Success(t *testing.T) {
 }
 
 func TestRunHandle_Complete_Failure(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	wantErr := errors.New("loop failed")
 
 	h.markDone(nil, wantErr)
@@ -59,7 +59,7 @@ func TestRunHandle_Complete_Failure(t *testing.T) {
 }
 
 func TestRunHandle_Complete_ContextCanceledSetsCancelled(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 
 	h.markDone(nil, context.Canceled)
 
@@ -73,7 +73,7 @@ func TestRunHandle_Complete_ContextCanceledSetsCancelled(t *testing.T) {
 }
 
 func TestRunHandle_Complete_DeadlineExceededSetsFailed(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 
 	h.markDone(nil, context.DeadlineExceeded)
 
@@ -84,7 +84,7 @@ func TestRunHandle_Complete_DeadlineExceededSetsFailed(t *testing.T) {
 
 func TestRunHandle_Cancel_InvokesCancelFunc(t *testing.T) {
 	cancelled := false
-	h := newRunHandle("run-1", func() { cancelled = true })
+	h := newRunHandle("run-1", nil, func() { cancelled = true })
 
 	require.NoError(t, h.Cancel(context.Background()))
 	require.True(t, cancelled)
@@ -117,19 +117,19 @@ func TestRunHandle_Cancel_InvokesCancelFunc(t *testing.T) {
 }
 
 func TestRunHandle_Cancel_NilCancelFunc(t *testing.T) {
-	h := newRunHandle("run-1", nil)
+	h := newRunHandle("run-1", nil, nil)
 	require.ErrorIs(t, h.Cancel(context.Background()), types.ErrRunAlreadyCompleted)
 }
 
 func TestRunHandle_Cancel_AfterComplete(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	h.markDone(&types.AgentRunResult{Content: "done"}, nil)
 
 	require.ErrorIs(t, h.Cancel(context.Background()), types.ErrRunAlreadyCompleted)
 }
 
 func TestRunHandle_Get_UnblocksOnContextCancel(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	ctx, cancel := context.WithCancel(context.Background())
 
 	errCh := make(chan error, 1)
@@ -155,7 +155,7 @@ func TestRunHandle_Get_UnblocksOnContextCancel(t *testing.T) {
 }
 
 func TestRunHandle_Get_WaitsForComplete(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	want := &types.AgentRunResult{Content: "later"}
 
 	done := make(chan struct{})
@@ -177,6 +177,6 @@ func TestRunHandle_Get_WaitsForComplete(t *testing.T) {
 }
 
 func TestRunHandle_Done_SameChannel(t *testing.T) {
-	h := newRunHandle("run-1", func() {})
+	h := newRunHandle("run-1", nil, func() {})
 	require.Equal(t, h.Done(), h.Done())
 }

--- a/internal/runtime/local/runtime.go
+++ b/internal/runtime/local/runtime.go
@@ -36,8 +36,9 @@ type LocalRuntime struct {
 	approvalHandler types.ApprovalHandler
 
 	// pendingApprovals holds token → resolve channel for tools awaiting human approval.
-	// Used by Approve() to unblock executeSingleTool when the caller responds via OnApproval
-	// (streaming path). Thread-safe: parallel tool calls each register their own token.
+	// Used by approve() to unblock executeSingleTool when the caller responds via
+	// StreamHandle.Approve (streaming path). Thread-safe: parallel tool calls each register
+	// their own token.
 	pendingApprovals sync.Map // key: string token, value: chan types.ApprovalStatus
 }
 
@@ -134,7 +135,7 @@ func (rt *LocalRuntime) Run(ctx context.Context, req *sdkruntime.RunRequest) (sd
 
 	rt.shareEventBusWithSubAgents(req.SubAgents)
 
-	handle := newRunHandle(runID, runCancel)
+	handle := newRunHandle(runID, rt, runCancel)
 	go rt.driveRun(runCtx, req, handle)
 	return handle, nil
 }
@@ -210,6 +211,12 @@ func (rt *LocalRuntime) GetRunHandle(_ context.Context, _ string) (sdkruntime.Ru
 	return nil, types.ErrRunNotFound
 }
 
+// OnApproval is a deprecated Runtime-interface wrapper around [LocalRuntime.approve].
+// Prefer [sdkruntime.StreamHandle.Approve]. Removed in v0.4.0.
+func (rt *LocalRuntime) OnApproval(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
+	return rt.approve(ctx, approvalToken, status)
+}
+
 // Stream starts the agent loop in a background goroutine and returns a [sdkruntime.StreamHandle]
 // immediately. Subscribe via [sdkruntime.StreamHandle.Events] (offset 0 only on LocalRuntime).
 // RUN_STARTED is emitted before the loop begins; RUN_FINISHED or RUN_ERROR closes the channel.
@@ -259,7 +266,7 @@ func (rt *LocalRuntime) Stream(ctx context.Context, req *sdkruntime.RunRequest) 
 		return nil, err
 	}
 
-	handle := newStreamHandle(runID, runCancel, eventCh)
+	handle := newStreamHandle(runID, rt, runCancel, eventCh)
 	rt.publishLifecycleEvent(channel, events.NewAgentRunStartedEvent(threadID, runID))
 	go rt.driveStream(runCtx, req, handle, channel, threadID, closeSub)
 	return handle, nil
@@ -348,12 +355,13 @@ func (rt *LocalRuntime) GetStreamHandle(_ context.Context, _ string) (sdkruntime
 	return nil, types.ErrStreamNotFound
 }
 
-// Approve resolves a pending tool approval registered during a streaming run.
+// approve resolves a pending tool approval registered during a streaming run.
 // When a tool requires approval, executeSingleTool registers a token and blocks; the
-// caller receives a CUSTOM event on the stream with that token and calls Approve to unblock.
+// caller receives a CUSTOM event on the stream with that token and calls
+// [sdkruntime.StreamHandle.Approve] to unblock.
 // Returns [types.ErrApprovalAlreadyResolved] when the token is unknown or was already
 // resolved (same sentinel as Temporal when CompleteActivity reports not found).
-func (rt *LocalRuntime) Approve(_ context.Context, approvalToken string, status types.ApprovalStatus) error {
+func (rt *LocalRuntime) approve(_ context.Context, approvalToken string, status types.ApprovalStatus) error {
 	val, ok := rt.pendingApprovals.LoadAndDelete(approvalToken)
 	if !ok {
 		return types.ErrApprovalAlreadyResolved

--- a/internal/runtime/local/runtime_test.go
+++ b/internal/runtime/local/runtime_test.go
@@ -656,7 +656,7 @@ func TestStream_ContextCancelledAborts(t *testing.T) {
 
 func TestApprove_UnknownToken(t *testing.T) {
 	rt := newLocalRT(t, &seqLLMClient{})
-	err := rt.Approve(context.Background(), "nonexistent-token", types.ApprovalStatusApproved)
+	err := rt.approve(context.Background(), "nonexistent-token", types.ApprovalStatusApproved)
 	require.ErrorIs(t, err, types.ErrApprovalAlreadyResolved)
 }
 
@@ -667,7 +667,7 @@ func TestApprove_ResolvesRegisteredChannel(t *testing.T) {
 	resultCh := make(chan types.ApprovalStatus, 1)
 	rt.pendingApprovals.Store(token, resultCh)
 
-	err := rt.Approve(context.Background(), token, types.ApprovalStatusApproved)
+	err := rt.approve(context.Background(), token, types.ApprovalStatusApproved)
 	require.NoError(t, err)
 
 	select {
@@ -678,7 +678,7 @@ func TestApprove_ResolvesRegisteredChannel(t *testing.T) {
 	}
 
 	_, loaded := rt.pendingApprovals.Load(token)
-	require.False(t, loaded, "token must be removed after Approve")
+	require.False(t, loaded, "token must be removed after approve")
 }
 
 func TestApprove_RejectsViaSameToken(t *testing.T) {
@@ -688,7 +688,7 @@ func TestApprove_RejectsViaSameToken(t *testing.T) {
 	resultCh := make(chan types.ApprovalStatus, 1)
 	rt.pendingApprovals.Store(token, resultCh)
 
-	err := rt.Approve(context.Background(), token, types.ApprovalStatusRejected)
+	err := rt.approve(context.Background(), token, types.ApprovalStatusRejected)
 	require.NoError(t, err)
 
 	status := <-resultCh
@@ -702,8 +702,8 @@ func TestApprove_DoubleApproveSecondErrors(t *testing.T) {
 	resultCh := make(chan types.ApprovalStatus, 1)
 	rt.pendingApprovals.Store(token, resultCh)
 
-	require.NoError(t, rt.Approve(context.Background(), token, types.ApprovalStatusApproved))
-	err := rt.Approve(context.Background(), token, types.ApprovalStatusApproved)
+	require.NoError(t, rt.approve(context.Background(), token, types.ApprovalStatusApproved))
+	err := rt.approve(context.Background(), token, types.ApprovalStatusApproved)
 	require.ErrorIs(t, err, types.ErrApprovalAlreadyResolved)
 }
 
@@ -749,7 +749,7 @@ outer:
 				if parseErr == nil && val.ApprovalToken != "" {
 					approvalToken = val.ApprovalToken
 					go func(tok string) {
-						_ = rt.Approve(context.Background(), tok, types.ApprovalStatusApproved)
+						_ = rt.approve(context.Background(), tok, types.ApprovalStatusApproved)
 					}(approvalToken)
 				}
 			}

--- a/internal/runtime/local/stream_handle.go
+++ b/internal/runtime/local/stream_handle.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/agenticenv/agent-sdk-go/internal/events"
@@ -30,11 +31,21 @@ type streamHandle struct {
 // newStreamHandle creates a live stream handle for runID, embedding a new [runHandle].
 // cancel aborts the run context; eventCh is the receive-only event stream
 // (subscribe-before-start), handed out once by [streamHandle.Events].
-func newStreamHandle(id string, cancel context.CancelFunc, eventCh <-chan events.AgentEvent) *streamHandle {
+func newStreamHandle(id string, rt *LocalRuntime, cancel context.CancelFunc, eventCh <-chan events.AgentEvent) *streamHandle {
 	return &streamHandle{
-		runHandle: newRunHandle(id, cancel),
+		runHandle: newRunHandle(id, rt, cancel),
 		eventCh:   eventCh,
 	}
+}
+
+// Approve completes a tool or delegation approval using the token from the CUSTOM event
+// and the chosen status (e.g. [types.ApprovalStatusApproved] or [types.ApprovalStatusRejected]).
+// Returns [types.ErrApprovalAlreadyResolved] when the token was already completed.
+func (h *streamHandle) Approve(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
+	if h.rt == nil {
+		return fmt.Errorf("local: stream handle %q is not configured", h.id)
+	}
+	return h.rt.approve(ctx, approvalToken, status)
 }
 
 // Events returns this run's in-process event channel (subscribe-before-start).

--- a/internal/runtime/local/stream_handle_test.go
+++ b/internal/runtime/local/stream_handle_test.go
@@ -12,13 +12,13 @@ import (
 
 func TestStreamHandle_ID(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 	require.Equal(t, "run-1", h.ID())
 }
 
 func TestStreamHandle_Status_InitiallyRunning(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 
 	st, err := h.Status(context.Background())
 	require.NoError(t, err)
@@ -27,7 +27,7 @@ func TestStreamHandle_Status_InitiallyRunning(t *testing.T) {
 
 func TestStreamHandle_Complete_Success(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 
 	h.markDone(nil, nil)
 
@@ -44,7 +44,7 @@ func TestStreamHandle_Complete_Success(t *testing.T) {
 
 func TestStreamHandle_Complete_Failure(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 
 	h.markDone(nil, errors.New("loop failed"))
 
@@ -56,7 +56,7 @@ func TestStreamHandle_Complete_Failure(t *testing.T) {
 func TestStreamHandle_Cancel_InvokesCancelFunc(t *testing.T) {
 	cancelled := false
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() { cancelled = true }, ch)
+	h := newStreamHandle("run-1", nil, func() { cancelled = true }, ch)
 
 	require.NoError(t, h.Cancel(context.Background()))
 	require.True(t, cancelled)
@@ -65,13 +65,13 @@ func TestStreamHandle_Cancel_InvokesCancelFunc(t *testing.T) {
 
 func TestStreamHandle_Cancel_NilCancelFunc(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", nil, ch)
+	h := newStreamHandle("run-1", nil, nil, ch)
 	require.ErrorIs(t, h.Cancel(context.Background()), types.ErrRunAlreadyCompleted)
 }
 
 func TestStreamHandle_Cancel_AfterComplete(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 	h.markDone(nil, nil)
 
 	require.ErrorIs(t, h.Cancel(context.Background()), types.ErrRunAlreadyCompleted)
@@ -79,7 +79,7 @@ func TestStreamHandle_Cancel_AfterComplete(t *testing.T) {
 
 func TestStreamHandle_Events_ReturnsChannelOnce(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 
 	got, err := h.Events(context.Background(), 0)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestStreamHandle_Events_ReturnsChannelOnce(t *testing.T) {
 
 func TestStreamHandle_Events_SecondCallAfterComplete(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 
 	_, err := h.Events(context.Background(), 0)
 	require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestStreamHandle_Events_SecondCallAfterComplete(t *testing.T) {
 
 func TestStreamHandle_Events_OffsetUnsupported(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 
 	_, err := h.Events(context.Background(), 5)
 	require.ErrorIs(t, err, types.ErrStreamOffsetNotSupported)
@@ -113,7 +113,7 @@ func TestStreamHandle_Events_OffsetUnsupported(t *testing.T) {
 
 func TestStreamHandle_Events_AfterComplete(t *testing.T) {
 	ch := make(chan events.AgentEvent)
-	h := newStreamHandle("run-1", func() {}, ch)
+	h := newStreamHandle("run-1", nil, func() {}, ch)
 	h.markDone(nil, nil)
 
 	_, err := h.Events(context.Background(), 0)

--- a/internal/runtime/mocks/mock_runtime.go
+++ b/internal/runtime/mocks/mock_runtime.go
@@ -37,20 +37,6 @@ func (m *MockRuntime) EXPECT() *MockRuntimeMockRecorder {
 	return m.recorder
 }
 
-// Approve mocks base method.
-func (m *MockRuntime) Approve(arg0 context.Context, arg1 string, arg2 types.ApprovalStatus) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Approve", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Approve indicates an expected call of Approve.
-func (mr *MockRuntimeMockRecorder) Approve(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Approve", reflect.TypeOf((*MockRuntime)(nil).Approve), arg0, arg1, arg2)
-}
-
 // Close mocks base method.
 func (m *MockRuntime) Close() {
 	m.ctrl.T.Helper()
@@ -91,6 +77,20 @@ func (m *MockRuntime) GetStreamHandle(arg0 context.Context, arg1 string) (runtim
 func (mr *MockRuntimeMockRecorder) GetStreamHandle(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamHandle", reflect.TypeOf((*MockRuntime)(nil).GetStreamHandle), arg0, arg1)
+}
+
+// OnApproval mocks base method.
+func (m *MockRuntime) OnApproval(arg0 context.Context, arg1 string, arg2 types.ApprovalStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OnApproval", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// OnApproval indicates an expected call of OnApproval.
+func (mr *MockRuntimeMockRecorder) OnApproval(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnApproval", reflect.TypeOf((*MockRuntime)(nil).OnApproval), arg0, arg1, arg2)
 }
 
 // Run mocks base method.
@@ -239,6 +239,20 @@ func NewMockStreamHandle(ctrl *gomock.Controller) *MockStreamHandle {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStreamHandle) EXPECT() *MockStreamHandleMockRecorder {
 	return m.recorder
+}
+
+// Approve mocks base method.
+func (m *MockStreamHandle) Approve(arg0 context.Context, arg1 string, arg2 types.ApprovalStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Approve", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Approve indicates an expected call of Approve.
+func (mr *MockStreamHandleMockRecorder) Approve(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Approve", reflect.TypeOf((*MockStreamHandle)(nil).Approve), arg0, arg1, arg2)
 }
 
 // Cancel mocks base method.

--- a/internal/runtime/mocks/mock_worker_runtime.go
+++ b/internal/runtime/mocks/mock_worker_runtime.go
@@ -36,20 +36,6 @@ func (m *MockWorkerRuntime) EXPECT() *MockWorkerRuntimeMockRecorder {
 	return m.recorder
 }
 
-// Approve mocks base method.
-func (m *MockWorkerRuntime) Approve(arg0 context.Context, arg1 string, arg2 types.ApprovalStatus) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Approve", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Approve indicates an expected call of Approve.
-func (mr *MockWorkerRuntimeMockRecorder) Approve(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Approve", reflect.TypeOf((*MockWorkerRuntime)(nil).Approve), arg0, arg1, arg2)
-}
-
 // Close mocks base method.
 func (m *MockWorkerRuntime) Close() {
 	m.ctrl.T.Helper()
@@ -90,6 +76,20 @@ func (m *MockWorkerRuntime) GetStreamHandle(arg0 context.Context, arg1 string) (
 func (mr *MockWorkerRuntimeMockRecorder) GetStreamHandle(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStreamHandle", reflect.TypeOf((*MockWorkerRuntime)(nil).GetStreamHandle), arg0, arg1)
+}
+
+// OnApproval mocks base method.
+func (m *MockWorkerRuntime) OnApproval(arg0 context.Context, arg1 string, arg2 types.ApprovalStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OnApproval", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// OnApproval indicates an expected call of OnApproval.
+func (mr *MockWorkerRuntimeMockRecorder) OnApproval(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnApproval", reflect.TypeOf((*MockWorkerRuntime)(nil).OnApproval), arg0, arg1, arg2)
 }
 
 // Run mocks base method.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -22,8 +22,8 @@ import (
 // Per-run lifecycle (status, cancel, wait-for-result, event subscription) lives on the
 // handles returned by [Runtime.Run] / [Runtime.GetRunHandle] and
 // [Runtime.Stream] / [Runtime.GetStreamHandle] — not on Runtime itself.
-// Runtime starts or reconnects to runs, resolves out-of-band approvals, and releases
-// shared resources.
+// Runtime starts or reconnects to runs and releases shared resources. Stream approvals go through
+// [StreamHandle.Approve]; [Runtime.OnApproval] remains only for deprecated agent-level compat.
 type Runtime interface {
 	// Run starts one blocking-style agent run and returns a [RunHandle] immediately.
 	// The run continues asynchronously; use [RunHandle.Get] or [RunHandle.Done] to wait for
@@ -46,9 +46,16 @@ type Runtime interface {
 	// Stream starts one streaming agent run and returns a [StreamHandle] immediately.
 	// It does not subscribe to events; call [StreamHandle.Events] on the returned handle.
 	// The runtime mints the run ID exposed by [StreamHandle.ID]. For approvals (tool or
-	// delegation), subscribe via [StreamHandle.Events] and handle CUSTOM events. When using
-	// conversation, set [RunRequest.ConversationID] on the request.
+	// delegation), subscribe via [StreamHandle.Events], handle CUSTOM events, then call
+	// [StreamHandle.Approve]. When using conversation, set [RunRequest.ConversationID] on the request.
 	Stream(ctx context.Context, req *RunRequest) (StreamHandle, error)
+
+	// OnApproval completes a pending stream approval by token. Prefer [StreamHandle.Approve].
+	// Returns [types.ErrApprovalAlreadyResolved] when the token was already completed.
+	//
+	// Deprecated: Use [StreamHandle.Approve] on the handle from [Runtime.Stream] or
+	// [Runtime.GetStreamHandle] instead. This method will be removed in v0.4.0.
+	OnApproval(ctx context.Context, approvalToken string, status types.ApprovalStatus) error
 
 	// GetStreamHandle returns a [StreamHandle] for an existing streaming run identified by
 	// runID (e.g. after a process restart). Use this instead of [Runtime.Stream]
@@ -60,11 +67,6 @@ type Runtime interface {
 	// Returns [ErrRunAlreadyCompleted] when the run has already finished.
 	// Returns [ErrStreamOffsetNotSupported] when the runtime cannot replay at the requested offset.
 	GetStreamHandle(ctx context.Context, runID string) (StreamHandle, error)
-
-	// Approve completes a pending tool approval when the runtime uses out-of-band approval
-	// (e.g. Temporal CompleteActivity). Returns [ErrApprovalAlreadyResolved] when the token
-	// was already completed.
-	Approve(ctx context.Context, approvalToken string, status types.ApprovalStatus) error
 
 	// Close releases runtime resources (connections, workers, background goroutines).
 	Close()
@@ -122,6 +124,11 @@ type StreamHandle interface {
 	// Done returns a channel that is closed when the stream run finishes (success or failure).
 	// Safe to call multiple times; always returns the same channel.
 	Done() <-chan struct{}
+
+	// Approve completes a tool approval request using the token from the approval event
+	// and the chosen status (e.g., [ApprovalStatusApproved] or [ApprovalStatusRejected]).
+	// Returns [ErrApprovalAlreadyResolved] when the token was already completed.
+	Approve(ctx context.Context, approvalToken string, status types.ApprovalStatus) error
 
 	// Events subscribes to this run's event stream starting at fromOffset.
 	// fromOffset == 0 means from the beginning of the run (first-time subscriber).

--- a/internal/runtime/temporal/agent_workflow.go
+++ b/internal/runtime/temporal/agent_workflow.go
@@ -1362,7 +1362,7 @@ func (rt *TemporalRuntime) AgentWorkflowCleanupActivity(ctx context.Context, inp
 
 // AgentToolApprovalActivity blocks until the driver completes it via CompleteActivity.
 // Publishes a CUSTOM (tool_approval / delegation) event to the WorkflowStream so the client
-// can display the approval UI and call OnApproval with the task token.
+// can display the approval UI and call StreamHandle.Approve with the task token.
 // StreamWorkflowID is the workflow whose stream receives the approval event (root or sub-agent root).
 func (rt *TemporalRuntime) AgentToolApprovalActivity(ctx context.Context, input AgentToolApprovalInput) (types.ApprovalStatus, error) {
 	if err := rt.verifyAgentFingerprint(ctx, input.AgentFingerprint, nil); err != nil {

--- a/internal/runtime/temporal/options.go
+++ b/internal/runtime/temporal/options.go
@@ -151,7 +151,7 @@ func WithMetrics(m interfaces.Metrics) Option {
 }
 
 // WithApprovalHandler sets the Run-path approval callback (from agent WithApprovalHandler).
-// Stream uses CUSTOM events + Approve/OnApproval instead.
+// Stream uses CUSTOM events + StreamHandle.Approve instead.
 func WithApprovalHandler(fn types.ApprovalHandler) Option {
 	return func(rt *TemporalRuntime) { rt.approvalHandler = fn }
 }

--- a/internal/runtime/temporal/runtime.go
+++ b/internal/runtime/temporal/runtime.go
@@ -66,7 +66,7 @@ type TemporalRuntime struct {
 	logger logger.Logger
 
 	// approvalHandler is the Run-path approval callback (agent WithApprovalHandler).
-	// Nil when unset. Stream uses CUSTOM events + Approve/OnApproval instead.
+	// Nil when unset. Stream uses CUSTOM events + StreamHandle.Approve instead.
 	approvalHandler types.ApprovalHandler
 
 	// Fingerprint inputs captured at construction; per-run digest from [computeAgentFingerprintFromRuntime].
@@ -305,7 +305,10 @@ func (rt *TemporalRuntime) getActiveWorkflowIDs() []string {
 	return ids
 }
 
-func (rt *TemporalRuntime) Approve(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
+// approve completes a tool approval request using the token from the approval event
+// and the chosen status (e.g., [ApprovalStatusApproved] or [ApprovalStatusRejected]).
+// Returns [ErrApprovalAlreadyResolved] when the token was already completed.
+func (rt *TemporalRuntime) approve(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
 	if status != types.ApprovalStatusApproved && status != types.ApprovalStatusRejected {
 		return fmt.Errorf("invalid approval status: %s", status)
 	}
@@ -575,8 +578,8 @@ func (rt *TemporalRuntime) driveRun(
 					return errors.New("invalid approval status")
 				}
 				approvalResponseCh <- approvalResponse{approvalToken: token, status: status}
-				// TODO: Respond always returns nil today (async OnApproval in driveRun). Later, surface
-				// types.ErrApprovalAlreadyResolved (and other OnApproval errors) to the handler so a
+				// TODO: Respond always returns nil today (async approve in driveRun). Later, surface
+				// types.ErrApprovalAlreadyResolved (and other approve errors) to the handler so a
 				// second UI can dismiss the prompt. Dual-process GetRunHandle is unsupported; document
 				// that only the owner process should handle approvals.
 				return nil
@@ -585,7 +588,7 @@ func (rt *TemporalRuntime) driveRun(
 			rt.approvalHandler(approvalCtx, apprReq)
 			cancel()
 		case resp := <-approvalResponseCh:
-			if err := rt.OnApproval(runCtx, resp.approvalToken, resp.status); err != nil {
+			if err := rt.approve(runCtx, resp.approvalToken, resp.status); err != nil {
 				if errors.Is(err, types.ErrApprovalAlreadyResolved) {
 					rt.logger.Debug(runCtx, "runtime approval already resolved",
 						slog.String("scope", "runtime"))
@@ -659,6 +662,12 @@ func (rt *TemporalRuntime) GetRunHandle(ctx context.Context, runID string) (runt
 	rt.activeRuns.Set(workflowID, handle)
 	go rt.driveRun(runCtx, runCancel, workflowID, handle, approvalEventCh, streamClient, subscribeCancel)
 	return handle, nil
+}
+
+// OnApproval is a deprecated Runtime-interface wrapper around [TemporalRuntime.approve].
+// Prefer [runtime.StreamHandle.Approve]. Removed in v0.4.0.
+func (rt *TemporalRuntime) OnApproval(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
+	return rt.approve(ctx, approvalToken, status)
 }
 
 // Stream starts the agent Temporal workflow and returns a [runtime.StreamHandle] immediately.
@@ -940,32 +949,6 @@ func (rt *TemporalRuntime) isPendingApproval(ctx context.Context, workflowID str
 		return true
 	}
 	return pending
-}
-
-// OnApproval completes a tool approval when using ExecuteStream. Pass the string from ev.Approval
-// (see the streaming examples) along with the chosen status.
-//
-// Returns [types.ErrApprovalAlreadyResolved] when the approval token refers to an activity that
-// has already been completed. This can happen after Events (reconnect) replays a CUSTOM event for an
-// approval that was resolved while the subscriber was disconnected. Treat it as informational.
-func (rt *TemporalRuntime) OnApproval(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
-	if status != types.ApprovalStatusApproved && status != types.ApprovalStatusRejected {
-		return fmt.Errorf("invalid approval status: %s", status)
-	}
-	taskToken, err := base64.StdEncoding.DecodeString(approvalToken)
-	if err != nil {
-		return fmt.Errorf("invalid approval token: %w", err)
-	}
-	if err := rt.temporalClient.CompleteActivity(ctx, taskToken, status, nil); err != nil {
-		if isNotFoundError(err) {
-			rt.logger.Debug(ctx, "runtime: approval already resolved, returning sentinel",
-				slog.String("scope", "runtime"),
-				slog.String("status", string(status)))
-			return types.ErrApprovalAlreadyResolved
-		}
-		return err
-	}
-	return nil
 }
 
 // isNotFoundError reports whether err is a Temporal "not found" service error, which is returned

--- a/internal/runtime/temporal/runtime_test.go
+++ b/internal/runtime/temporal/runtime_test.go
@@ -167,33 +167,33 @@ func TestTruncateUTF8String(t *testing.T) {
 
 func TestApprove_InvalidStatus(t *testing.T) {
 	rt := &TemporalRuntime{}
-	err := rt.Approve(context.Background(), "dGVzdA==", types.ApprovalStatusPending)
+	err := rt.approve(context.Background(), "dGVzdA==", types.ApprovalStatusPending)
 	if err == nil || !strings.Contains(err.Error(), "invalid approval status") {
-		t.Fatalf("Approve = %v", err)
+		t.Fatalf("approve = %v", err)
 	}
 }
 
 func TestApprove_InvalidToken(t *testing.T) {
 	rt := &TemporalRuntime{}
-	err := rt.Approve(context.Background(), "not-valid-base64!!!", types.ApprovalStatusApproved)
+	err := rt.approve(context.Background(), "not-valid-base64!!!", types.ApprovalStatusApproved)
 	if err == nil || !strings.Contains(err.Error(), "invalid approval token") {
-		t.Fatalf("Approve = %v", err)
+		t.Fatalf("approve = %v", err)
 	}
 }
 
 func TestOnApproval_InvalidStatus(t *testing.T) {
 	rt := &TemporalRuntime{}
-	err := rt.OnApproval(context.Background(), "dGVzdA==", types.ApprovalStatusNone)
+	err := rt.approve(context.Background(), "dGVzdA==", types.ApprovalStatusNone)
 	if err == nil || !strings.Contains(err.Error(), "invalid approval status") {
-		t.Fatalf("OnApproval = %v", err)
+		t.Fatalf("approve = %v", err)
 	}
 }
 
 func TestOnApproval_InvalidToken(t *testing.T) {
 	rt := &TemporalRuntime{}
-	err := rt.OnApproval(context.Background(), "###", types.ApprovalStatusRejected)
+	err := rt.approve(context.Background(), "###", types.ApprovalStatusRejected)
 	if err == nil || !strings.Contains(err.Error(), "invalid approval token") {
-		t.Fatalf("OnApproval = %v", err)
+		t.Fatalf("approve = %v", err)
 	}
 }
 
@@ -1033,8 +1033,8 @@ func TestTemporalRuntime_Approve_CompleteActivity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := rt.Approve(context.Background(), token, types.ApprovalStatusApproved); err != nil {
-		t.Fatalf("Approve: %v", err)
+	if err := rt.approve(context.Background(), token, types.ApprovalStatusApproved); err != nil {
+		t.Fatalf("approve: %v", err)
 	}
 }
 
@@ -1058,12 +1058,12 @@ func TestTemporalRuntime_Approve_SecondCallAlreadyResolved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := rt.Approve(context.Background(), token, types.ApprovalStatusApproved); err != nil {
-		t.Fatalf("first Approve: %v", err)
+	if err := rt.approve(context.Background(), token, types.ApprovalStatusApproved); err != nil {
+		t.Fatalf("first approve: %v", err)
 	}
-	err = rt.Approve(context.Background(), token, types.ApprovalStatusApproved)
+	err = rt.approve(context.Background(), token, types.ApprovalStatusApproved)
 	if !errors.Is(err, types.ErrApprovalAlreadyResolved) {
-		t.Fatalf("second Approve: got %v, want ErrApprovalAlreadyResolved", err)
+		t.Fatalf("second approve: got %v, want ErrApprovalAlreadyResolved", err)
 	}
 }
 
@@ -1083,7 +1083,7 @@ func TestTemporalRuntime_OnApproval_AlreadyResolved(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = rt.OnApproval(context.Background(), token, types.ApprovalStatusRejected)
+	err = rt.approve(context.Background(), token, types.ApprovalStatusRejected)
 	if !errors.Is(err, types.ErrApprovalAlreadyResolved) {
 		t.Fatalf("got %v, want ErrApprovalAlreadyResolved", err)
 	}

--- a/internal/runtime/temporal/stream_handle.go
+++ b/internal/runtime/temporal/stream_handle.go
@@ -52,6 +52,19 @@ func newStreamHandle(
 	}
 }
 
+// Approve completes a pending tool or delegation approval for this stream run.
+// Pass the approval token from the CUSTOM event Value and the chosen status.
+//
+// Returns [types.ErrApprovalAlreadyResolved] when the approval token refers to an activity that
+// has already been completed. This can happen after Events (reconnect) replays a CUSTOM event for an
+// approval that was resolved while the subscriber was disconnected. Treat it as informational.
+func (h *streamHandle) Approve(ctx context.Context, approvalToken string, status types.ApprovalStatus) error {
+	if h.rt == nil {
+		return fmt.Errorf("temporal: stream handle %q is not configured", h.id)
+	}
+	return h.rt.approve(ctx, approvalToken, status)
+}
+
 // Events subscribes to this run's event stream starting at fromOffset.
 // fromOffset == 0 emits synthetic RUN_STARTED; fromOffset > 0 resumes after reconnect.
 // Returns [types.ErrRunNotFound] / [types.ErrRunAlreadyCompleted] from the

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -10,10 +10,11 @@ var ErrTemporalDialTimeout = errors.New("temporal: dial timeout — could not co
 // complete within the configured timeout after connecting to the Temporal server.
 var ErrTemporalNamespaceCheckTimeout = errors.New("temporal: namespace check timeout — namespace may not exist or server is overloaded")
 
-// ErrApprovalAlreadyResolved is returned by [Runtime.Approve] when the approval token refers to an
-// activity task that has already been completed (approved or rejected). This happens when a
-// reconnecting subscriber replays a CUSTOM approval event that was resolved while the subscriber
-// was disconnected. Callers should treat this as informational: the run is already advancing.
+// ErrApprovalAlreadyResolved is returned by [StreamHandle.Approve] (and the deprecated
+// Runtime.OnApproval) when the approval token refers to an activity task that has already been
+// completed (approved or rejected). This happens when a reconnecting subscriber replays a CUSTOM
+// approval event that was resolved while the subscriber was disconnected. Callers should treat
+// this as informational: the run is already advancing.
 var ErrApprovalAlreadyResolved = errors.New("runtime: approval already resolved")
 
 // ErrRunNotFound is returned when a runID is not recognised by the runtime

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -202,7 +202,7 @@ func copyApprovalArgs(src map[string]any) map[string]any {
 // Set opts.DisableTokenStreaming = true to receive a single complete message instead.
 //
 // For approvals (tool or delegation), receive [AgentEventTypeCustom] events from the Events channel
-// and call [Agent.OnApproval] with the token extracted from the payload.
+// and call [AgentStream.Approve] with the token extracted from the payload.
 // When using [WithConversation], pass the conversation ID in opts.
 func (a *Agent) Stream(ctx context.Context, input string, opts *AgentStreamOptions) (AgentStream, error) {
 	ctx = a.attachMemoryScopeContext(ctx)

--- a/pkg/agent/agent_stream.go
+++ b/pkg/agent/agent_stream.go
@@ -96,6 +96,11 @@ type AgentStream interface {
 	// Safe to call multiple times; always returns the same channel.
 	Done() <-chan struct{}
 
+	// Approve completes a tool or delegation approval using the token from the CUSTOM approval
+	// event and the chosen status ([ApprovalStatusApproved] or [ApprovalStatusRejected]).
+	// Returns [ErrApprovalAlreadyResolved] when the token was already completed.
+	Approve(ctx context.Context, approvalToken string, status ApprovalStatus) error
+
 	// Events subscribes to the agent event stream and returns a receive-only channel.
 	// The channel is closed after the terminal lifecycle event (RUN_FINISHED / RUN_ERROR),
 	// or when ctx is cancelled (Temporal: stops this subscriber only; the agent run continues).
@@ -180,6 +185,14 @@ func (s *agentStream) Done() <-chan struct{} {
 		return ch
 	}
 	return s.sh.Done()
+}
+
+// Approve delegates to [runtime.StreamHandle.Approve].
+func (s *agentStream) Approve(ctx context.Context, approvalToken string, status ApprovalStatus) error {
+	if s.sh == nil {
+		return ErrRunNotFound
+	}
+	return s.sh.Approve(ctx, approvalToken, status)
 }
 
 // Events resolves opts into an offset, then delegates to [runtime.StreamHandle.Events].

--- a/pkg/agent/agent_stream_test.go
+++ b/pkg/agent/agent_stream_test.go
@@ -286,6 +286,27 @@ func TestAgent_GetAgentStream_StatusAndCancelDelegate(t *testing.T) {
 	}
 }
 
+func TestAgent_GetAgentStream_ApproveDelegates(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRT := rtmocks.NewMockRuntime(ctrl)
+	h := rtmocks.NewMockStreamHandle(ctrl)
+	mockRT.EXPECT().GetStreamHandle(gomock.Any(), "s1").Return(h, nil)
+	h.EXPECT().ID().Return("s1").AnyTimes()
+	done := make(chan struct{})
+	h.EXPECT().Done().Return((<-chan struct{})(done)).AnyTimes()
+	h.EXPECT().Approve(gomock.Any(), "tok", types.ApprovalStatusApproved).Return(nil)
+
+	a := testAgentWithRuntime(mockRT)
+	agentStream, err := a.GetAgentStream(context.Background(), "s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := agentStream.Approve(context.Background(), "tok", ApprovalStatusApproved); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestAgent_Stream_GetAndDone(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -351,7 +351,7 @@ func TestAgent_OnApproval(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockRT := rtmocks.NewMockRuntime(ctrl)
-	mockRT.EXPECT().Approve(gomock.Any(), "tok", types.ApprovalStatusApproved).Return(nil)
+	mockRT.EXPECT().OnApproval(gomock.Any(), "tok", types.ApprovalStatusApproved).Return(nil)
 
 	a := testAgentWithRuntime(mockRT)
 	if err := a.OnApproval(context.Background(), "tok", types.ApprovalStatusApproved); err != nil {

--- a/pkg/agent/approval.go
+++ b/pkg/agent/approval.go
@@ -6,10 +6,11 @@ import (
 	"github.com/agenticenv/agent-sdk-go/internal/types"
 )
 
-// ErrApprovalAlreadyResolved is returned by [Agent.OnApproval] when the approval token refers to
-// an activity task that has already been completed (approved or rejected). This can happen when a
-// reconnecting subscriber replays a CUSTOM approval event for an approval that was resolved while
-// the subscriber was disconnected. Treat it as informational — the run is already advancing.
+// ErrApprovalAlreadyResolved is returned by [AgentStream.Approve] (and the deprecated
+// [Agent.OnApproval]) when the approval token refers to an activity task that has already been
+// completed (approved or rejected). This can happen when a reconnecting subscriber replays a
+// CUSTOM approval event for an approval that was resolved while the subscriber was disconnected.
+// Treat it as informational — the run is already advancing.
 var ErrApprovalAlreadyResolved = types.ErrApprovalAlreadyResolved
 
 type ApprovalStatus = types.ApprovalStatus
@@ -31,7 +32,7 @@ type ApprovalSender = types.ApprovalSender
 // Register once at [NewAgent] via [WithApprovalHandler] (construction-time, not per-call).
 // req.Respond is always set: call req.Respond(ApprovalStatusApproved) or Rejected when ready.
 // The handler may return immediately after starting async work. Multiple invocations may run
-// concurrently when tools are invoked in parallel. For streaming approvals use [Agent.OnApproval].
+// concurrently when tools are invoked in parallel. For streaming approvals use [AgentStream.Approve].
 type ApprovalHandler = types.ApprovalHandler
 
 // ApprovalRequestName classifies approval callbacks (aligned with CUSTOM event roles).
@@ -45,7 +46,7 @@ const (
 // ApprovalRequest describes a pending tool approval for [Agent.Run].
 // Name + Value mirror CUSTOM stream events; use [ParseToolApproval] / [ParseDelegationApproval].
 // Respond is always set; call it once with ApprovalStatusApproved or ApprovalStatusRejected.
-// For streaming approvals, use [Agent.OnApproval] with the approval token from the CUSTOM event Value.
+// For streaming approvals, use [AgentStream.Approve] with the approval token from the CUSTOM event Value.
 type ApprovalRequest = types.ApprovalRequest
 
 // ToolApprovalRequestValue is the decoded Value for tool approvals (matches CUSTOM approval payload).
@@ -64,8 +65,12 @@ func ParseDelegationApproval(req *ApprovalRequest) (SubAgentDelegationApprovalRe
 	return types.ParseDelegationApproval(req)
 }
 
-// OnApproval completes a tool approval when using [Agent.Stream]. Pass the token from the approval
-// event and the chosen status (see streaming examples).
+// OnApproval completes a pending tool or delegation approval when using [Agent.Stream].
+// Pass the approval token from the CUSTOM event Value and [ApprovalStatusApproved] or
+// [ApprovalStatusRejected].
+//
+// Deprecated: Use [AgentStream.Approve] on the handle from [Agent.Stream] or
+// [Agent.GetAgentStream] instead. This method will be removed in v0.4.0.
 func (a *Agent) OnApproval(ctx context.Context, approvalToken string, status ApprovalStatus) error {
-	return a.runtime.Approve(ctx, approvalToken, status)
+	return a.runtime.OnApproval(ctx, approvalToken, status)
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -411,7 +411,7 @@ func WithLogLevel(level string) Option {
 // WithApprovalHandler registers the approval callback once at [NewAgent] construction time for
 // [Agent.Run]. Required when tools need approval. The callback receives req
 // with req.Respond set; call req.Respond(Approved|Rejected). Agent only; [Agent.Stream] uses
-// [Agent.OnApproval] on CUSTOM events instead.
+// [AgentStream.Approve] on CUSTOM events instead.
 func WithApprovalHandler(fn types.ApprovalHandler) Option {
 	return func(c *agentConfig) { c.approvalHandler = fn }
 }

--- a/pkg/agent/mocks/mock_agent_stream.go
+++ b/pkg/agent/mocks/mock_agent_stream.go
@@ -37,6 +37,20 @@ func (m *MockAgentStream) EXPECT() *MockAgentStreamMockRecorder {
 	return m.recorder
 }
 
+// Approve mocks base method.
+func (m *MockAgentStream) Approve(arg0 context.Context, arg1 string, arg2 types.ApprovalStatus) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Approve", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Approve indicates an expected call of Approve.
+func (mr *MockAgentStreamMockRecorder) Approve(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Approve", reflect.TypeOf((*MockAgentStream)(nil).Approve), arg0, arg1, arg2)
+}
+
 // Cancel mocks base method.
 func (m *MockAgentStream) Cancel(arg0 context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION

## Description

- Add `AgentStream.Approve` / `StreamHandle.Approve` as the preferred stream HITL path (token from CUSTOM events).
- Keep `Agent.OnApproval` / `Runtime.OnApproval` as deprecated wrappers until v0.4.0; share private `approve` in local and Temporal runtimes.
- Point docs, README, examples, and CLI at `stream.Approve` only. Run path stays `WithApprovalHandler` + `req.Respond`.

## Test plan
- [x] `go test ./pkg/agent/ ./internal/runtime/local/ ./internal/runtime/temporal/ -count=1`
- [x] `cd examples && go run ./agent_with_subagents` — answer `y`/`n` on delegation approval
- [x] Spot-check Run approval still works: `go run ./agent_with_tools/approval`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / chore

## Related issues

Closes #55 

## Checklist

- [x] I have run `task check`
- [x] I have run `task examples:all`
- [x] I have run `task tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
