### PR TITLE
fix(temporal): unblock Get/Events on run timeout and terminate  workflows on close

### DIFF
--- a/docs/advanced/timeouts-and-modes.mdx
+++ b/docs/advanced/timeouts-and-modes.mdx
@@ -54,8 +54,6 @@ Used when the context has **no deadline**. Agent-only — ignored by `NewAgentWo
 
 ### What each context does
 
-Use a separate context for starting the run vs waiting or subscribing. Cancelling the wrong one is a common mistake.
-
 | Call | Cancelling its `ctx`… |
 |---|---|
 | `Run(ctx, …)` / `Stream(ctx, …)` | Stops the **agent run** |
@@ -64,18 +62,27 @@ Use a separate context for starting the run vs waiting or subscribing. Cancellin
 | `GetAgentRun(ctx, id)` / `GetAgentStream(ctx, id)` | Only bounds the **reconnect lookup** — run keeps going |
 | `handle.Cancel(ctx)` | Stops the **agent run** (explicit stop) |
 
-**App pattern:** put the run lifetime on `Run` / `Stream`. Put short deadlines on `Get` / `Events` when you only want to stop waiting or unsubscribing. After a crash, reconnect with `GetAgentRun` / `GetAgentStream`, then wait again with `Get` / `Events`. Call `Cancel()` on the handle when you want to stop the run.
+**Common case — pass the same ctx to both `Run` and `Get`:**
 
 ```go
-// This ctx owns the run — cancel or deadline here stops the agent.
-runCtx, cancelRun := context.WithTimeout(context.Background(), 5*time.Minute)
-defer cancelRun()
-run, err := a.Run(runCtx, prompt, nil)
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+defer cancel()
+run, err := a.Run(ctx, prompt, nil)
+result, err := run.Get(ctx) // unblocks when the run finishes or the timeout fires
+```
 
-// This ctx only bounds how long you wait — canceling it does not stop the run.
+When the ctx fires, `driveRun` cancels the workflow and `Get` returns `context.DeadlineExceeded`. If the run finishes first, `Get` returns the result. Either way the behaviour is correct and predictable.
+
+**Advanced — separate wait ctx (reconnect / partial wait):** use a different, shorter ctx on `Get` only when you want to stop waiting and reconnect later while leaving the run alive.
+
+```go
+run, err := a.Run(runCtx, prompt, nil) // runCtx owns the run lifetime
+
+// Stop waiting after 30 s but leave the run alive.
 waitCtx, cancelWait := context.WithTimeout(context.Background(), 30*time.Second)
 defer cancelWait()
-result, err := run.Get(waitCtx)
+result, err := run.Get(waitCtx) // returns context.DeadlineExceeded if still running
+// ... reconnect later with GetAgentRun(runID)
 ```
 
 ### Timeouts after reconnect (Temporal)
@@ -83,7 +90,7 @@ result, err := run.Get(waitCtx)
 `GetAgentRun` / `GetAgentStream` do not take over the original `Run` / `Stream` context.
 
 - Cancelling the reconnect `ctx` does **not** stop the run.
-- If the agent has `WithTimeout`, that limit applies again from the moment you reconnect — it is a **fresh** timeout, not “time left” from the original start.
+- If the agent has `WithTimeout`, that limit applies again from the moment you reconnect — it is a **fresh** timeout, not “time left” from the original start. A run that executed for 4 minutes before a crash gets a full fresh timeout window after reconnect. If you need a hard ceiling across the full run lifetime, call `Cancel()` on the handle after reconnect instead of relying on `WithTimeout`.
 - To stop the run after reconnect, call `Cancel()` on the handle.
 
 ## Agent modes
@@ -179,7 +186,8 @@ If `finish_reason: max_iterations` appears in telemetry but the task wasn't comp
 | Failure | `Run` (`Get`) | `Stream` |
 |---|---|---|
 | **Context deadline exceeded** | On `Run`/`Stream` ctx: cancels the run. On `Get` ctx only: unblocks waiter (run continues) | On `Stream` ctx: cancels run, emits `AgentEventTypeRunError`. On `Events` ctx only: subscriber stops (Temporal; run continues) |
-| **Agent timeout fires** | `Get` returns timeout error | Emits `AgentEventTypeRunError` |
+| **Agent timeout fires** | `Get` returns `context.DeadlineExceeded` | Emits `AgentEventTypeRunError` with message `"context deadline exceeded"` |
+| **Explicit `Cancel()` / Run or Stream ctx cancelled** | `Get` returns `context.Canceled` | Emits `AgentEventTypeRunError` with message `"context canceled"` |
 | **Approval timeout** | `Get` returns error after approval window expires | Emits `AgentEventTypeRunError` |
 | **Max iterations reached** | `Get` returns result with `FinishReason: max_iterations` | Emits `RUN_FINISHED` with reason set |
 | **LLM provider error** | `Get` returns the provider error | Emits `AgentEventTypeRunError` |

--- a/examples/durable_agent/README.md
+++ b/examples/durable_agent/README.md
@@ -40,7 +40,7 @@ TEMPORAL_TASKQUEUE=agent-sdk-go-durable-agent
 
 Both `agent` and `worker` read the same values via `[config.LoadFromEnv()](../config.go)`. Override any `TEMPORAL_*` variable for your environment.
 
-4. **Temporal server** — Docker must be available. Start with:
+1. **Temporal server** — Docker must be available. Start with:
 
 ```bash
 task infra:temporal:up && task infra:temporal:wait
@@ -159,7 +159,7 @@ Wait for the REPL prompt, then type:
 Hello from remote agent!
 ```
 
-> **Note:** This scenario intentionally exercises the no-worker path. With no pollers on the task queue, the SDK checks Temporal before starting the stream (~**15 seconds**). If a worker **was** running recently, Temporal may still list stale pollers briefly — the stream can start, the workflow queues, and you wait for the run timeout instead (**3 minutes** in this example via `WithTimeout` in `[opts/opts.go](opts/opts.go)`). After either error, start the worker and resend — that is the expected flow.
+> **Note:** This scenario intentionally exercises the no-worker path. With no pollers on the task queue, the SDK checks Temporal before starting the stream (~**15 seconds**). If a worker **was** running recently, Temporal may still list stale pollers briefly — the stream can start, the workflow queues, and you wait for the run timeout instead (**3 minutes** in this example via `WithTimeout` in `[opts/opts.go](opts/opts.go)`). On timeout the SDK terminates the workflow and the agent stream surfaces `[error] context deadline exceeded` (no worker required to finish cancel). After either error, start the worker and **resend** the prompt — that is the expected flow.
 
 **Expected behavior — depends on timing:**
 
@@ -186,7 +186,7 @@ you>
 
 Check the Temporal Web UI — a workflow may appear even when no worker is executing tasks.
 
-**Learn:** The first error is expected — interactive mode fails fast when no worker is polling, instead of hanging forever.
+**Learn:** Path A fails fast when no worker is polling. Path B waits for `WithTimeout` then errors clearly — the agent must not hang, and starting a worker after timeout does not “revive” a timed-out run (resend a new prompt instead).
 
 **Terminal 1 — now start the worker:**
 
@@ -385,7 +385,7 @@ What to look for in terminal 2 (stream pauses, no immediate error):
 The stream goes silent — Temporal is waiting for a worker to poll and resume the in-flight activity. No worker is available so no events are sent to the agent stream. After the run timeout (**3 minutes** in this example) the error surfaces:
 
 ```text
-[error] request timed out (approval expired or deadline exceeded)
+[error] context deadline exceeded
 --- stream end ---
 
 you>
@@ -675,7 +675,7 @@ The state file is cleared on `RUN_FINISHED`. The REPL then continues normally.
 
 The state file is cleared. The work **was done** — Temporal completed the run and the LLM generated the full response. The loss is only the streaming view of it:
 
-- **With `WithConversation` configured** — the response is already in conversation history. Start a new turn and continue naturally; the agent remembers the previous answer.
+- **With** `WithConversation` **configured** — the response is already in conversation history. Start a new turn and continue naturally; the agent remembers the previous answer.
 - **Without conversation (this example)** — the response is not visible. Start a new run to get a fresh response.
 
 > **Note:** The `durable_agent` example does not wire up multi-turn conversation history. For production apps where users expect full history across restarts, use **[Agent Chat](https://github.com/agenticenv/agent-chat)** which persists conversation turns to Postgres.
@@ -757,7 +757,7 @@ go run ./durable_agent/agent
 you> Hello from remote agent!
 ```
 
-> **Note:** Same timing as scenario 2 — the agent checks pollers on **`agent-sdk-go-durable-agent`**, not the worker’s queue. With no pollers there (~**15 seconds**), path **A** is typical. Stale pollers on the agent queue from an earlier run can produce path **B** (**3 minutes** run timeout).
+> **Note:** Same timing as scenario 2 — the agent checks pollers on `agent-sdk-go-durable-agent`, not the worker’s queue. With no pollers there (~**15 seconds**), path **A** is typical. Stale pollers on the agent queue from an earlier run can produce path **B** (**3 minutes** run timeout).
 
 **Expected behavior — depends on timing:**
 
@@ -776,7 +776,7 @@ No `--- stream start ---` — the stream never opened.
 ```text
 --- stream start ---
 
-[error] request timed out (approval expired or deadline exceeded)
+[error] context deadline exceeded
 --- stream end ---
 
 you>
@@ -787,5 +787,4 @@ Check the Temporal Web UI — a workflow may appear on `agent-sdk-go-durable-age
 Misconfiguration surfaces clearly rather than silently corrupting state. Stop the worker and restart both processes with matching `TEMPORAL_TASKQUEUE` (or remove the override) to recover.
 
 > **Tip:** For `AgentModeAutonomous`, the worker check is skipped entirely — a task queue mismatch will not error immediately but will cause the workflow to queue in Temporal until the agent timeout hits. Always verify task queue names match across agent and worker config before deploying.
-
 

--- a/internal/runtime/temporal/run_handle.go
+++ b/internal/runtime/temporal/run_handle.go
@@ -2,6 +2,7 @@ package temporal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -40,6 +41,10 @@ type runHandle struct {
 	mu  sync.Mutex
 	res *types.AgentRunResult
 	err error
+	// stopCause is set by driveRun/driveStream when the run context ends
+	// (DeadlineExceeded = WithTimeout / Stream|Run ctx deadline; Canceled = Cancel()).
+	// Events uses it to emit a clear terminal error without requiring an Events ctx deadline.
+	stopCause error
 }
 
 // newRunHandle creates a handle for runID / workflowID.
@@ -114,6 +119,25 @@ func (h *runHandle) Get(ctx context.Context) (*types.AgentRunResult, error) {
 // Done returns the channel closed when the workflow finishes.
 func (h *runHandle) Done() <-chan struct{} { return h.doneCh }
 
+// setStopCause records why the run context ended. First writer wins.
+func (h *runHandle) setStopCause(err error) {
+	if err == nil {
+		return
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.stopCause == nil {
+		h.stopCause = err
+	}
+}
+
+// StopCause returns the run-context error that stopped the run, or nil.
+func (h *runHandle) StopCause() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.stopCause
+}
+
 // awaitCompletion waits for the Temporal workflow result and closes Done.
 // Uses context.Background so a cancelled Get caller does not abort the wait.
 // Burns cancelOnce (clears cancel without calling it) so later Cancel is already-completed,
@@ -139,6 +163,16 @@ func (h *runHandle) awaitCompletion() {
 		result.RunID = h.id
 	}
 	h.mu.Lock()
+	// Map raw Temporal termination errors to clean sentinel values so callers
+	// can use errors.Is rather than string-matching Temporal internals.
+	if err != nil {
+		switch {
+		case errors.Is(h.stopCause, context.DeadlineExceeded):
+			err = context.DeadlineExceeded
+		case errors.Is(h.stopCause, context.Canceled):
+			err = context.Canceled
+		}
+	}
 	h.err = err
 	h.res = result
 	h.mu.Unlock()

--- a/internal/runtime/temporal/run_handle_test.go
+++ b/internal/runtime/temporal/run_handle_test.go
@@ -195,6 +195,42 @@ func TestRunHandle_Get_WaitsForWorkflow(t *testing.T) {
 	}
 }
 
+// TestRunHandle_Get_RunContextTimeout verifies that when the run stops because its context
+// deadline fired (WithTimeout or Run ctx), Get(Background) returns context.DeadlineExceeded
+// rather than the raw Temporal "terminated" error string.
+func TestRunHandle_Get_RunContextTimeout(t *testing.T) {
+	release := make(chan struct{})
+	termErr := errors.New("workflow terminated: agent run timeout")
+
+	tc := temporalmocks.NewClient(t)
+	wfRun := blockingWorkflowRun(release, nil, termErr)
+	h := newTestRunHandle("run-1", "wf-1", tc, wfRun, nil)
+	h.setStopCause(context.DeadlineExceeded)
+
+	close(release)
+
+	_, err := h.Get(context.Background())
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestRunHandle_Get_RunContextCanceled verifies that when the run stops because it was
+// explicitly cancelled (Cancel() or Run ctx cancelled), Get(Background) returns
+// context.Canceled rather than the raw Temporal "terminated" error string.
+func TestRunHandle_Get_RunContextCanceled(t *testing.T) {
+	release := make(chan struct{})
+	termErr := errors.New("workflow terminated: run cancelled")
+
+	tc := temporalmocks.NewClient(t)
+	wfRun := blockingWorkflowRun(release, nil, termErr)
+	h := newTestRunHandle("run-1", "wf-1", tc, wfRun, nil)
+	h.setStopCause(context.Canceled)
+
+	close(release)
+
+	_, err := h.Get(context.Background())
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestRunHandle_Cancel_Running(t *testing.T) {
 	release := make(chan struct{})
 	var cancelled atomic.Bool

--- a/internal/runtime/temporal/runtime.go
+++ b/internal/runtime/temporal/runtime.go
@@ -211,9 +211,10 @@ func (rt *TemporalRuntime) Stop() {
 	}
 }
 
-// stopWorkflow cancels a workflow; if cancel fails, terminates it.
-// reason is recorded on TerminateWorkflow only.
-func (rt *TemporalRuntime) stopWorkflow(ctx context.Context, workflowID, reason string) {
+// cancelWorkflow cancels a workflow; if the Cancel RPC fails, terminates it.
+// Note: a successful Cancel with no worker still leaves Cancel Requested — callers that
+// must not strand the workflow should use [TemporalRuntime.stopWorkflow].
+func (rt *TemporalRuntime) cancelWorkflow(ctx context.Context, workflowID, reason string) {
 	if rt.temporalClient == nil || workflowID == "" {
 		return
 	}
@@ -226,6 +227,52 @@ func (rt *TemporalRuntime) stopWorkflow(ctx context.Context, workflowID, reason 
 			slog.String("workflowID", workflowID),
 			slog.Any("error", err))
 		_ = rt.temporalClient.TerminateWorkflow(ctx, workflowID, "", reason)
+	}
+}
+
+// terminateWorkflow force-stops a workflow so awaitCompletion/Get/Events can finish
+// even when no worker is available to process a Cancel.
+func (rt *TemporalRuntime) terminateWorkflow(ctx context.Context, workflowID, reason string) {
+	if rt.temporalClient == nil || workflowID == "" {
+		return
+	}
+	rt.logger.Debug(ctx, "runtime terminating workflow",
+		slog.String("scope", "runtime"),
+		slog.String("workflowID", workflowID),
+		slog.String("reason", reason))
+	_ = rt.temporalClient.TerminateWorkflow(ctx, workflowID, "", reason)
+}
+
+// stopWorkflow stops a workflow after the run context ends, then waits for done.
+//
+//   - DeadlineExceeded (WithTimeout / Run|Stream ctx deadline): Terminate immediately so
+//     subscribers unblock with a timeout error even when no worker is polling.
+//   - Otherwise (explicit Cancel / parent cancel): Cancel first, then Terminate if the
+//     workflow is still open after 3s (no-worker Cancel Requested hang).
+//
+// done is the handle Done channel from newRunHandle (always non-nil in production).
+func (rt *TemporalRuntime) stopWorkflow(
+	stopCtx context.Context,
+	workflowID string,
+	runErr error,
+	done <-chan struct{},
+) {
+	if errors.Is(runErr, context.DeadlineExceeded) {
+		rt.terminateWorkflow(stopCtx, workflowID, "run timeout")
+		<-done
+		return
+	}
+
+	rt.cancelWorkflow(stopCtx, workflowID, "run cancelled")
+	select {
+	case <-done:
+		return
+	case <-time.After(3 * time.Second):
+		rt.terminateWorkflow(stopCtx, workflowID, "run cancelled")
+		select {
+		case <-done:
+		case <-stopCtx.Done():
+		}
 	}
 }
 
@@ -270,9 +317,7 @@ func (rt *TemporalRuntime) Close() {
 	if rt.temporalClient != nil {
 		termCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
-		for _, workflowID := range rt.getActiveWorkflowIDs() {
-			rt.stopWorkflow(termCtx, workflowID, "agent closed")
-		}
+		rt.stopActiveWorkflows(termCtx)
 	}
 
 	if rt.agentWorker != nil {
@@ -287,22 +332,51 @@ func (rt *TemporalRuntime) Close() {
 	rt.logger.Info(ctx, "runtime closed", slog.String("scope", "runtime"), slog.String("name", rt.AgentSpec.Name))
 }
 
-func (rt *TemporalRuntime) getActiveWorkflowIDs() []string {
-	n := 0
+// stopActiveWorkflows terminates all live run/stream workflows in parallel, then
+// waits for each to reach a terminal state (bounded by ctx).
+//
+// Close uses Terminate directly — not the cancel-then-3s-then-terminate path used
+// by explicit Cancel/timeout — because the agent is shutting down and no caller
+// will consume the result. The 3s cancel grace exists to let a live handle's
+// workflow run cleanup handlers; on Close there is no one left to receive them.
+// All workflows are sent Terminate simultaneously so shutdown time is constant
+// regardless of how many active runs/streams exist.
+func (rt *TemporalRuntime) stopActiveWorkflows(ctx context.Context) {
+	const reason = "agent closed"
+	var wg sync.WaitGroup
+
+	launch := func(workflowID string, done <-chan struct{}) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rt.terminateWorkflow(ctx, workflowID, reason)
+			select {
+			case <-done:
+			case <-ctx.Done():
+			}
+		}()
+	}
+
 	if rt.activeRuns != nil {
-		n += rt.activeRuns.Len()
+		for _, workflowID := range rt.activeRuns.Keys() {
+			h, ok := rt.activeRuns.Get(workflowID)
+			if !ok || h == nil {
+				continue
+			}
+			launch(workflowID, h.Done())
+		}
 	}
 	if rt.activeStreams != nil {
-		n += rt.activeStreams.Len()
+		for _, workflowID := range rt.activeStreams.Keys() {
+			h, ok := rt.activeStreams.Get(workflowID)
+			if !ok || h == nil {
+				continue
+			}
+			launch(workflowID, h.Done())
+		}
 	}
-	ids := make([]string, 0, n)
-	if rt.activeRuns != nil {
-		ids = append(ids, rt.activeRuns.Keys()...)
-	}
-	if rt.activeStreams != nil {
-		ids = append(ids, rt.activeStreams.Keys()...)
-	}
-	return ids
+
+	wg.Wait()
 }
 
 // approve completes a tool approval request using the token from the approval event
@@ -498,8 +572,8 @@ type approvalResponse struct {
 }
 
 // driveRun watches the run until [runHandle.Done], delivering approvals when configured.
-// On runCtx cancellation (timeout/cancel), cancels the workflow (terminate if cancel fails)
-// so the handle's await can finish.
+// On runCtx cancellation (timeout/cancel), stops the workflow so Get/Events can finish
+// (see [TemporalRuntime.stopWorkflow]).
 func (rt *TemporalRuntime) driveRun(
 	runCtx context.Context,
 	runCancel context.CancelFunc,
@@ -543,14 +617,15 @@ func (rt *TemporalRuntime) driveRun(
 			}
 			return
 		case <-runCtx.Done():
+			runErr := runCtx.Err()
 			rt.logger.Debug(runCtx, "runtime run cancelled",
 				slog.String("scope", "runtime"),
 				slog.String("workflowID", workflowID),
-				slog.Any("error", runCtx.Err()))
+				slog.Any("error", runErr))
+			handle.setStopCause(runErr)
 			stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
-			rt.stopWorkflow(stopCtx, workflowID, "run cancelled")
+			rt.stopWorkflow(stopCtx, workflowID, runErr, handle.Done())
 			stopCancel()
-			<-handle.Done()
 			return
 		case ev, ok := <-approvalEventCh:
 			if !ok {
@@ -881,7 +956,8 @@ func (rt *TemporalRuntime) newDriveContext(parent context.Context) (context.Cont
 }
 
 // driveStream watches the stream until [streamHandle.Done].
-// On runCtx cancellation (timeout/cancel), stops the workflow so await can finish.
+// On runCtx cancellation (timeout/cancel), stops the workflow so await/Events can finish
+// (see [TemporalRuntime.stopWorkflow]).
 // No approval subscription — Stream uses Events + Approve instead of driveRun's path.
 func (rt *TemporalRuntime) driveStream(
 	runCtx context.Context,
@@ -894,14 +970,15 @@ func (rt *TemporalRuntime) driveStream(
 	case <-handle.Done():
 		return
 	case <-runCtx.Done():
+		runErr := runCtx.Err()
 		rt.logger.Debug(runCtx, "runtime stream cancelled",
 			slog.String("scope", "runtime"),
 			slog.String("workflowID", workflowID),
-			slog.Any("error", runCtx.Err()))
+			slog.Any("error", runErr))
+		handle.setStopCause(runErr)
 		stopCtx, stopCancel := context.WithTimeout(context.Background(), 15*time.Second)
-		rt.stopWorkflow(stopCtx, workflowID, "run cancelled")
+		rt.stopWorkflow(stopCtx, workflowID, runErr, handle.Done())
 		stopCancel()
-		<-handle.Done()
 	}
 }
 

--- a/internal/runtime/temporal/runtime_test.go
+++ b/internal/runtime/temporal/runtime_test.go
@@ -586,34 +586,57 @@ func TestTemporalRuntime_Close_StopsWorkers(t *testing.T) {
 	}
 }
 
-// TestTemporalRuntime_Close_ActiveWorkflows_CancelSucceeds verifies Close() prefers a graceful
-// CancelWorkflow over TerminateWorkflow when cancellation succeeds.
-func TestTemporalRuntime_Close_ActiveWorkflows_CancelSucceeds(t *testing.T) {
+func TestStopWorkflow_TimeoutTerminatesImmediately(t *testing.T) {
 	tc := temporalmocks.NewClient(t)
+	done := make(chan struct{})
+	tc.On("TerminateWorkflow", mock.Anything, "wf-timeout", "", "run timeout").
+		Run(func(mock.Arguments) { close(done) }).
+		Return(nil).Once()
 
-	tc.On("CancelWorkflow", mock.Anything, "run-w1", "").Return(nil).Once()
-
-	rt, err := NewTemporalRuntime(
-		WithTemporalClient(tc, "tq"),
-		WithAgentSpec(sdkruntime.AgentSpec{Name: "agent-a"}),
-		WithAgentConfig(sdkruntime.AgentConfig{LLM: sdkruntime.AgentLLM{Client: stubLLM{}}}),
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rt.activeRuns.Set("run-w1", &runHandle{})
-
-	rt.Close()
-	tc.AssertExpectations(t) // no TerminateWorkflow call expected/set up; would fail if invoked
+	rt := &TemporalRuntime{temporalClient: tc, logger: logger.NoopLogger()}
+	rt.stopWorkflow(context.Background(), "wf-timeout", context.DeadlineExceeded, done)
+	tc.AssertExpectations(t)
 }
 
-// TestTemporalRuntime_Close_ActiveWorkflows_CancelFailsFallsBackToTerminate verifies Close()
-// falls back to TerminateWorkflow only when CancelWorkflow itself errors.
-func TestTemporalRuntime_Close_ActiveWorkflows_CancelFailsFallsBackToTerminate(t *testing.T) {
+// TestStopWorkflow_CancelFallsBackToTerminate: Cancel RPC succeeds but Done never closes
+// (no worker) → Terminate after the hardcoded 3s grace.
+func TestStopWorkflow_CancelFallsBackToTerminate(t *testing.T) {
 	tc := temporalmocks.NewClient(t)
+	done := make(chan struct{})
+	tc.On("CancelWorkflow", mock.Anything, "wf-cancel", "").Return(nil).Once()
+	tc.On("TerminateWorkflow", mock.Anything, "wf-cancel", "", "run cancelled").
+		Run(func(mock.Arguments) { close(done) }).
+		Return(nil).Once()
 
-	tc.On("CancelWorkflow", mock.Anything, "run-w1", "").Return(errors.New("cancel failed")).Once()
-	tc.On("TerminateWorkflow", mock.Anything, "run-w1", "", "agent closed").Return(nil).Once()
+	rt := &TemporalRuntime{temporalClient: tc, logger: logger.NoopLogger()}
+	start := time.Now()
+	rt.stopWorkflow(context.Background(), "wf-cancel", context.Canceled, done)
+	if elapsed := time.Since(start); elapsed < 3*time.Second {
+		t.Fatalf("expected ~3s grace before terminate, finished in %v", elapsed)
+	}
+	tc.AssertExpectations(t)
+}
+
+func TestStopWorkflow_CancelCompletesWithoutTerminate(t *testing.T) {
+	tc := temporalmocks.NewClient(t)
+	done := make(chan struct{})
+	tc.On("CancelWorkflow", mock.Anything, "wf-soft", "").
+		Run(func(mock.Arguments) { close(done) }).
+		Return(nil).Once()
+
+	rt := &TemporalRuntime{temporalClient: tc, logger: logger.NoopLogger()}
+	rt.stopWorkflow(context.Background(), "wf-soft", context.Canceled, done)
+	tc.AssertExpectations(t)
+}
+
+// TestTemporalRuntime_Close_ActiveRuns_TerminatesDirectly: Close sends TerminateWorkflow
+// (not CancelWorkflow) for active runs so shutdown is immediate with no 3s grace period.
+func TestTemporalRuntime_Close_ActiveRuns_TerminatesDirectly(t *testing.T) {
+	tc := temporalmocks.NewClient(t)
+	done := make(chan struct{})
+	tc.On("TerminateWorkflow", mock.Anything, "run-w1", "", "agent closed").
+		Run(func(mock.Arguments) { close(done) }).
+		Return(nil).Once()
 
 	rt, err := NewTemporalRuntime(
 		WithTemporalClient(tc, "tq"),
@@ -623,7 +646,30 @@ func TestTemporalRuntime_Close_ActiveWorkflows_CancelFailsFallsBackToTerminate(t
 	if err != nil {
 		t.Fatal(err)
 	}
-	rt.activeRuns.Set("run-w1", &runHandle{})
+	rt.activeRuns.Set("run-w1", &runHandle{doneCh: done})
+
+	rt.Close()
+	tc.AssertExpectations(t)
+}
+
+// TestTemporalRuntime_Close_ActiveStreams_TerminatesDirectly: Close sends TerminateWorkflow
+// (not CancelWorkflow) for active streams, same direct-terminate path as runs.
+func TestTemporalRuntime_Close_ActiveStreams_TerminatesDirectly(t *testing.T) {
+	tc := temporalmocks.NewClient(t)
+	done := make(chan struct{})
+	tc.On("TerminateWorkflow", mock.Anything, "stream-w1", "", "agent closed").
+		Run(func(mock.Arguments) { close(done) }).
+		Return(nil).Once()
+
+	rt, err := NewTemporalRuntime(
+		WithTemporalClient(tc, "tq"),
+		WithAgentSpec(sdkruntime.AgentSpec{Name: "agent-a"}),
+		WithAgentConfig(sdkruntime.AgentConfig{LLM: sdkruntime.AgentLLM{Client: stubLLM{}}}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt.activeStreams.Set("stream-w1", &streamHandle{runHandle: &runHandle{doneCh: done}})
 
 	rt.Close()
 	tc.AssertExpectations(t)

--- a/internal/runtime/temporal/stream_handle.go
+++ b/internal/runtime/temporal/stream_handle.go
@@ -69,12 +69,24 @@ func (h *streamHandle) Approve(ctx context.Context, approvalToken string, status
 // fromOffset == 0 emits synthetic RUN_STARTED; fromOffset > 0 resumes after reconnect.
 // Returns [types.ErrRunNotFound] / [types.ErrRunAlreadyCompleted] from the
 // pre-subscribe workflow describe check.
+//
+// ctx controls the subscription lifetime only — cancelling it stops this subscriber
+// without affecting the agent run. The pre-subscribe status check uses its own bounded
+// context so a short-deadline subscription ctx does not cause the check to fail before
+// the subscription can start.
 func (h *streamHandle) Events(ctx context.Context, fromOffset int64) (<-chan events.AgentEvent, error) {
 	if h.rt == nil || h.rt.temporalClient == nil {
 		return nil, fmt.Errorf("temporal: stream handle %q is not configured for Events", h.id)
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
-	status, err := h.rt.getRunStatus(ctx, h.workflowID)
+	// Use a separate bounded ctx for the status gate so the subscription-lifetime ctx
+	// (which may have a short deadline) does not race with a slow describe RPC.
+	describeCtx, describeCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer describeCancel()
+	status, err := h.rt.getRunStatus(describeCtx, h.workflowID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,24 +122,44 @@ func (h *streamHandle) deliverEvents(ctx context.Context, fromOffset int64, outC
 	sc := newStreamClient(h.rt.temporalClient, h.workflowID)
 	defer func() { _ = sc.Close(context.Background()) }()
 
+	// Subscribe ends when the caller disconnects (Events ctx) OR the run finishes (Done).
+	// Run stop must unblock Events without requiring an Events ctx deadline.
+	subscribeCtx, subscribeCancel := context.WithCancel(ctx)
+	defer subscribeCancel()
+	go func() {
+		select {
+		case <-h.Done():
+			subscribeCancel()
+		case <-subscribeCtx.Done():
+		}
+	}()
+
 	// staleMessageIDs tracks messageIDs whose prior attempt tokens should be discarded.
 	// Cleared per-messageID when the new attempt's TEXT/REASONING _START event arrives.
 	staleMessageIDs := make(map[string]struct{})
 
-	for item, err := range sc.Subscribe(ctx, newStreamSubscribeOptions(fromOffset, []string{streamTopicEvents, streamTopicRetry})) {
+loop:
+	for item, err := range sc.Subscribe(subscribeCtx, newStreamSubscribeOptions(fromOffset, []string{streamTopicEvents, streamTopicRetry})) {
 		if err != nil {
 			if ctx.Err() != nil {
-				// Caller disconnected (ctx cancelled) — exit cleanly without touching the run.
-				return
+				select {
+				case <-h.Done():
+					// Run also finished — deliver terminal below.
+				default:
+					// Caller disconnected (Events ctx) — leave the run alone.
+					return
+				}
+			} else {
+				select {
+				case <-h.Done():
+					// Run stop cancelled subscribe — deliver terminal below.
+				default:
+					h.rt.logger.Warn(ctx, "stream: subscribe error, falling back to terminal result fetch",
+						slog.String("scope", "runtime"),
+						slog.Any("error", err))
+				}
 			}
-			// Genuine subscribe failure (not ctx cancellation, and not a clean terminal end,
-			// which the iterator reports by ending the loop without an error). Break out and
-			// still attempt to deliver a terminal event below, so the channel-close contract
-			// (RUN_FINISHED/RUN_ERROR before close) holds even when the stream connection itself failed.
-			h.rt.logger.Warn(ctx, "stream: subscribe error, falling back to terminal result fetch",
-				slog.String("scope", "runtime"),
-				slog.Any("error", err))
-			break
+			break loop
 		}
 
 		// Handle retry control signals: mark the messageID as stale, do not forward.
@@ -185,23 +217,42 @@ func (h *streamHandle) deliverEvents(ctx context.Context, fromOffset int64, outC
 		select {
 		case outCh <- ev:
 		case <-ctx.Done():
-			return
+			select {
+			case <-h.Done():
+				break loop
+			default:
+				return
+			}
+		case <-h.Done():
+			break loop
 		}
 	}
 
-	result, err := h.Get(ctx)
+	// Run lifetime owns the terminal wait — do not require Events ctx deadline.
+	result, err := h.Get(context.Background())
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-			termCtx, termCancel := context.WithTimeout(context.Background(), 15*time.Second)
-			_ = h.rt.temporalClient.TerminateWorkflow(termCtx, h.workflowID, "", "run timeout")
-			termCancel()
-			outCh <- events.NewAgentRunErrorEvent("request timed out (approval expired or deadline exceeded)")
-			return
-		}
-		outCh <- events.NewAgentRunErrorEvent(err.Error())
+		outCh <- events.NewAgentRunErrorEvent(terminalStreamErrorMessage(h.StopCause(), err))
 		return
 	}
 	outCh <- syntheticStreamCompleteEvent(result, h.threadID, h.id, rootName)
+}
+
+// terminalStreamErrorMessage maps run-stop cause + workflow Get error to a stable Events message.
+// Context sentinel errors (deadline / cancel) are returned as their canonical string so callers
+// get a predictable message regardless of what Temporal wraps around them.
+func terminalStreamErrorMessage(stopCause, getErr error) string {
+	switch {
+	case errors.Is(stopCause, context.DeadlineExceeded) || errors.Is(getErr, context.DeadlineExceeded):
+		return "context deadline exceeded"
+	case errors.Is(stopCause, context.Canceled) || errors.Is(getErr, context.Canceled):
+		return "context canceled"
+	case getErr != nil:
+		return getErr.Error()
+	case stopCause != nil:
+		return stopCause.Error()
+	default:
+		return "run failed"
+	}
 }
 
 // syntheticStreamCompleteEvent builds a root [RUN_FINISHED] event from the workflow result.

--- a/internal/runtime/temporal/stream_handle_test.go
+++ b/internal/runtime/temporal/stream_handle_test.go
@@ -319,6 +319,88 @@ func TestStreamHandle_Events_WorkflowError(t *testing.T) {
 	require.Contains(t, gotTypes, events.AgentEventTypeRunError)
 }
 
+// TestStreamHandle_Events_RunTimeoutUnblocksWithoutEventsDeadline verifies that when the run
+// stops via WithTimeout (stopCause=DeadlineExceeded), Events(Background) still gets RUN_ERROR
+// with "context deadline exceeded" — apps must not put a deadline on every Events call.
+func TestStreamHandle_Events_RunTimeoutUnblocksWithoutEventsDeadline(t *testing.T) {
+	release := make(chan struct{})
+	termErr := errors.New("workflow terminated: run timeout")
+
+	tc := temporalmocks.NewClient(t)
+	stubEventsRunningThenSubscribeEnd(tc, "wf-1")
+
+	rt := newTestStreamRuntime(tc)
+	wfRun := blockingWorkflowRun(release, nil, termErr)
+	h := newTestStreamHandle("run-1", "wf-1", "thread-1", tc, rt, wfRun, nil, nil)
+	h.setStopCause(context.DeadlineExceeded)
+
+	ch, err := h.Events(context.Background(), 0)
+	require.NoError(t, err)
+
+	close(release)
+	evs := collectStreamEvents(t, ch, 3*time.Second)
+	require.Contains(t, streamEventTypes(evs), events.AgentEventTypeRunError)
+
+	var msg string
+	for _, ev := range evs {
+		if re, ok := ev.(*events.AgentRunErrorEvent); ok {
+			msg = re.Message
+		}
+	}
+	require.Equal(t, "context deadline exceeded", msg)
+	waitHandleDone(t, h.Done())
+}
+
+// TestStreamHandle_Events_RunCancelUnblocksWithoutEventsDeadline verifies that when the run
+// stops via explicit Cancel() (stopCause=Canceled), Events(Background) still gets RUN_ERROR
+// with "context canceled" — symmetric to the timeout case.
+func TestStreamHandle_Events_RunCancelUnblocksWithoutEventsDeadline(t *testing.T) {
+	release := make(chan struct{})
+	termErr := errors.New("workflow terminated: run cancelled")
+
+	tc := temporalmocks.NewClient(t)
+	stubEventsRunningThenSubscribeEnd(tc, "wf-1")
+
+	rt := newTestStreamRuntime(tc)
+	wfRun := blockingWorkflowRun(release, nil, termErr)
+	h := newTestStreamHandle("run-1", "wf-1", "thread-1", tc, rt, wfRun, nil, nil)
+	h.setStopCause(context.Canceled)
+
+	ch, err := h.Events(context.Background(), 0)
+	require.NoError(t, err)
+
+	close(release)
+	evs := collectStreamEvents(t, ch, 3*time.Second)
+	require.Contains(t, streamEventTypes(evs), events.AgentEventTypeRunError)
+
+	var msg string
+	for _, ev := range evs {
+		if re, ok := ev.(*events.AgentRunErrorEvent); ok {
+			msg = re.Message
+		}
+	}
+	require.Equal(t, "context canceled", msg)
+	waitHandleDone(t, h.Done())
+}
+
+func TestTerminalStreamErrorMessage(t *testing.T) {
+	// Deadline: stopCause wins regardless of getErr content.
+	require.Equal(t, "context deadline exceeded",
+		terminalStreamErrorMessage(context.DeadlineExceeded, errors.New("terminated")))
+	// Deadline: getErr sentinel also triggers clean message.
+	require.Equal(t, "context deadline exceeded",
+		terminalStreamErrorMessage(nil, context.DeadlineExceeded))
+	// Cancel: stopCause wins, raw Temporal string is not surfaced.
+	require.Equal(t, "context canceled",
+		terminalStreamErrorMessage(context.Canceled, errors.New("workflow terminated")))
+	// Cancel: getErr sentinel also triggers clean message.
+	require.Equal(t, "context canceled",
+		terminalStreamErrorMessage(nil, context.Canceled))
+	// No sentinel: raw error from Temporal is passed through.
+	require.Equal(t, "workflow failed",
+		terminalStreamErrorMessage(nil, errors.New("workflow failed")))
+}
+
 // TestStreamHandle_Events_SubscribeErrorStillDeliversTerminal simulates a non-terminal
 // Subscribe failure (UpdateWorkflow error while the workflow is still RUNNING). deliverEvents
 // must fall through to Get and emit RUN_FINISHED before closing the channel — not exit early


### PR DESCRIPTION
## Description

- Unblock `Get` / `Events` when a run hits `WithTimeout` or Stream/Run deadline (no per-call waiter deadlines required); emit a clear timeout error instead of hanging.
- Stop stuck Temporal workflows on timeout (terminate) and on agent `Close` (parallel terminate with reason `agent closed`).
- Keep `Get` / `Events` / reconnect ctx cancel as waiter-only; run cancel stays on Stream/Run ctx, `WithTimeout`, or explicit `Cancel()`.
- Move stream approvals to `AgentStream.Approve` (deprecates `Agent.OnApproval`); update docs and durable_agent scenario notes.

## Test plan
- [x] `go test ./internal/runtime/temporal/ ./pkg/agent/`
- [x] durable_agent scenario 2: agent, no worker → fail-fast or `context deadline exceeded` (no hang / late `canceled`)
- [x] Stream with `WithTimeout`: Events on `Background` still gets terminal timeout error
- [x] Agent `Close` with active runs: workflows terminate; process exits within Close timeout

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / chore

## Related issues


## Checklist

- [x] I have run `task check`
- [x] I have run `task examples:all`
- [x] I have run `task tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
