### PR TITLE
feat: per-run budget enforcement with token/cost limits and approval actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ defer a.Close()
 - **Streaming & AG-UI** — partial token streaming; AG-UI protocol for frontend integration
 - **Reasoning** — extended thinking on Anthropic, Gemini, DeepSeek, and OpenAI reasoning models
 - **Token usage** — aggregate prompt, completion, and reasoning token counts per run
+- **Budget control** — cap token spend per run; stop execution or require human-in-the-loop approval when the limits are reached
 - **Hooks & guardrails** — middleware at LLM, tool, retrieval, and memory lifecycle points
 - **Execution config** — per-operation timeouts and max attempts via `With*ExecutionConfig`
 - **Durable execution** — crash-resilient runs via Temporal or Restate; reconnect to active runs and resume event streams after a restart

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -67,6 +67,7 @@
               "features/retrieval",
               "features/response-format",
               "features/token-usage",
+              "features/budget",
               "features/reasoning",
               "features/hooks",
               "features/ag-ui-protocol"
@@ -138,7 +139,8 @@
           {
             "group": "Configuration",
             "pages": [
-              "examples/execution-config"
+              "examples/execution-config",
+              "examples/agent-with-budget"
             ]
           },
           {

--- a/docs/examples/agent-with-budget.mdx
+++ b/docs/examples/agent-with-budget.mdx
@@ -1,0 +1,46 @@
+---
+title: "Budget Config"
+description: "Configure WithBudget to stop or pause a run when token or cost limits are reached"
+---
+
+Shows [`WithBudget`](/features/budget) on a single agent: `BudgetStopRun` ends the run with `ErrBudgetExceeded`, and `BudgetWaitForApproval` pauses for the caller to continue or stop.
+
+Source: [`examples/agent_with_budget/`](https://github.com/agenticenv/agent-sdk-go/tree/main/examples/agent_with_budget)
+
+Limits in the example are intentionally low so they trigger on a short prompt. Raise them for real workloads.
+
+## What it demonstrates
+
+- Token cap via `MaxTokens`
+- Optional `MaxCostUSD` with caller-supplied `PromptUSDPer1M` / `CompletionUSDPer1M`
+- `BudgetStopRun` — run stops and `Get` returns `ErrBudgetExceeded`
+- `BudgetWaitForApproval` — `WithApprovalHandler` decides whether to continue
+
+## Run
+
+From `examples/`:
+
+```bash
+go run ./agent_with_budget
+go run ./agent_with_budget "Tell me a short interesting fact about space."
+```
+
+## Expected output
+
+Scenario 1 prints `run stopped: per-run budget exceeded (BudgetStopRun)` when the token cap is hit.
+
+Scenario 2 prints a `[budget] limit reached` line, then prompts `continue this run? (y/n)`. Type `y` to continue or `n` to stop with `ErrBudgetExceeded`. `task examples:*` sets `EXAMPLES_AUTO_APPROVE=true` and continues without a prompt.
+
+## Learn more
+
+<CardGroup cols={2}>
+
+  <Card title="Budget" icon="gauge" href="/features/budget" horizontal>
+    Limits, actions, validation, nested sub-agents
+  </Card>
+
+  <Card title="Approvals" icon="hand" href="/features/approvals" horizontal>
+    Run handler vs Stream CUSTOM events
+  </Card>
+
+</CardGroup>

--- a/docs/examples/running-examples.mdx
+++ b/docs/examples/running-examples.mdx
@@ -35,6 +35,7 @@ Most examples accept all three via `config.RuntimeOption`. Temporal labs (`durab
 | [Non-blocking Run](/examples/nonblocking-run) | [Run](/getting-started/run) | Local, Temporal, Restate | — |
 | [JSON Response](/examples/json-response) | [Response format](/features/response-format) | Local, Temporal, Restate | — |
 | [Reasoning](/examples/reasoning) | [Reasoning](/features/reasoning) | Local, Temporal, Restate | — |
+| [Budget Config](/examples/agent-with-budget) | [Budget](/features/budget) | Local, Temporal, Restate | — |
 | [Tools](/examples/tools) | [Tools](/features/tools) | Local, Temporal, Restate | — |
 | [Workflows](/examples/workflows) | [Deterministic Execution](/advanced/deterministic-execution) | Local, Temporal, Restate | — (in-process default); Temporal (ORCHESTRATION_ENGINE=temporal) |
 | [Code Execution](/examples/code-execution) | [Code Execution in Agents](/advanced/code-execution) | Local, Temporal, Restate | — (local os/exec default); Docker (SANDBOX_ENV=docker) |

--- a/docs/features/approvals.mdx
+++ b/docs/features/approvals.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Approvals"
-description: "Configure human-in-the-loop approval for tool calls, MCP invocations, and sub-agent delegation"
+description: "Configure human-in-the-loop approval for tool calls, MCP invocations, sub-agent delegation, and per-run budget limits"
 ---
 
-Before registry tools, MCP tools, or sub-agent delegation execute, the SDK can pause and wait for **human approval**. One agent-level policy governs all three paths.
+Before registry tools, MCP tools, or sub-agent delegation execute, the SDK can pause and wait for **human approval**. One agent-level policy governs all three paths. Budget pauses use the same handler and stream `Approve` path, but they are not gated by the tool approval policy — see [Budget approval](#budget-approval).
 
 When an approval is required, the run **pauses at that tool call** and delivers an `ApprovalRequest` to your handler (or a `CUSTOM` event on the stream). The run resumes only after `req.Respond()` or `AgentStream.Approve()` is called with `Approved` or `Rejected`. If rejected, the tool call is skipped and the LLM receives a clear refusal message, then continues generating a response without that tool result. The overall run does not fail on rejection — only on timeout.
 
@@ -71,6 +71,7 @@ For a **non-blocking** wait, use the same handler and select on `agentRun.Done()
 |---|---|---|
 | Tool approval | `ParseToolApproval(req)` | `ToolName`, `AgentName` |
 | Sub-agent delegation | `ParseDelegationApproval(req)` | `SubAgentName`, `AgentName` |
+| Budget | `ParseBudgetApproval(req)` | `TotalTokens`, `CostUSD`, `AgentName`, `ApprovalToken` |
 
 ### Error handling
 
@@ -131,6 +132,14 @@ for ev := range eventCh {
         if err != nil {
             log.WithError(err).Error("Approve failed")
         }
+    } else if b, err := agent.ParseCustomEventBudget(ce); err == nil {
+        err := stream.Approve(ctx, b.ApprovalToken, agent.ApprovalStatusApproved)
+        if errors.Is(err, agent.ErrApprovalAlreadyResolved) {
+            continue
+        }
+        if err != nil {
+            log.WithError(err).Error("Approve failed")
+        }
     }
 }
 ```
@@ -138,6 +147,14 @@ for ev := range eventCh {
 <Warning>
 `Run` uses `req.Respond()` in `WithApprovalHandler`. `Stream` uses `AgentStream.Approve` with the token from the CUSTOM event. Do not mix the two paths.
 </Warning>
+
+## Budget approval
+
+[`WithBudget`](/features/budget) can pause the run when the token or cost cap is reached. That pause is **not** a tool-approval policy decision: the agent still needs `WithApprovalHandler` on `Run` (or `AgentStream.Approve` on `Stream`), and nested sub-agent budget pauses are delivered to the **parent** caller.
+
+Rejecting a budget approval stops the run with `ErrBudgetExceeded`. Approving continues from the current usage; the next pause fires only after another full limit from that point.
+
+Full API, payload fields, and Stream example: [Budget](/features/budget).
 
 ## Sub-agent approval
 
@@ -222,5 +239,9 @@ The CUSTOM approval event is delivered once. If you already responded before the
 
   <Card title="Sub-agents" icon="sitemap" href="/features/sub-agents" horizontal>
     Delegation approval flow
+  </Card>
+
+  <Card title="Budget" icon="gauge" href="/features/budget" horizontal>
+    Pause a run when the token or cost cap is reached
   </Card>
 </CardGroup>

--- a/docs/features/budget.mdx
+++ b/docs/features/budget.mdx
@@ -1,0 +1,216 @@
+---
+title: "Budget"
+description: "Cap token and cost usage on each agent run with WithBudget"
+---
+
+`WithBudget` sets token and cost limits on an agent for each run. When a limit is reached, the SDK either stops the run and returns `ErrBudgetExceeded`, or pauses and waits for human approval to continue. Limits reset when a new run starts.
+
+When an agent delegates to sub-agents, **all sub-agent token and cost usage is included** in the parent run's total. The parent budget governs the entire run tree. **A `WithBudget` configured directly on a sub-agent is silently ignored** when that sub-agent is invoked from a parent — a warning is logged at runtime to flag this.
+
+## Configuration
+
+```go
+a, err := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithBudget(agent.BudgetConfig{
+        MaxTokens:          100_000,          // stop at 100k total tokens
+        MaxCostUSD:         2.00,             // or $2 USD, whichever comes first
+        PromptUSDPer1M:     3.00,             // required when MaxCostUSD is set
+        CompletionUSDPer1M: 15.00,            // required when MaxCostUSD is set
+        OnExceeded:         agent.BudgetStopRun,
+    }),
+)
+```
+
+### BudgetConfig fields
+
+| Field | Required | Description |
+|---|---|---|
+| `MaxTokens` | At least one of MaxTokens or MaxCostUSD | Maximum total tokens (prompt + completion) for a single run. Must be ≥ 0; zero means no token limit. |
+| `MaxCostUSD` | At least one of MaxTokens or MaxCostUSD | Maximum estimated cost in US dollars for a single run. Must be ≥ 0; zero means no cost limit. |
+| `PromptUSDPer1M` | When `MaxCostUSD > 0` | Cost per one million prompt tokens (e.g. `3.0` for $3/1M). Must be ≥ 0. |
+| `CompletionUSDPer1M` | When `MaxCostUSD > 0` | Cost per one million completion tokens (e.g. `15.0` for $15/1M). Must be ≥ 0. |
+| `OnExceeded` | No (defaults to `BudgetStopRun`) | Action to take when a limit is reached. |
+| `ApprovalExtraTokens` | No | Tokens allowed between pauses when `OnExceeded` is `BudgetWaitForApproval`. Zero defaults to `MaxTokens`. **Only valid with `BudgetWaitForApproval`** — setting this with `BudgetStopRun` returns a validation error. |
+| `ApprovalExtraCostUSD` | No | Cost allowed between pauses for `BudgetWaitForApproval`. Zero defaults to `MaxCostUSD`. **Only valid with `BudgetWaitForApproval`**. |
+| `MaxApprovals` | No | Maximum number of `BudgetWaitForApproval` pauses allowed per run. Once reached the next breach stops the run with `ErrBudgetExceeded`. Zero defaults to `5`. **Only valid with `BudgetWaitForApproval`**. |
+
+### Limit precedence
+
+When both `MaxTokens` and `MaxCostUSD` are set, the **token limit is checked first** on every LLM call. If tokens are exceeded, a token breach error is returned even if the cost limit is also exceeded. Set only one limit if you need to distinguish which triggered.
+
+### OnExceeded actions
+
+| Value | Description |
+|---|---|
+| `BudgetStopRun` | Stop the run immediately and return `ErrBudgetExceeded` to the caller. |
+| `BudgetWaitForApproval` | Pause the run and wait for the caller to approve or deny continuation. For `Run`: `WithApprovalHandler` must be provided at call time (not at `NewAgent`). For `Stream`: emits a `CUSTOM` budget approval event (`AgentCustomEventNameBudget`); no handler needed. |
+
+## BudgetStopRun
+
+When the limit is reached, `agentRun.Get` (or `agentStream.Events`) returns `ErrBudgetExceeded`. Check with `errors.Is`:
+
+```go
+a, err := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithBudget(agent.BudgetConfig{
+        MaxTokens:  100_000,
+        OnExceeded: agent.BudgetStopRun,
+    }),
+)
+
+agentRun, err := a.Run(ctx, prompt, nil)
+if err != nil {
+    log.Fatal(err)
+}
+result, err := agentRun.Get(ctx)
+if errors.Is(err, agent.ErrBudgetExceeded) {
+    log.Println("run stopped: token limit reached")
+    // result is non-nil: result.Content may contain a partial response from the last
+    // completed LLM call before the limit was hit. result.Telemetry is always populated.
+    return
+}
+```
+
+`result.Telemetry.Run.FinishReason` is set to `"budget_exceeded"` when the run is stopped by the budget. `result` is always non-nil on budget stop; `result.Content` holds any partial response from the last completed LLM call.
+
+## BudgetWaitForApproval
+
+When the limit is reached, the run pauses and delivers an `ApprovalRequest` with name `ApprovalRequestNameBudget`. Decode with `ParseBudgetApproval` for `TotalTokens` / `CostUSD` / `ApprovalToken`.
+
+Call `req.Respond(agent.ApprovalStatusApproved)` to continue, or `req.Respond(agent.ApprovalStatusRejected)` to stop with `ErrBudgetExceeded`.
+
+Approving does not reset run totals. The next pause fires when usage grows by another `ApprovalExtraTokens` / `ApprovalExtraCostUSD` measured from the totals at the time of approval. After `MaxApprovals` approvals (default 5) the next breach stops the run.
+
+If the approval cannot be delivered because no stream subscriber is connected, the run stops with `ErrBudgetApprovalUnavailable` (a separate sentinel from `ErrBudgetExceeded`). Check with `errors.Is(err, agent.ErrBudgetApprovalUnavailable)` and retry.
+
+### Run
+
+`WithApprovalHandler` must be provided at the `Run()` call site. It is **not** required at `NewAgent`, so stream-only agents are not forced to register a no-op handler:
+
+
+```go
+approvalHandler := func(ctx context.Context, req *agent.ApprovalRequest) {
+    v, err := agent.ParseBudgetApproval(req)
+    if err != nil {
+        // ... handle tool approvals
+        return
+    }
+    log.Printf("budget reached: tokens=%d cost=$%.4f — approving",
+        v.TotalTokens, v.CostUSD)
+    _ = req.Respond(agent.ApprovalStatusApproved)
+}
+
+a, err := agent.NewAgent(
+    agent.WithLLMClient(llmClient),
+    agent.WithApprovalHandler(approvalHandler),
+    agent.WithBudget(agent.BudgetConfig{
+        MaxTokens:          100_000,
+        PromptUSDPer1M:     3.00,
+        CompletionUSDPer1M: 15.00,
+        MaxCostUSD:         2.00,
+        OnExceeded:         agent.BudgetWaitForApproval,
+    }),
+)
+```
+
+### Stream
+
+When the limit is reached during a stream run, a `CUSTOM` event with name `AgentCustomEventNameBudget` is emitted. Parse with `ParseCustomEventBudget`, then call `AgentStream.Approve`:
+
+```go
+agentStream, err := a.Stream(ctx, prompt, nil)
+// ...
+for ev := range eventCh {
+    ce, ok := ev.(*agent.AgentCustomEvent)
+    if !ok {
+        continue
+    }
+    v, err := agent.ParseCustomEventBudget(ce)
+    if err != nil {
+        continue
+    }
+    log.Printf("budget approval requested (token=%s) — approving", v.ApprovalToken)
+    if err := agentStream.Approve(ctx, v.ApprovalToken, agent.ApprovalStatusApproved); err != nil {
+        log.Printf("approve error: %v", err)
+    }
+}
+```
+
+## Cost calculation
+
+`MaxCostUSD` is estimated from accumulated token counts using the rates you supply:
+
+```
+cost = (prompt_tokens / 1_000_000 × PromptUSDPer1M) + (completion_tokens / 1_000_000 × CompletionUSDPer1M)
+```
+
+The SDK does **not** include built-in provider price tables. Set the rates to match the model you are using. If a provider does not report token counts, `MaxCostUSD` will not trigger (use `MaxTokens` instead).
+
+## Validation
+
+`NewAgent` returns an error if `WithBudget` is misconfigured:
+
+- Neither `MaxTokens` nor `MaxCostUSD` is non-zero.
+- `MaxCostUSD > 0` but `PromptUSDPer1M` or `CompletionUSDPer1M` is zero.
+- `OnExceeded` is `BudgetWaitForApproval` but no `WithApprovalHandler` is set.
+- `OnExceeded` is an unrecognised value.
+
+## Example
+
+<CardGroup cols={2}>
+  <Card title="Budget Config" icon="gauge" href="/examples/agent-with-budget" horizontal>
+    Stop run and wait-for-approval scenarios
+  </Card>
+</CardGroup>
+
+## Observability
+
+### Metrics
+
+Budget events emit the following counters (see `MetricBudget*` constants in the SDK):
+
+| Metric | When |
+|---|---|
+| `agent.budget.exceeded` | Every breach, before action is taken. Attributes: `budget.kind` (`tokens`/`cost_usd`), `budget.action` |
+| `agent.budget.approval.requested` | Each `BudgetWaitForApproval` pause is initiated |
+| `agent.budget.approval.approved` | Caller approved continuation |
+| `agent.budget.approval.rejected` | Caller denied continuation |
+| `agent.budget.approval.timed_out` | Approval request timed out |
+| `agent.budget.approval.unavailable` | No stream subscriber to receive the approval event |
+| `agent.budget.approval.exhausted` | `MaxApprovals` reached; run stops |
+
+### OnBudgetExceeded hook
+
+Register an `OnBudgetExceeded` hook for custom alerting, audit logging, or metrics:
+
+```go
+agent.WithHooks(agent.HookGroup{
+    Name: "budget-alerts",
+    Hooks: agent.AgentHooks{
+        OnBudgetExceeded: []agent.OnBudgetExceededHook{
+            func(ctx context.Context, in agent.OnBudgetExceededHookInput) {
+                log.Printf("budget breach: kind=%s tokens=%d cost=$%.4f action=%s approvals=%d/%t",
+                    in.Kind, in.TotalTokens, in.TotalCostUSD,
+                    in.Action, in.ApprovalCount, in.ApprovalsExhausted)
+            },
+        },
+    },
+})
+```
+
+The hook fires before the action (stop or pause) is taken and is fire-and-forget.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Token Usage" icon="chart-bar" href="/features/token-usage" horizontal>
+    Aggregate token counts per run
+  </Card>
+  <Card title="Approvals" icon="hand" href="/features/approvals" horizontal>
+    Same Run handler and Stream Approve path for BudgetWaitForApproval
+  </Card>
+  <Card title="Hooks" icon="webhook" href="/features/hooks" horizontal>
+    OnBudgetExceeded and per-LLM-call hooks for cost observability
+  </Card>
+</CardGroup>

--- a/docs/features/hooks.mdx
+++ b/docs/features/hooks.mdx
@@ -117,7 +117,7 @@ agent.WithHooks("pii", agent.AgentHooks{
 
 ### Token budget and cost tracking
 
-Enforce a per-run or per-user token budget across LLM calls:
+For a **per-run** token or cost cap, use [`WithBudget`](/features/budget) — the SDK stops or pauses the run without hook code. Use `AfterLLM` for custom accounting that spans users, tenants, or multiple runs:
 
 ```go
 agent.WithHooks("cost", agent.AgentHooks{
@@ -125,8 +125,8 @@ agent.WithHooks("cost", agent.AgentHooks{
         func(ctx context.Context, in agent.AfterLLMHookInput) (agent.AfterLLMHookOutput, error) {
             if in.Response.Usage != nil {
                 trackTokens(in.RunMeta.RunID, in.Response.Usage.TotalTokens)
-                if budgetExceeded(in.RunMeta.RunID) {
-                    return agent.AfterLLMHookOutput{}, errors.New("token budget exceeded")
+                if userQuotaExceeded(in.RunMeta.RunID) {
+                    return agent.AfterLLMHookOutput{}, errors.New("user token quota exceeded")
                 }
             }
             return agent.AfterLLMHookOutput{Response: in.Response}, nil
@@ -135,7 +135,7 @@ agent.WithHooks("cost", agent.AgentHooks{
 })
 ```
 
-**Hooks:** `BeforeLLM` (cache read / short-circuit), `AfterLLM` (token tracking, cache write, model fallback)
+**Hooks:** `BeforeLLM` (cache read / short-circuit), `AfterLLM` (per-call tracking, cache write, model fallback)
 
 ### Tenant isolation for memory
 
@@ -228,7 +228,8 @@ agent.WithHooks("retrieval", agent.AgentHooks{
 | PII scrubbing from tool args / results | `BeforeTool`, `AfterTool` |
 | PII scrubbing from retrieval | `BeforeRetrieve`, `AfterRetrieve` |
 | PII scrubbing from memory | `BeforeMemoryStore`, `AfterMemoryLoad` |
-| Token tracking and budget enforcement | `AfterLLM` |
+| Per-run token/cost cap | [`WithBudget`](/features/budget) (not a hook) |
+| Custom token accounting (per-user / multi-run) | `AfterLLM` |
 | LLM response caching | `BeforeLLM` (read), `AfterLLM` (write) |
 | Model fallback on error | `AfterLLM` |
 | Tool rate limiting | `BeforeTool` |
@@ -260,5 +261,9 @@ agent.WithHooks("retrieval", agent.AgentHooks{
 
   <Card title="Retrieval" icon="book-open" href="/features/retrieval" horizontal>
     BeforeRetrieve and AfterRetrieve hooks
+  </Card>
+
+  <Card title="Budget" icon="gauge" href="/features/budget" horizontal>
+    Built-in token and cost limits without AfterLLM
   </Card>
 </CardGroup>

--- a/docs/features/sub-agents.mdx
+++ b/docs/features/sub-agents.mdx
@@ -73,7 +73,7 @@ Each delegation is a tool round on the **main agent** — it consumes one iterat
 ## Behavior
 
 - **Conversation isolation** — sub-agents do not inherit the main agent's conversation ID. They run without session history from the parent.
-- **Independent approval policies** — parent and child policies are independent (see [Approvals](/features/approvals)).
+- **Budget** — when a parent agent has [`WithBudget`](/features/budget), nested sub-agent token and cost usage counts toward the **parent** run. A child's own `WithBudget` applies only when that agent is run on its own.
 - **Worker pairing** — with `DisableLocalWorker`, pair each `NewAgentWorker` with the same options as the `NewAgent` it runs.
 - **Validation at build** — sub-agent graphs are validated for cycles and depth violations at `NewAgent`. Errors fail fast.
 
@@ -117,5 +117,9 @@ _ = a.SubAgentRegistry().Unregister("Math")
 
   <Card title="Approvals" icon="shield-check" href="/features/approvals" horizontal>
     Parent vs specialist approval policies
+  </Card>
+
+  <Card title="Budget" icon="gauge" href="/features/budget" horizontal>
+    Parent budget covers nested sub-agent usage
   </Card>
 </CardGroup>

--- a/docs/features/token-usage.mdx
+++ b/docs/features/token-usage.mdx
@@ -63,9 +63,13 @@ for ev := range eventCh {
 
 OpenAI streaming with `include_usage` surfaces totals on `RUN_FINISHED`. Example: [Stream](/examples/stream).
 
+## Budget enforcement
+
+To automatically stop or pause a run when a token or cost limit is reached, use [`WithBudget`](/features/budget). It works across all runtimes and covers sub-agent usage transparently without any hook code.
+
 ## Per-request usage
 
-For per-LLM-call breakdowns — to log each round individually, enforce mid-run budgets, or build cost dashboards — use [`AfterLLMHook`](/features/hooks) and inspect `in.Response.Usage` on each iteration:
+For per-LLM-call breakdowns — to log each round individually, build cost dashboards, or track iteration-level usage — use [`AfterLLMHook`](/features/hooks) and inspect `in.Response.Usage` on each iteration:
 
 ```go
 agent.WithHooks("cost", agent.AgentHooks{
@@ -91,6 +95,10 @@ agent.WithHooks("cost", agent.AgentHooks{
 ## Related
 
 <CardGroup cols={2}>
+
+  <Card title="Budget" icon="gauge" href="/features/budget" horizontal>
+    Token and cost limits with automatic enforcement
+  </Card>
 
   <Card title="Reasoning" icon="lightbulb" href="/features/reasoning" horizontal>
     ReasoningTokens from extended thinking

--- a/docs/getting-started/configuration.mdx
+++ b/docs/getting-started/configuration.mdx
@@ -86,7 +86,8 @@ Restate embeds the SDK endpoint in `NewAgent`. When Restate runs in Docker and t
 | `WithMaxIterations(n)` | Max LLM rounds per run (default: **5**). Each round is one LLM call; tool execution doesn't count separately. Increase for complex agents, multi-tool sequences, or runs with sub-agent delegation. See [Timeouts & Modes](/advanced/timeouts-and-modes) |
 | `WithTimeout(d)` | Default run timeout when the context has no deadline |
 | `WithApprovalTimeout(d)` | Max wait per approval — defaults to timeout minus 30s |
-| `WithApprovalHandler(fn)` | Callback for tool and delegation approvals on `Run` |
+| `WithApprovalHandler(fn)` | Callback for tool, delegation, and budget approvals on `Run` |
+| `WithBudget(cfg)` | Token and cost cap for each run. See [Budget](/features/budget) |
 | `WithAgentToolExecutionMode(mode)` | `Parallel` (default) or `Sequential` per LLM turn |
 
 Context deadlines always take precedence over `WithTimeout`. See [Timeouts & Modes](/advanced/timeouts-and-modes).
@@ -164,3 +165,5 @@ When splitting client and worker across processes, `NewAgent` and `NewAgentWorke
 ## Token usage
 
 There is no separate token usage option. Read [`LLMUsage`](/features/token-usage) from `AgentRunResult` after `Run`, or from `AgentRunFinishedEvent.Result.LLMUsage` after `Stream`.
+
+To **cap** tokens or estimated cost for each run, use [`WithBudget`](/features/budget).

--- a/docs/getting-started/streaming.mdx
+++ b/docs/getting-started/streaming.mdx
@@ -177,13 +177,13 @@ Stream events are typed [`AgentEvent`](https://pkg.go.dev/github.com/agenticenv/
 |---|---|
 | `AgentEventTypeReasoningMessageContent` | Partial reasoning/thinking delta (Anthropic when extended thinking is enabled) |
 
-### Custom (approvals and delegation)
+### Custom (approvals, delegation, and budget)
 
 | Event | When |
 |---|---|
-| `AgentEventTypeCustom` | Approval or delegation requests during `Stream` |
+| `AgentEventTypeCustom` | Tool approval, sub-agent delegation, or `budget_approval` during `Stream` |
 
-Parse approval events with `ParseCustomEventApproval` / `ParseCustomEventDelegation`, then call [`AgentStream.Approve`](/features/approvals) with the `ApprovalToken`. See [Approvals](/features/approvals) for the full flow.
+Parse approval events with `ParseCustomEventApproval` / `ParseCustomEventDelegation` / `ParseCustomEventBudget`, then call [`AgentStream.Approve`](/features/approvals) with the `ApprovalToken`. See [Approvals](/features/approvals) and [Budget](/features/budget).
 
 ## Displaying streamed text
 

--- a/docs/production/readiness.mdx
+++ b/docs/production/readiness.mdx
@@ -69,11 +69,12 @@ See [Timeouts & Modes](/advanced/timeouts-and-modes) for the full failure behavi
 
 ## Cost controls
 
+- **Budget** — Use [`WithBudget`](/features/budget) to set hard token and cost limits on each run. The SDK enforces them automatically across all runtimes and includes sub-agent usage in the total. Choose `BudgetStopRun` to halt on breach or `BudgetWaitForApproval` for human-in-the-loop control. See [Budget](/features/budget).
 - **Token budget per run** — Set `WithLLMSampling(&LLMSampling{MaxTokens: N})` to cap completion tokens per LLM call. Prevents runaway costs from unexpectedly long responses.
 - **Cap iteration count** — `WithMaxIterations` (default 5) directly caps how many LLM calls a single run makes. Reduce it for cost-sensitive workloads.
 - **Monitor token usage** — Read `result.LLMUsage.TotalTokens` on every run and aggregate by user/tenant. See [Token Usage](/features/token-usage).
 - **OTLP token metrics** — `agent.llm.tokens.input` and `agent.llm.tokens.output` histograms let you alert on token spend in dashboards. See [Metrics](/observability/metrics).
-- **Sub-agent token multiplication** — Each sub-agent delegation triggers its own LLM calls. Monitor sub-agent trees carefully — a 3-level deep tree with 3 tools per level can multiply token spend significantly.
+- **Sub-agent token multiplication** — Each sub-agent delegation triggers its own LLM calls. Monitor sub-agent trees carefully — a 3-level deep tree with 3 tools per level can multiply token spend significantly. Use `WithBudget` to cap total usage across the whole tree.
 - **Estimate before production** — Run the [Benchmarks](/testing/benchmarks) harness with real provider clients and `mock_tokens` tuned to your expected prompt size to estimate cost at target load.
 
 ## Prompt Caching

--- a/docs/runtimes/in-process.mdx
+++ b/docs/runtimes/in-process.mdx
@@ -50,6 +50,7 @@ All SDK capabilities are available on the in-process runtime:
 - Conversation (in-memory), memory, retrieval (RAG)
 - Streaming, AG-UI events, hooks
 - Human-in-the-loop approvals
+- Budget (`WithBudget`)
 - OpenTelemetry observability
 
 Durable execution (crash recovery) and durable reconnect (`GetAgentRun` / `GetAgentStream` + `WithOffset`) require the [Temporal](/runtimes/temporal) or [Restate](/runtimes/restate) runtime. Temporal also offers horizontal worker scaling via `NewAgentWorker`; Restate scales via multiple registered endpoint deployments.

--- a/examples/README.md
+++ b/examples/README.md
@@ -103,6 +103,7 @@ These examples run with `AGENT_RUNTIME=local` (default), `AGENT_RUNTIME=temporal
 | `agent_with_subagents` | Main agent + math specialist — `WithSubAgents`; prints **`STEP_STARTED` / `STEP_FINISHED`** (sub-agent name) around each child run when using `Stream` | — |
 | `agent_with_json_response` | Structured LLM output — `WithResponseFormat` + `interfaces.JSONSchema` (JSON with schema; no tools) | — |
 | `agent_with_reasoning` | Generic `interfaces.LLMReasoning` via `WithLLMSampling` — `Stream` to observe `thinking_delta` (e.g. Anthropic) | — |
+| `agent_with_budget` | Budget config via `WithBudget` — stop the run or pause for approval when the limit is reached | — |
 | `agent_with_mcp_config` | MCP via `WithMCPConfig` — transport from env; **[README](agent_with_mcp_config/README.md)** | stdio: — (`.env.defaults`); remote MCP: manual |
 | `agent_with_mcp_client` | Same via `mcpclient.NewClient` + `WithMCPClients` — **[README](agent_with_mcp_client/README.md)** | same as `mcp_config` |
 | `agent_with_a2a_config` | Outbound A2A via `WithA2AConfig` — **`A2A_URL`**; **[README](agent_with_a2a_config/README.md)** | `infra:a2a:up` or external A2A (manual) |
@@ -246,6 +247,17 @@ go run ./agent_with_json_response "What is the capital of Japan?"
 go run ./agent_with_reasoning
 go run ./agent_with_reasoning "Why is the sky blue? One short paragraph."
 ```
+
+### Budget config (`WithBudget`)
+
+Limits in this example are intentionally low so they trigger on a short prompt.
+
+```bash
+go run ./agent_with_budget
+go run ./agent_with_budget "Tell me a short interesting fact about space."
+```
+
+Scenario 2 asks `continue this run? (y/n)`. `task examples:*` sets `EXAMPLES_AUTO_APPROVE=true` so the batch run does not wait.
 
 ### Streaming + conversation (event handling pattern)
 

--- a/examples/agent_with_budget/main.go
+++ b/examples/agent_with_budget/main.go
@@ -1,0 +1,173 @@
+// Example demonstrating per-run budget enforcement with WithBudget.
+//
+// Two scenarios are shown:
+//
+//  1. BudgetStopRun: the run stops immediately and returns ErrBudgetExceeded when the
+//     configured token or cost limit is reached.
+//  2. BudgetWaitForApproval: the run pauses when the limit is reached; the approval
+//     handler decides whether to continue or stop.
+//
+// Run:
+//
+//	go run ./agent_with_budget
+//	go run ./agent_with_budget "Your custom prompt here"
+//
+// Set SHOW_LLM_USAGE=true to print token usage at the end of each run.
+// The budget limits in this example are set very low so they trigger on most prompts.
+// Raise them to realistic values (e.g. MaxTokens: 100_000) for production use.
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	config "github.com/agenticenv/agent-sdk-go/examples"
+	"github.com/agenticenv/agent-sdk-go/examples/shared"
+	"github.com/agenticenv/agent-sdk-go/pkg/agent"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+)
+
+func main() {
+	cfg := config.LoadFromEnv()
+
+	llmClient, err := config.NewLLMClientFromConfig(cfg)
+	if err != nil {
+		log.Fatalf("failed to create LLM client: %v", err)
+	}
+
+	prompt := strings.Join(os.Args[1:], " ")
+	if prompt == "" {
+		prompt = "Tell me a short interesting fact about space."
+	}
+
+	fmt.Println("=== Scenario 1: BudgetStopRun ===")
+	runWithStopRun(cfg, llmClient, prompt)
+
+	fmt.Println("\n=== Scenario 2: BudgetWaitForApproval ===")
+	runWithApproval(cfg, llmClient, prompt)
+}
+
+// runWithStopRun shows a run that is stopped automatically when MaxTokens is reached.
+func runWithStopRun(cfg *config.Config, llmClient interfaces.LLMClient, prompt string) {
+	opts := []agent.Option{
+		agent.WithName("budget-stop-agent"),
+		agent.WithSystemPrompt("You are a helpful assistant. Be concise."),
+		agent.WithLLMClient(llmClient),
+		agent.WithBudget(agent.BudgetConfig{
+			// Very low limit for demo purposes; raise for production.
+			MaxTokens:  50,
+			OnExceeded: agent.BudgetStopRun,
+		}),
+		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
+	}
+	opts = append(opts, config.RuntimeOption(cfg)...)
+
+	a, err := agent.NewAgent(opts...)
+	if err != nil {
+		log.Fatal(config.FormatNewAgentError("failed to create agent", err))
+	}
+	defer a.Close()
+
+	fmt.Printf("user: %s\n", prompt)
+	agentRun, err := a.Run(context.Background(), prompt, nil)
+	if err != nil {
+		log.Printf("run start error: %v", err)
+		return
+	}
+	result, err := agentRun.Get(context.Background())
+	if err != nil {
+		if errors.Is(err, agent.ErrBudgetExceeded) {
+			fmt.Println("run stopped: per-run budget exceeded (BudgetStopRun)")
+		} else {
+			log.Printf("run error: %v", err)
+		}
+		return
+	}
+	fmt.Printf("assistant: %s\n", result.Content)
+	fmt.Printf("finish_reason: %s\n", result.Telemetry.Run.FinishReason)
+	shared.PrintRunFooters(result)
+}
+
+// runWithApproval shows a run that pauses for human approval when MaxTokens is reached.
+// In Run mode the registered ApprovalHandler is called synchronously.
+// In Stream mode a CUSTOM "budget_approval" AG-UI event is emitted; call AgentStream.Approve
+// with the token from the event payload to unblock the run.
+func runWithApproval(cfg *config.Config, llmClient interfaces.LLMClient, prompt string) {
+	autoApprove := strings.EqualFold(strings.TrimSpace(os.Getenv("EXAMPLES_AUTO_APPROVE")), "true")
+	approvalHandler := func(_ context.Context, req *agent.ApprovalRequest) {
+		v, err := agent.ParseBudgetApproval(req)
+		if err != nil {
+			_ = req.Respond(agent.ApprovalStatusRejected)
+			return
+		}
+		fmt.Printf("[budget] limit reached: total_tokens=%d estimated_cost_usd=%.6f\n", v.TotalTokens, v.CostUSD)
+		if autoApprove {
+			fmt.Println("[budget] EXAMPLES_AUTO_APPROVE=true — continuing")
+			if err := req.Respond(agent.ApprovalStatusApproved); err != nil {
+				log.Printf("[budget] respond error: %v", err)
+			}
+			return
+		}
+		fmt.Print("[budget] continue this run? (y/n): ")
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			log.Printf("[budget] read error: %v", err)
+			_ = req.Respond(agent.ApprovalStatusRejected)
+			return
+		}
+		status := agent.ApprovalStatusRejected
+		if strings.TrimSpace(strings.ToLower(line)) == "y" {
+			status = agent.ApprovalStatusApproved
+		}
+		if err := req.Respond(status); err != nil {
+			log.Printf("[budget] respond error: %v", err)
+		}
+	}
+
+	opts := []agent.Option{
+		agent.WithName("budget-approval-agent"),
+		agent.WithSystemPrompt("You are a helpful assistant. Be concise."),
+		agent.WithLLMClient(llmClient),
+		agent.WithApprovalHandler(approvalHandler),
+		agent.WithBudget(agent.BudgetConfig{
+			// Very low limits for demo purposes; raise for production.
+			MaxTokens:          50,
+			PromptUSDPer1M:     3.0,
+			CompletionUSDPer1M: 15.0,
+			MaxCostUSD:         0.001,
+			OnExceeded:         agent.BudgetWaitForApproval,
+		}),
+		agent.WithLogger(config.NewLoggerFromLogConfig(cfg)),
+	}
+	opts = append(opts, config.RuntimeOption(cfg)...)
+
+	a, err := agent.NewAgent(opts...)
+	if err != nil {
+		log.Fatal(config.FormatNewAgentError("failed to create agent", err))
+	}
+	defer a.Close()
+
+	fmt.Printf("user: %s\n", prompt)
+	agentRun, err := a.Run(context.Background(), prompt, nil)
+	if err != nil {
+		log.Printf("run start error: %v", err)
+		return
+	}
+	result, err := agentRun.Get(context.Background())
+	if err != nil {
+		if errors.Is(err, agent.ErrBudgetExceeded) {
+			fmt.Println("run stopped: budget exceeded and approval denied")
+		} else {
+			log.Printf("run error: %v", err)
+		}
+		return
+	}
+	fmt.Printf("assistant: %s\n", result.Content)
+	fmt.Printf("finish_reason: %s\n", result.Telemetry.Run.FinishReason)
+	shared.PrintRunFooters(result)
+}

--- a/internal/events/custom_events.go
+++ b/internal/events/custom_events.go
@@ -48,6 +48,7 @@ type AgentCustomEventName string
 const (
 	AgentCustomEventNameToolApproval       AgentCustomEventName = "tool_approval"
 	AgentCustomEventNameSubAgentDelegation AgentCustomEventName = "sub_agent_delegation"
+	AgentCustomEventNameBudget             AgentCustomEventName = "budget_approval"
 )
 
 // AgentCustomEventApprovalValue is the JSON shape for CUSTOM name=approval (tool or delegation; use Kind).
@@ -87,6 +88,17 @@ func NewAgentCustomEventDelegationValue(subAgentName, approvalToken string) *Age
 
 func (v *AgentCustomEventDelegationValue) ToJSON() ([]byte, error) { return json.Marshal(v) }
 
+// AgentCustomEventBudgetValue is the JSON shape for CUSTOM name=budget_approval.
+type AgentCustomEventBudgetValue struct {
+	AgentName     string  `json:"agentName,omitempty"`
+	Detail        string  `json:"detail,omitempty"`
+	TotalTokens   int64   `json:"totalTokens,omitempty"`
+	CostUSD       float64 `json:"costUsd,omitempty"`
+	ApprovalToken string  `json:"approvalToken,omitempty"`
+}
+
+func (v *AgentCustomEventBudgetValue) ToJSON() ([]byte, error) { return json.Marshal(v) }
+
 func parseCustomPayload[V any](ev *AgentCustomEvent) (v V, err error) {
 	if ev == nil {
 		return v, fmt.Errorf("events: nil custom event")
@@ -111,13 +123,36 @@ func parseCustomPayload[V any](ev *AgentCustomEvent) (v V, err error) {
 	}
 }
 
-// ParseCustomEventApproval returns the typed value field for CUSTOM events with name "approval"
+// ParseCustomEventApproval returns the typed value field for CUSTOM events with name "tool_approval"
 // (after EventFromJSON or bus decode, Value is often map[string]any).
 func ParseCustomEventApproval(ev *AgentCustomEvent) (AgentCustomEventApprovalValue, error) {
+	if ev == nil {
+		return AgentCustomEventApprovalValue{}, fmt.Errorf("events: nil custom event")
+	}
+	if ev.Name != string(AgentCustomEventNameToolApproval) {
+		return AgentCustomEventApprovalValue{}, fmt.Errorf("events: not a tool approval custom event")
+	}
 	return parseCustomPayload[AgentCustomEventApprovalValue](ev)
 }
 
-// ParseCustomEventDelegation returns the typed value field for CUSTOM events with name "delegation".
+// ParseCustomEventDelegation returns the typed value field for CUSTOM events with name "sub_agent_delegation".
 func ParseCustomEventDelegation(ev *AgentCustomEvent) (AgentCustomEventDelegationValue, error) {
+	if ev == nil {
+		return AgentCustomEventDelegationValue{}, fmt.Errorf("events: nil custom event")
+	}
+	if ev.Name != string(AgentCustomEventNameSubAgentDelegation) {
+		return AgentCustomEventDelegationValue{}, fmt.Errorf("events: not a sub-agent delegation custom event")
+	}
 	return parseCustomPayload[AgentCustomEventDelegationValue](ev)
+}
+
+// ParseCustomEventBudget returns the typed value field for CUSTOM events with name "budget_approval".
+func ParseCustomEventBudget(ev *AgentCustomEvent) (AgentCustomEventBudgetValue, error) {
+	if ev == nil {
+		return AgentCustomEventBudgetValue{}, fmt.Errorf("events: nil custom event")
+	}
+	if ev.Name != string(AgentCustomEventNameBudget) {
+		return AgentCustomEventBudgetValue{}, fmt.Errorf("events: not a budget approval custom event")
+	}
+	return parseCustomPayload[AgentCustomEventBudgetValue](ev)
 }

--- a/internal/events/events_test.go
+++ b/internal/events/events_test.go
@@ -379,6 +379,20 @@ func TestCustomEventTypedValueHelpers(t *testing.T) {
 	if parsedDelegation.SubAgentName != "child" || parsedDelegation.ApprovalToken != "tok-2" {
 		t.Fatalf("unexpected parsed delegation: %#v", parsedDelegation)
 	}
+
+	ev3 := NewAgentCustomEvent(string(AgentCustomEventNameBudget), map[string]any{
+		"agentName":     "budget-agent",
+		"totalTokens":   int64(120),
+		"costUsd":       0.01,
+		"approvalToken": "tok-3",
+	})
+	parsedBudget, err := ParseCustomEventBudget(ev3)
+	if err != nil {
+		t.Fatalf("ParseCustomEventBudget error: %v", err)
+	}
+	if parsedBudget.AgentName != "budget-agent" || parsedBudget.TotalTokens != 120 || parsedBudget.ApprovalToken != "tok-3" {
+		t.Fatalf("unexpected parsed budget: %#v", parsedBudget)
+	}
 }
 
 func TestCustomEventParseErrors(t *testing.T) {

--- a/internal/hooks/budget.go
+++ b/internal/hooks/budget.go
@@ -1,0 +1,58 @@
+package hooks
+
+import (
+	"context"
+
+	"github.com/agenticenv/agent-sdk-go/internal/types"
+)
+
+// OnBudgetExceededHookInput is the payload delivered to [OnBudgetExceededHook] each time a
+// per-run budget limit is breached, before the configured action (stop or approval) is taken.
+type OnBudgetExceededHookInput struct {
+	// RunMeta carries read-only execution context for the current run.
+	RunMeta RunMeta
+
+	// Kind identifies which limit was breached: tokens or cost_usd.
+	Kind types.BudgetExceededKind
+
+	// TotalTokens is the accumulated token count at the time of the breach.
+	TotalTokens int64
+
+	// TotalCostUSD is the accumulated estimated cost in US dollars at the time of the breach.
+	TotalCostUSD float64
+
+	// Action is the configured OnExceeded action (BudgetStopRun or BudgetWaitForApproval).
+	// When ApprovalsExhausted is true the effective action is BudgetStopRun regardless of this value.
+	Action types.BudgetExceededAction
+
+	// ApprovalCount is how many BudgetWaitForApproval approvals have been granted so far in
+	// this run (before this breach is processed).
+	ApprovalCount int
+
+	// ApprovalsExhausted is true when MaxApprovals has been reached and the run will stop
+	// regardless of the configured OnExceeded action.
+	ApprovalsExhausted bool
+}
+
+// OnBudgetExceededHook is called when a per-run budget limit is breached.
+// It is fire-and-forget: the return value is ignored. Use it for metrics, alerts, and audit
+// logging. Do not use it to modify run behaviour — use OnExceeded actions for that.
+type OnBudgetExceededHook func(ctx context.Context, input OnBudgetExceededHookInput)
+
+// RunOnBudgetExceeded fires all OnBudgetExceeded hooks in group registration order.
+// Errors are not propagated; the hook is observability-only.
+func RunOnBudgetExceeded(ctx context.Context, groups []HookGroup, input OnBudgetExceededHookInput) {
+	for _, g := range groups {
+		if len(g.Hooks.OnBudgetExceeded) == 0 {
+			continue
+		}
+		groupInput := input
+		groupInput.RunMeta.HooksGroup = g.Name
+		for _, hook := range g.Hooks.OnBudgetExceeded {
+			if hook == nil {
+				continue
+			}
+			hook(ctx, groupInput)
+		}
+	}
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -53,6 +53,11 @@ type AgentHooks struct {
 	AfterMemoryLoad   []AfterMemoryLoadHook
 	BeforeMemoryStore []BeforeMemoryStoreHook
 	AfterMemoryStore  []AfterMemoryStoreHook
+
+	// OnBudgetExceeded fires each time a per-run budget limit is breached, before the
+	// configured action (stop or approval pause) is taken. Fire-and-forget — use it for
+	// metrics, alerts, and audit logging. Errors are not propagated.
+	OnBudgetExceeded []OnBudgetExceededHook
 }
 
 // HookGroup is a named set of middleware hooks registered via
@@ -97,5 +102,7 @@ func (h AgentHooks) Merge(other AgentHooks) AgentHooks {
 		AfterMemoryLoad:   append(h.AfterMemoryLoad, other.AfterMemoryLoad...),
 		BeforeMemoryStore: append(h.BeforeMemoryStore, other.BeforeMemoryStore...),
 		AfterMemoryStore:  append(h.AfterMemoryStore, other.AfterMemoryStore...),
+
+		OnBudgetExceeded: append(h.OnBudgetExceeded, other.OnBudgetExceeded...),
 	}
 }

--- a/internal/runtime/base/budget.go
+++ b/internal/runtime/base/budget.go
@@ -1,0 +1,229 @@
+package base
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/agenticenv/agent-sdk-go/internal/types"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+)
+
+const (
+	// nanoUSDPerUSD is the number of nano-dollars per US dollar (1e9).
+	// Cost is accumulated as int64 nano-dollars to avoid float64 drift over many LLM calls.
+	nanoUSDPerUSD = 1_000_000_000
+
+	// defaultMaxApprovals is the default cap on BudgetWaitForApproval pauses per run.
+	defaultMaxApprovals = 5
+)
+
+// BudgetTracker accumulates token and cost usage for one run and checks limits.
+// It is not safe for concurrent use; callers must serialize access.
+//
+// Cost is stored internally as integer nano-dollars (1e-9 USD) to avoid floating-point
+// accumulation drift over hundreds of LLM calls. Public methods return and accept float64 USD
+// for API compatibility; conversions are performed at the boundary.
+type BudgetTracker struct {
+	cfg *types.BudgetConfig
+
+	totalTokens      int64
+	totalCostNanoUSD int64 // accumulated cost in nano-dollars
+
+	// Precomputed integer rates (nano-USD per token) derived from the config float64 rates.
+	// Computed once in NewBudgetTracker; used for accumulation instead of float64 arithmetic.
+	promptRateNanoUSDPerToken     int64
+	completionRateNanoUSDPerToken int64
+	maxCostNanoUSD                int64 // MaxCostUSD converted to nano-dollars
+
+	// watermark records the totals at the last approval boundary. After a
+	// BudgetWaitForApproval approval, it advances to the current totals so the next
+	// trigger fires only when usage grows past that point.
+	watermarkTokens      int64
+	watermarkCostNanoUSD int64
+
+	// approvalCount tracks how many BudgetWaitForApproval approvals have been granted in
+	// this run. When it reaches effectiveMaxApprovals, the next breach is treated as
+	// BudgetStopRun regardless of cfg.OnExceeded.
+	approvalCount        int
+	effectiveMaxApproval int
+
+	// hasAdded guards against RestoreState being called after the first Add, which would
+	// silently corrupt accumulated totals.
+	hasAdded bool
+}
+
+// NewBudgetTracker returns a tracker for cfg. Returns nil when cfg is nil (no enforcement).
+// Precomputes integer nano-dollar rates from the config float64 rates to avoid accumulation drift.
+func NewBudgetTracker(cfg *types.BudgetConfig) *BudgetTracker {
+	if cfg == nil {
+		return nil
+	}
+	t := &BudgetTracker{cfg: cfg}
+	// Precompute: nano-USD per token = (USD / 1M tokens) * 1e9 / 1e6 = (USD/1M) * 1000.
+	if cfg.PromptUSDPer1M > 0 {
+		t.promptRateNanoUSDPerToken = int64(math.Round(cfg.PromptUSDPer1M * 1000))
+	}
+	if cfg.CompletionUSDPer1M > 0 {
+		t.completionRateNanoUSDPerToken = int64(math.Round(cfg.CompletionUSDPer1M * 1000))
+	}
+	if cfg.MaxCostUSD > 0 {
+		t.maxCostNanoUSD = int64(math.Round(cfg.MaxCostUSD * nanoUSDPerUSD))
+	}
+	maxApprovals := cfg.MaxApprovals
+	if maxApprovals <= 0 {
+		maxApprovals = defaultMaxApprovals
+	}
+	t.effectiveMaxApproval = maxApprovals
+	return t
+}
+
+// BudgetExceededError is returned by Add or Check when a limit is breached.
+// When Kind is BudgetExceededKindTokens: TotalTokens, LimitTokens, WatermarkTokens are set.
+// When Kind is BudgetExceededKindCost: TotalCostUSD, LimitCostUSD, WatermarkCostUSD are set.
+type BudgetExceededError struct {
+	Kind             types.BudgetExceededKind
+	TotalTokens      int64
+	TotalCostUSD     float64
+	LimitTokens      int64   // effective window size (ApprovalExtraTokens or MaxTokens)
+	LimitCostUSD     float64 // effective window size in USD
+	WatermarkTokens  int64   // token total at last approval (0 if never approved)
+	WatermarkCostUSD float64 // cost total at last approval (0 if never approved)
+}
+
+func (e *BudgetExceededError) Error() string {
+	switch e.Kind {
+	case types.BudgetExceededKindCost:
+		return fmt.Sprintf(
+			"per-run budget exceeded: estimated cost $%.6f exceeds limit $%.6f (watermark $%.6f)",
+			e.TotalCostUSD, e.LimitCostUSD, e.WatermarkCostUSD,
+		)
+	default:
+		return fmt.Sprintf(
+			"per-run budget exceeded: total tokens %d exceeds limit %d (watermark %d)",
+			e.TotalTokens, e.LimitTokens, e.WatermarkTokens,
+		)
+	}
+}
+
+// Add accumulates usage from u and returns a BudgetExceededError if any limit is now exceeded.
+// Returns nil when no limit is breached. The tracker is always updated even on error.
+// u may be nil (no-op). Safe to call after a breach — subsequent calls continue accumulating.
+func (t *BudgetTracker) Add(u *interfaces.LLMUsage) error {
+	if t == nil || u == nil {
+		return nil
+	}
+	t.hasAdded = true
+	t.totalTokens += u.TotalTokens
+	t.totalCostNanoUSD += u.PromptTokens*t.promptRateNanoUSDPerToken +
+		u.CompletionTokens*t.completionRateNanoUSDPerToken
+	return t.checkLimits()
+}
+
+// Check returns a BudgetExceededError when current totals breach limits relative to the
+// watermark, without adding usage. Used after nested sub-agent runs that accumulated
+// into a shared tracker.
+func (t *BudgetTracker) Check() error {
+	if t == nil {
+		return nil
+	}
+	return t.checkLimits()
+}
+
+func (t *BudgetTracker) checkLimits() error {
+	if t.cfg.MaxTokens > 0 {
+		// ApprovalExtraTokens is set by validateBudget for wait_for_approval (defaults to
+		// MaxTokens) and cleared for stop_run, so Extra==0 always means "use MaxTokens".
+		limit := t.cfg.ApprovalExtraTokens
+		if limit == 0 {
+			limit = t.cfg.MaxTokens
+		}
+		if t.totalTokens >= t.watermarkTokens+limit {
+			return &BudgetExceededError{
+				Kind:            types.BudgetExceededKindTokens,
+				TotalTokens:     t.totalTokens,
+				LimitTokens:     limit,
+				WatermarkTokens: t.watermarkTokens,
+			}
+		}
+	}
+	if t.cfg.MaxCostUSD > 0 {
+		limit := t.cfg.ApprovalExtraCostUSD
+		limitNano := int64(math.Round(limit * nanoUSDPerUSD))
+		if limitNano == 0 {
+			limitNano = t.maxCostNanoUSD
+			limit = t.cfg.MaxCostUSD
+		}
+		if t.totalCostNanoUSD >= t.watermarkCostNanoUSD+limitNano {
+			return &BudgetExceededError{
+				Kind:             types.BudgetExceededKindCost,
+				TotalCostUSD:     float64(t.totalCostNanoUSD) / nanoUSDPerUSD,
+				LimitCostUSD:     limit,
+				WatermarkCostUSD: float64(t.watermarkCostNanoUSD) / nanoUSDPerUSD,
+			}
+		}
+	}
+	return nil
+}
+
+// AdvanceWatermark moves the approval watermark to the current totals after a
+// BudgetWaitForApproval approval and increments the approval counter.
+// Returns false when MaxApprovals has been reached — caller must treat the next breach as
+// BudgetStopRun.
+func (t *BudgetTracker) AdvanceWatermark() (approvalGranted bool) {
+	if t == nil {
+		return true
+	}
+	t.approvalCount++
+	t.watermarkTokens = t.totalTokens
+	t.watermarkCostNanoUSD = t.totalCostNanoUSD
+	return true
+}
+
+// ApprovalsExhausted reports whether the run has consumed all allowed approval pauses.
+// When true, the next budget breach must be treated as BudgetStopRun.
+func (t *BudgetTracker) ApprovalsExhausted() bool {
+	if t == nil {
+		return false
+	}
+	return t.approvalCount >= t.effectiveMaxApproval
+}
+
+// ApprovalCount returns how many BudgetWaitForApproval approvals have been granted this run.
+func (t *BudgetTracker) ApprovalCount() int {
+	if t == nil {
+		return 0
+	}
+	return t.approvalCount
+}
+
+// Totals returns the accumulated token count and estimated cost in US dollars for the run.
+func (t *BudgetTracker) Totals() (tokens int64, costUSD float64) {
+	if t == nil {
+		return 0, 0
+	}
+	return t.totalTokens, float64(t.totalCostNanoUSD) / nanoUSDPerUSD
+}
+
+// WatermarkTotals returns the token and USD values at the last approval watermark.
+func (t *BudgetTracker) WatermarkTotals() (tokens int64, costUSD float64) {
+	if t == nil {
+		return 0, 0
+	}
+	return t.watermarkTokens, float64(t.watermarkCostNanoUSD) / nanoUSDPerUSD
+}
+
+// RestoreState reloads accumulated totals and watermark values from durable state (e.g. after
+// a Temporal ContinueAsNew). Must be called before any Add; panics otherwise to prevent
+// silent corruption of accumulated totals.
+func (t *BudgetTracker) RestoreState(tokens int64, costUSD float64, wmTokens int64, wmCostUSD float64) {
+	if t == nil {
+		return
+	}
+	if t.hasAdded {
+		panic("budget: RestoreState called after Add — restore must happen before accumulation begins")
+	}
+	t.totalTokens = tokens
+	t.totalCostNanoUSD = int64(math.Round(costUSD * nanoUSDPerUSD))
+	t.watermarkTokens = wmTokens
+	t.watermarkCostNanoUSD = int64(math.Round(wmCostUSD * nanoUSDPerUSD))
+}

--- a/internal/runtime/base/budget_test.go
+++ b/internal/runtime/base/budget_test.go
@@ -1,0 +1,224 @@
+package base_test
+
+import (
+	"testing"
+
+	"github.com/agenticenv/agent-sdk-go/internal/runtime/base"
+	"github.com/agenticenv/agent-sdk-go/internal/types"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func usage(prompt, completion, total int64) *interfaces.LLMUsage {
+	return &interfaces.LLMUsage{
+		PromptTokens:     prompt,
+		CompletionTokens: completion,
+		TotalTokens:      total,
+	}
+}
+
+func TestNewBudgetTracker_NilConfig(t *testing.T) {
+	bt := base.NewBudgetTracker(nil)
+	assert.Nil(t, bt)
+	// nil tracker must be safe to call
+	assert.NoError(t, bt.Add(usage(100, 50, 150)))
+	bt.AdvanceWatermark()
+	tok, cost := bt.Totals()
+	assert.Equal(t, int64(0), tok)
+	assert.Equal(t, float64(0), cost)
+}
+
+func TestBudgetTracker_NoLimitExceeded(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  1000,
+		OnExceeded: types.BudgetStopRun,
+	})
+	require.NotNil(t, bt)
+	err := bt.Add(usage(100, 50, 150))
+	assert.NoError(t, err)
+	tokens, _ := bt.Totals()
+	assert.Equal(t, int64(150), tokens)
+}
+
+func TestBudgetTracker_TokenLimitExceeded(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	})
+	err := bt.Add(usage(60, 50, 110))
+	require.Error(t, err)
+	var budgetErr *base.BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	assert.Equal(t, types.BudgetExceededKindTokens, budgetErr.Kind)
+	assert.Equal(t, int64(110), budgetErr.TotalTokens)
+	assert.Equal(t, int64(100), budgetErr.LimitTokens)
+	assert.Equal(t, int64(0), budgetErr.WatermarkTokens)
+}
+
+func TestBudgetTracker_CostLimitExceeded(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxCostUSD:         0.001,
+		PromptUSDPer1M:     1.0,
+		CompletionUSDPer1M: 3.0,
+		OnExceeded:         types.BudgetStopRun,
+	})
+	// 500 prompt + 200 completion = 0.0005 + 0.0006 = 0.0011 USD
+	err := bt.Add(usage(500, 200, 700))
+	require.Error(t, err)
+	var budgetErr *base.BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	assert.Equal(t, types.BudgetExceededKindCost, budgetErr.Kind)
+	assert.InDelta(t, 0.0011, budgetErr.TotalCostUSD, 1e-6)
+	assert.Equal(t, float64(0), budgetErr.WatermarkCostUSD)
+}
+
+func TestBudgetTracker_AdvanceWatermark(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100, // same as MaxTokens after NewAgent defaulting
+		OnExceeded:          types.BudgetWaitForApproval,
+	})
+	// First breach at 110 tokens.
+	err := bt.Add(usage(60, 50, 110))
+	require.Error(t, err)
+
+	// Simulate approval: advance watermark.
+	assert.True(t, bt.AdvanceWatermark())
+
+	// After advancing watermark to 110, the next trigger is at watermark+extra = 110+100 = 210.
+	// Adding 15 = total 125; still under 210 — no breach.
+	err = bt.Add(usage(10, 5, 15))
+	assert.NoError(t, err, "after watermark advance small usage should not re-trigger")
+
+	// Adding 100 more brings total to 225 which exceeds 210 — new breach.
+	err = bt.Add(usage(60, 50, 100))
+	assert.Error(t, err, "exceeding watermark+limit should trigger again")
+}
+
+func TestBudgetTracker_ApprovalExtraTokens(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:           1000,
+		ApprovalExtraTokens: 100, // smaller top-up after each approval
+		OnExceeded:          types.BudgetWaitForApproval,
+	})
+	require.Error(t, bt.Add(usage(50, 50, 100))) // first window uses Extra=100
+	assert.True(t, bt.AdvanceWatermark())
+
+	require.NoError(t, bt.Add(usage(40, 40, 80))) // 180 < 100+100
+	require.Error(t, bt.Add(usage(20, 20, 40)))   // 220 >= 200
+}
+
+func TestBudgetTracker_StopRunUsesMaxTokens(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	})
+	require.NoError(t, bt.Add(usage(40, 40, 80)))
+	require.Error(t, bt.Add(usage(20, 20, 30))) // 110 >= 100
+}
+
+func TestBudgetTracker_RestoreState(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  500,
+		OnExceeded: types.BudgetStopRun,
+	})
+	// Restore: total=400, watermark=0 (never approved). Next trigger at 0+500=500.
+	bt.RestoreState(400, 0.004, 0, 0)
+	tok, cost := bt.Totals()
+	assert.Equal(t, int64(400), tok)
+	assert.InDelta(t, 0.004, cost, 1e-10)
+
+	// Adding 110 tokens brings total to 510, which crosses 0+500=500 limit.
+	err := bt.Add(usage(60, 50, 110))
+	assert.Error(t, err)
+}
+
+func TestBudgetTracker_NilUsage(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	})
+	err := bt.Add(nil)
+	assert.NoError(t, err)
+}
+
+func TestBudgetTracker_Check(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	})
+	require.NoError(t, bt.Check())
+
+	require.Error(t, bt.Add(usage(60, 50, 110)))
+	require.Error(t, bt.Check(), "Check should report breach without adding")
+
+	assert.True(t, bt.AdvanceWatermark())
+	require.NoError(t, bt.Check(), "after watermark, current totals are within the next window")
+}
+
+func TestBudgetTracker_RestoreState_PanicsAfterAdd(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:  500,
+		OnExceeded: types.BudgetStopRun,
+	})
+	_ = bt.Add(usage(10, 10, 20))
+	assert.Panics(t, func() {
+		bt.RestoreState(100, 0.001, 0, 0)
+	}, "RestoreState after Add must panic")
+}
+
+func TestBudgetTracker_ApprovalsExhausted(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+		MaxApprovals:        2,
+	})
+	assert.False(t, bt.ApprovalsExhausted())
+
+	bt.AdvanceWatermark()
+	assert.Equal(t, 1, bt.ApprovalCount())
+	assert.False(t, bt.ApprovalsExhausted())
+
+	bt.AdvanceWatermark()
+	assert.Equal(t, 2, bt.ApprovalCount())
+	assert.True(t, bt.ApprovalsExhausted(), "after MaxApprovals=2 advances, must be exhausted")
+}
+
+func TestBudgetTracker_WatermarkIncludedInError(t *testing.T) {
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	})
+	_ = bt.Add(usage(60, 50, 110)) // first breach; watermark=0
+	bt.AdvanceWatermark()          // watermark advances to 110
+
+	// Second breach; watermark should appear in error.
+	err := bt.Add(usage(60, 50, 100))
+	require.Error(t, err)
+	var budgetErr *base.BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	assert.Equal(t, int64(110), budgetErr.WatermarkTokens, "watermark should be 110 after first approval")
+	assert.Equal(t, int64(210), budgetErr.TotalTokens)
+}
+
+func TestBudgetTracker_IntegerCostAccumulation_NoDrift(t *testing.T) {
+	// Verify that 1000 identical LLM calls accumulate cost without float64 drift.
+	bt := base.NewBudgetTracker(&types.BudgetConfig{
+		MaxCostUSD:         100.0,
+		PromptUSDPer1M:     3.0,
+		CompletionUSDPer1M: 15.0,
+		OnExceeded:         types.BudgetStopRun,
+	})
+	// Each call: 100 prompt + 50 completion.
+	// cost = (100*3 + 50*15)/1e6 = (300+750)/1e6 = 0.00105 USD
+	for i := 0; i < 1000; i++ {
+		u := usage(100, 50, 150)
+		_ = bt.Add(u)
+	}
+	_, cost := bt.Totals()
+	// Expected: 1000 * 0.00105 = 1.05 USD
+	assert.InDelta(t, 1.05, cost, 1e-9, "integer accumulation must not drift beyond 1 nano-dollar")
+}

--- a/internal/runtime/local/agent_loop.go
+++ b/internal/runtime/local/agent_loop.go
@@ -3,6 +3,7 @@ package local
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/agenticenv/agent-sdk-go/internal/events"
+	"github.com/agenticenv/agent-sdk-go/internal/hooks"
 	sdkruntime "github.com/agenticenv/agent-sdk-go/internal/runtime"
 	"github.com/agenticenv/agent-sdk-go/internal/runtime/base"
 	"github.com/agenticenv/agent-sdk-go/internal/types"
@@ -52,6 +54,14 @@ type AgentLoopInput struct {
 	MemoryScope interfaces.MemoryScope
 	// RunID is the stable identifier for this agent run; passed to LLM hooks via [RunMeta].
 	RunID string
+	// BudgetTracker tracks per-run token and cost usage against the configured limits.
+	// Nil when no budget is configured. Shared with nested subagent calls; subagent calls
+	// set EnforceBudget=false so only the root run triggers OnExceeded.
+	BudgetTracker *base.BudgetTracker
+	// EnforceBudget controls whether the budget check runs after each LLM call.
+	// True on root runs when WithBudget is configured; false on nested subagent calls
+	// so the parent run's tracker accumulates child usage and enforces the limit.
+	EnforceBudget bool
 }
 
 // AgentLoopResult is the outcome of a completed local agent run.
@@ -114,6 +124,15 @@ func (rt *LocalRuntime) executeAgentLoop(ctx context.Context, input AgentLoopInp
 	toolExecMode := rt.ToolExecutionMode
 	if toolExecMode == "" {
 		toolExecMode = types.AgentToolExecutionModeParallel
+	}
+
+	// Warn when a budget is configured on a sub-agent run — the parent's budget applies and
+	// this agent's budget will not be enforced for this invocation.
+	if input.BudgetTracker != nil && !input.EnforceBudget && input.SubAgentDepth > 0 {
+		log.Warn(ctx, "local: agent has WithBudget but is running as a sub-agent; "+
+			"budget enforcement is disabled for this invocation — the parent run's budget applies",
+			slog.String("scope", "loop"),
+			slog.Int("sub_agent_depth", input.SubAgentDepth))
 	}
 
 	// Internal emit: publish events to the eventbus channel for this run.
@@ -248,6 +267,9 @@ func (rt *LocalRuntime) executeAgentLoop(ctx context.Context, input AgentLoopInp
 
 		telemetry.Run.TotalLLMCalls++
 		llmUsage = base.MergeLLMUsage(llmUsage, llmResult.Usage)
+		if budgetErr := rt.checkBudget(ctx, input, telemetry, llmResult.Usage); budgetErr != nil {
+			return &AgentLoopResult{Content: lastContent, LLMUsage: llmUsage, Telemetry: telemetry}, budgetErr
+		}
 
 		// Final response: no tool calls → done.
 		if len(llmResult.ToolCalls) == 0 {
@@ -291,6 +313,9 @@ func (rt *LocalRuntime) executeAgentLoop(ctx context.Context, input AgentLoopInp
 				return nil, fmt.Errorf("llm final call (iter %d): %w", iter, err)
 			}
 			llmUsage = base.MergeLLMUsage(llmUsage, llmResult.Usage)
+			if budgetErr := rt.checkBudget(ctx, input, telemetry, llmResult.Usage); budgetErr != nil {
+				return &AgentLoopResult{Content: lastContent, LLMUsage: llmUsage, Telemetry: telemetry}, budgetErr
+			}
 			messages = append(messages, interfaces.Message{
 				Role:    interfaces.MessageRoleAssistant,
 				Content: llmResult.Content,
@@ -353,6 +378,12 @@ func (rt *LocalRuntime) executeAgentLoop(ctx context.Context, input AgentLoopInp
 					telemetry.Storage.TotalMemoryStores++
 				}
 			}
+		}
+
+		// Nested sub-agents accumulate into the shared tracker during their run.
+		// Enforce here (like Temporal/Restate after tools), not only on the next parent LLM call.
+		if budgetErr := rt.enforceBudgetIfExceeded(ctx, input, telemetry); budgetErr != nil {
+			return &AgentLoopResult{Content: lastContent, LLMUsage: llmUsage, Telemetry: telemetry}, budgetErr
 		}
 
 		if rt.conversationMemoryEnabled(input) && rt.AgentConfig.Session.ConversationSaveOnIteration && len(messages) > persistedMessageCount {
@@ -679,11 +710,22 @@ func (rt *LocalRuntime) executeSingleTool(
 						SubAgentDepth:    input.SubAgentDepth + 1,
 						MaxSubAgentDepth: input.MaxSubAgentDepth,
 						Tools:            subAgentRoute.tools,
+						BudgetTracker:    input.BudgetTracker,
+						EnforceBudget:    false,
 					})
 				})
 				emit(events.NewAgentStepFinishedEvent(delegationName))
 				if execErr != nil {
-					content = "Sub-agent execution failed: " + execErr.Error()
+					if errors.Is(execErr, types.ErrBudgetExceeded) {
+						// Nested child stopped after shared budget Add; parent enforces after tools.
+						if subResult != nil && strings.TrimSpace(subResult.Content) != "" {
+							content = subResult.Content
+						} else {
+							content = "Sub-agent stopped: per-run budget exceeded."
+						}
+					} else {
+						content = "Sub-agent execution failed: " + execErr.Error()
+					}
 				} else {
 					content = subResult.Content
 				}
@@ -875,4 +917,192 @@ func (rt *LocalRuntime) subAgentExecutionPolicy() sdkruntime.ExecutionPolicy {
 		policy.Timeout = rt.AgentConfig.Limits.Timeout
 	}
 	return policy
+}
+
+// checkBudget runs after each LLM call. Parent runs (EnforceBudget) add usage and apply
+// OnExceeded. Nested sub-agents only accumulate into the shared tracker; on breach they
+// return ErrBudgetExceeded so the child stops and the parent can enforce after tools.
+func (rt *LocalRuntime) checkBudget(
+	ctx context.Context,
+	input AgentLoopInput,
+	telemetry *types.AgentTelemetry,
+	usage *interfaces.LLMUsage,
+) error {
+	if input.BudgetTracker == nil {
+		return nil
+	}
+	if !input.EnforceBudget {
+		if err := input.BudgetTracker.Add(usage); err != nil {
+			return fmt.Errorf("%w: %s", types.ErrBudgetExceeded, err.Error())
+		}
+		return nil
+	}
+	budgetErr := input.BudgetTracker.Add(usage)
+	if budgetErr == nil {
+		return nil
+	}
+	return rt.applyBudgetExceeded(ctx, input, telemetry, budgetErr)
+}
+
+// enforceBudgetIfExceeded applies OnExceeded when the shared tracker is already over limits
+// (e.g. after a nested sub-agent accumulated past the parent budget).
+func (rt *LocalRuntime) enforceBudgetIfExceeded(
+	ctx context.Context,
+	input AgentLoopInput,
+	telemetry *types.AgentTelemetry,
+) error {
+	if !input.EnforceBudget || input.BudgetTracker == nil {
+		return nil
+	}
+	budgetErr := input.BudgetTracker.Check()
+	if budgetErr == nil {
+		return nil
+	}
+	return rt.applyBudgetExceeded(ctx, input, telemetry, budgetErr)
+}
+
+func (rt *LocalRuntime) applyBudgetExceeded(
+	ctx context.Context,
+	input AgentLoopInput,
+	telemetry *types.AgentTelemetry,
+	budgetErr error,
+) error {
+	cfg := rt.AgentConfig.Limits.Budget
+	action := types.BudgetStopRun
+	if cfg != nil && cfg.OnExceeded != "" {
+		action = cfg.OnExceeded
+	}
+
+	var budgetExcErr *base.BudgetExceededError
+	errors.As(budgetErr, &budgetExcErr)
+
+	kind := types.BudgetExceededKindTokens
+	var totalTokens int64
+	var totalCostUSD float64
+	if budgetExcErr != nil {
+		kind = budgetExcErr.Kind
+		totalTokens = budgetExcErr.TotalTokens
+		totalCostUSD = budgetExcErr.TotalCostUSD
+	} else {
+		totalTokens, totalCostUSD = input.BudgetTracker.Totals()
+	}
+
+	approvalsExhausted := action == types.BudgetWaitForApproval && input.BudgetTracker.ApprovalsExhausted()
+	approvalCount := input.BudgetTracker.ApprovalCount()
+
+	kindAttr := interfaces.Attribute{Key: types.MetricAttrBudgetKind, Value: string(kind)}
+	actionAttr := interfaces.Attribute{Key: types.MetricAttrBudgetAction, Value: string(action)}
+
+	rt.Metrics.IncrementCounter(ctx, types.MetricBudgetExceeded, kindAttr, actionAttr)
+
+	rt.logger.Warn(ctx, "local: per-run budget exceeded",
+		slog.String("scope", "loop"),
+		slog.String("action", string(action)),
+		slog.String("budget.kind", string(kind)),
+		slog.Int64("budget.total_tokens", int64(totalTokens)),
+		slog.Float64("budget.total_cost_usd", totalCostUSD),
+		slog.Int("budget.approval_count", approvalCount),
+		slog.Bool("budget.approvals_exhausted", approvalsExhausted),
+		slog.String("detail", budgetErr.Error()))
+
+	hooks.RunOnBudgetExceeded(ctx, rt.AgentConfig.Hooks, hooks.OnBudgetExceededHookInput{
+		RunMeta:            hooks.RunMeta{RunID: input.RunID},
+		Kind:               kind,
+		TotalTokens:        totalTokens,
+		TotalCostUSD:       totalCostUSD,
+		Action:             action,
+		ApprovalCount:      approvalCount,
+		ApprovalsExhausted: approvalsExhausted,
+	})
+
+	if action == types.BudgetWaitForApproval && !approvalsExhausted {
+		rt.Metrics.IncrementCounter(ctx, types.MetricBudgetApprovalRequested, kindAttr)
+		status := rt.awaitBudgetApprovalStatus(ctx, input, budgetErr.Error())
+		switch status {
+		case types.ApprovalStatusApproved:
+			rt.Metrics.IncrementCounter(ctx, types.MetricBudgetApprovalApproved, kindAttr)
+			input.BudgetTracker.AdvanceWatermark()
+			return nil
+		case types.ApprovalStatusTimedOut:
+			rt.Metrics.IncrementCounter(ctx, types.MetricBudgetApprovalTimedOut, kindAttr)
+		case types.ApprovalStatusUnavailable:
+			rt.Metrics.IncrementCounter(ctx, types.MetricBudgetApprovalUnavailable, kindAttr)
+			rt.logger.Warn(ctx, "local: budget approval unavailable (no subscriber); stopping run",
+				slog.String("scope", "loop"))
+			telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+			return fmt.Errorf("%w: %s", types.ErrBudgetApprovalUnavailable, budgetErr.Error())
+		default:
+			rt.Metrics.IncrementCounter(ctx, types.MetricBudgetApprovalRejected, kindAttr)
+		}
+	} else if action == types.BudgetWaitForApproval && approvalsExhausted {
+		rt.Metrics.IncrementCounter(ctx, types.MetricBudgetApprovalExhausted, kindAttr)
+		rt.logger.Warn(ctx, "local: budget approval limit exhausted; stopping run",
+			slog.String("scope", "loop"),
+			slog.Int("budget.max_approvals", cfg.MaxApprovals))
+	}
+
+	telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+	return fmt.Errorf("%w: %w", types.ErrBudgetExceeded, budgetErr)
+}
+
+// awaitBudgetApprovalStatus sends a CUSTOM budget_approval event and invokes the approval
+// handler. Returns the resolved ApprovalStatus. Returns ApprovalStatusUnavailable when
+// there is no subscriber connected (channel empty and no handler configured).
+func (rt *LocalRuntime) awaitBudgetApprovalStatus(ctx context.Context, input AgentLoopInput, detail string) types.ApprovalStatus {
+	token := uuid.New().String()
+	resultCh := make(chan types.ApprovalStatus, 1)
+	respond := func(status types.ApprovalStatus) error {
+		select {
+		case resultCh <- status:
+		default:
+		}
+		return nil
+	}
+
+	tokens, costUSD := input.BudgetTracker.Totals()
+	value := types.BudgetApprovalRequestValue{
+		AgentName:     rt.AgentSpec.Name,
+		Detail:        detail,
+		TotalTokens:   tokens,
+		CostUSD:       costUSD,
+		ApprovalToken: token,
+	}
+	approvalReq := &types.ApprovalRequest{
+		Name:    types.ApprovalRequestNameBudget,
+		Value:   value,
+		Respond: respond,
+	}
+
+	// Register the token so streaming callers can call Stream.Approve(token, status) to unblock.
+	rt.pendingApprovals.Store(token, resultCh)
+	defer rt.pendingApprovals.Delete(token)
+
+	// Emit CUSTOM event for streaming callers so they can call Stream.Approve(token, status).
+	hasChannel := strings.TrimSpace(input.ChannelName) != ""
+	rt.publishEventToChannel(ctx, input.ChannelName, events.NewAgentCustomEvent(string(events.AgentCustomEventNameBudget),
+		events.AgentCustomEventBudgetValue{
+			AgentName:     value.AgentName,
+			Detail:        value.Detail,
+			TotalTokens:   value.TotalTokens,
+			CostUSD:       value.CostUSD,
+			ApprovalToken: value.ApprovalToken,
+		}))
+
+	// Non-streaming: call the approval handler synchronously.
+	if input.ApprovalHandler != nil {
+		approvalTimeout := rt.approvalTaskTimeout()
+		approvalCtx, cancel := context.WithTimeout(ctx, approvalTimeout)
+		input.ApprovalHandler(approvalCtx, approvalReq)
+		cancel()
+	} else if !hasChannel {
+		// No handler and no stream channel — cannot deliver the approval request.
+		return types.ApprovalStatusUnavailable
+	}
+
+	select {
+	case status := <-resultCh:
+		return status
+	case <-ctx.Done():
+		return types.ApprovalStatusRejected
+	}
 }

--- a/internal/runtime/local/budget_test.go
+++ b/internal/runtime/local/budget_test.go
@@ -1,0 +1,526 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	sdkruntime "github.com/agenticenv/agent-sdk-go/internal/runtime"
+	"github.com/agenticenv/agent-sdk-go/internal/runtime/base"
+	"github.com/agenticenv/agent-sdk-go/internal/types"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	"github.com/agenticenv/agent-sdk-go/pkg/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// llmClientWithUsage wraps a seqLLMClient and injects LLMUsage into responses.
+type llmClientWithUsage struct {
+	mu        sync.Mutex
+	responses []*interfaces.LLMResponse
+	call      int
+}
+
+func (s *llmClientWithUsage) Generate(_ context.Context, _ *interfaces.LLMRequest) (*interfaces.LLMResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	i := s.call
+	s.call++
+	if i < len(s.responses) {
+		return s.responses[i], nil
+	}
+	return &interfaces.LLMResponse{Content: "done"}, nil
+}
+func (s *llmClientWithUsage) GenerateStream(_ context.Context, _ *interfaces.LLMRequest) (interfaces.LLMStream, error) {
+	return nil, errors.New("stream not implemented")
+}
+func (s *llmClientWithUsage) GetModel() string { return "budget-test-model" }
+func (s *llmClientWithUsage) GetProvider() interfaces.LLMProvider {
+	return interfaces.LLMProviderOpenAI
+}
+func (s *llmClientWithUsage) IsStreamSupported() bool { return false }
+
+func llmResp(content string, promptTokens, completionTokens, totalTokens int64) *interfaces.LLMResponse {
+	return &interfaces.LLMResponse{
+		Content: content,
+		Usage: &interfaces.LLMUsage{
+			PromptTokens:     promptTokens,
+			CompletionTokens: completionTokens,
+			TotalTokens:      totalTokens,
+		},
+	}
+}
+
+func newBudgetRT(t *testing.T, budget *types.BudgetConfig, client interfaces.LLMClient, approvalHandler types.ApprovalHandler) *LocalRuntime {
+	t.Helper()
+	rt, err := NewLocalRuntime(
+		WithLogger(logger.NoopLogger()),
+		WithAgentSpec(sdkruntime.AgentSpec{Name: "budget-agent", SystemPrompt: "sys"}),
+		WithAgentConfig(sdkruntime.AgentConfig{
+			LLM: sdkruntime.AgentLLM{Client: client},
+			Limits: sdkruntime.AgentLimits{
+				MaxIterations:   10,
+				Timeout:         10 * time.Second,
+				ApprovalTimeout: 5 * time.Second,
+				Budget:          budget,
+			},
+		}),
+		WithApprovalHandler(approvalHandler),
+	)
+	require.NoError(t, err)
+	return rt
+}
+
+// TestBudgetEnforcement_StopRun verifies that when MaxTokens is exceeded and
+// OnExceeded is BudgetStopRun, the loop returns ErrBudgetExceeded and sets
+// FinishReasonBudgetExceeded.
+func TestBudgetEnforcement_StopRun(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("answer", 60, 50, 110), // 110 tokens → exceeds MaxTokens=100
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	rt := newBudgetRT(t, budget, client, nil)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:    "hello",
+		BudgetTracker: tracker,
+		EnforceBudget: true,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded), "expected ErrBudgetExceeded, got: %v", err)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+// TestBudgetEnforcement_NoBudget verifies that when no budget is configured
+// the loop completes normally even with high token usage.
+func TestBudgetEnforcement_NoBudget(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("answer", 1000, 2000, 3000),
+		},
+	}
+	rt := newBudgetRT(t, nil, client, nil)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:    "hello",
+		BudgetTracker: nil,
+		EnforceBudget: false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "answer", result.Content)
+}
+
+// TestBudgetEnforcement_WaitForApproval_Approved verifies that when BudgetWaitForApproval
+// is configured and the approval handler approves, the run completes (not stopped with error).
+// The LLM returned a final answer (no tool calls) during the breaching iteration, so "first"
+// is returned after approval because the loop already had its final answer.
+func TestBudgetEnforcement_WaitForApproval_Approved(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("first", 60, 50, 110), // exceeds 100 → approval requested; no tool calls → final answer
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	approvalHandler := func(_ context.Context, req *types.ApprovalRequest) {
+		_ = req.Respond(types.ApprovalStatusApproved)
+	}
+	rt := newBudgetRT(t, budget, client, approvalHandler)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:      "hello",
+		BudgetTracker:   tracker,
+		EnforceBudget:   true,
+		ApprovalHandler: approvalHandler,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "first", result.Content)
+}
+
+// TestBudgetEnforcement_WaitForApproval_Denied verifies that when BudgetWaitForApproval
+// is configured and the approval handler denies, the run stops with ErrBudgetExceeded.
+func TestBudgetEnforcement_WaitForApproval_Denied(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("first", 60, 50, 110), // exceeds 100 → approval requested
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	approvalHandler := func(_ context.Context, req *types.ApprovalRequest) {
+		_ = req.Respond(types.ApprovalStatusRejected)
+	}
+	rt := newBudgetRT(t, budget, client, approvalHandler)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:      "hello",
+		BudgetTracker:   tracker,
+		EnforceBudget:   true,
+		ApprovalHandler: approvalHandler,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded))
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+// TestBudgetEnforcement_SubagentAccumulatesUnderLimit runs a real nested sub-agent that
+// stays under the shared parent budget; usage is accumulated and the parent continues.
+func TestBudgetEnforcement_SubagentAccumulatesUnderLimit(t *testing.T) {
+	budget := &types.BudgetConfig{
+		MaxTokens:  1000,
+		OnExceeded: types.BudgetStopRun,
+	}
+	tracker := base.NewBudgetTracker(budget)
+
+	childClient := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("child done", 50, 50, 100),
+		},
+	}
+	childRT := newBudgetRT(t, nil, childClient, nil)
+
+	parentClient := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			{
+				ToolCalls: []*interfaces.ToolCall{{
+					ToolCallID: "c1",
+					ToolName:   "research",
+					Args:       map[string]any{"query": "q"},
+				}},
+				Usage: &interfaces.LLMUsage{PromptTokens: 5, CompletionTokens: 5, TotalTokens: 10},
+			},
+			llmResp("parent done", 5, 5, 10),
+		},
+	}
+	parentRT := newBudgetRT(t, budget, parentClient, nil)
+	delegateTool := stubKindTool{
+		stubTool: stubTool{name: "research", result: "unused"},
+		kind:     types.ToolKindSubAgent,
+	}
+
+	result, err := parentRT.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:       "go",
+		Tools:            []interfaces.Tool{delegateTool},
+		BudgetTracker:    tracker,
+		EnforceBudget:    true,
+		MaxSubAgentDepth: 2,
+		SubAgentRoutes: map[string]subAgentRoute{
+			"research": {name: "researcher", runtime: childRT},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "parent done", result.Content)
+
+	tokens, _ := tracker.Totals()
+	assert.Equal(t, int64(120), tokens, "parent + child LLM usage should accumulate in shared tracker")
+}
+
+// TestBudgetEnforcement_AfterNestedSubagent verifies the parent enforces immediately
+// after a nested sub-agent returns (shared tracker already over limit), without waiting
+// for another parent LLM call.
+func TestBudgetEnforcement_AfterNestedSubagent(t *testing.T) {
+	budget := &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	tracker := base.NewBudgetTracker(budget)
+
+	childClient := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("child done", 50, 50, 100), // pushes shared total over 100
+		},
+	}
+	childRT := newBudgetRT(t, nil, childClient, nil)
+
+	parentClient := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			{
+				ToolCalls: []*interfaces.ToolCall{{
+					ToolCallID: "c1",
+					ToolName:   "research",
+					Args:       map[string]any{"query": "q"},
+				}},
+				Usage: &interfaces.LLMUsage{PromptTokens: 5, CompletionTokens: 5, TotalTokens: 10},
+			},
+			llmResp("should-not-run", 1, 1, 2),
+		},
+	}
+	parentRT := newBudgetRT(t, budget, parentClient, nil)
+	delegateTool := stubKindTool{
+		stubTool: stubTool{name: "research", result: "unused"},
+		kind:     types.ToolKindSubAgent,
+	}
+
+	result, err := parentRT.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:       "go",
+		Tools:            []interfaces.Tool{delegateTool},
+		BudgetTracker:    tracker,
+		EnforceBudget:    true,
+		MaxSubAgentDepth: 2,
+		SubAgentRoutes: map[string]subAgentRoute{
+			"research": {name: "researcher", runtime: childRT},
+		},
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded), "expected ErrBudgetExceeded, got: %v", err)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+
+	parentClient.mu.Lock()
+	parentCalls := parentClient.call
+	parentClient.mu.Unlock()
+	assert.Equal(t, 1, parentCalls, "parent must not make another LLM call after nested budget stop")
+
+	tokens, _ := tracker.Totals()
+	assert.Equal(t, int64(110), tokens)
+}
+
+// TestBudgetEnforcement_AfterNestedSubagent_WaitForApproval verifies nested over-limit
+// uses wait-for-approval on the parent after the child returns.
+func TestBudgetEnforcement_AfterNestedSubagent_WaitForApproval(t *testing.T) {
+	budget := &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	tracker := base.NewBudgetTracker(budget)
+
+	childClient := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("child done", 50, 50, 100),
+		},
+	}
+	childRT := newBudgetRT(t, nil, childClient, nil)
+
+	parentClient := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			{
+				ToolCalls: []*interfaces.ToolCall{{
+					ToolCallID: "c1",
+					ToolName:   "research",
+					Args:       map[string]any{"query": "q"},
+				}},
+				Usage: &interfaces.LLMUsage{PromptTokens: 5, CompletionTokens: 5, TotalTokens: 10},
+			},
+			llmResp("parent after approve", 5, 5, 10),
+		},
+	}
+	approvalHandler := func(_ context.Context, req *types.ApprovalRequest) {
+		require.Equal(t, types.ApprovalRequestNameBudget, req.Name)
+		_ = req.Respond(types.ApprovalStatusApproved)
+	}
+	parentRT := newBudgetRT(t, budget, parentClient, approvalHandler)
+	delegateTool := stubKindTool{
+		stubTool: stubTool{name: "research", result: "unused"},
+		kind:     types.ToolKindSubAgent,
+	}
+
+	result, err := parentRT.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:       "go",
+		Tools:            []interfaces.Tool{delegateTool},
+		BudgetTracker:    tracker,
+		EnforceBudget:    true,
+		ApprovalHandler:  approvalHandler,
+		MaxSubAgentDepth: 2,
+		SubAgentRoutes: map[string]subAgentRoute{
+			"research": {name: "researcher", runtime: childRT},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "parent after approve", result.Content)
+}
+
+// TestBudgetEnforcement_StopRun_MaxCostUSD exercises cost-limit enforcement in the local loop.
+func TestBudgetEnforcement_StopRun_MaxCostUSD(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			{
+				Content: "too costly",
+				Usage: &interfaces.LLMUsage{
+					PromptTokens:     500,
+					CompletionTokens: 200,
+					TotalTokens:      700,
+				},
+			},
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxCostUSD:         0.001,
+		PromptUSDPer1M:     1.0,
+		CompletionUSDPer1M: 3.0,
+		OnExceeded:         types.BudgetStopRun,
+	}
+	rt := newBudgetRT(t, budget, client, nil)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:    "hello",
+		BudgetTracker: tracker,
+		EnforceBudget: true,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded), "got: %v", err)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+// TestBudgetEnforcement_TokenAndCostSimultaneous verifies that when both MaxTokens and
+// MaxCostUSD are set, the token limit fires first (checked before cost in checkLimits).
+func TestBudgetEnforcement_TokenAndCostSimultaneous(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			// 110 tokens → exceeds MaxTokens=100 AND would exceed MaxCostUSD if checked.
+			llmResp("answer", 60, 50, 110),
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxTokens:          100,
+		MaxCostUSD:         0.001,
+		PromptUSDPer1M:     1.0,
+		CompletionUSDPer1M: 3.0,
+		OnExceeded:         types.BudgetStopRun,
+	}
+	rt := newBudgetRT(t, budget, client, nil)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:    "hello",
+		BudgetTracker: tracker,
+		EnforceBudget: true,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded))
+	// Token limit fires first: the BudgetExceededError kind must be tokens.
+	var budgetErr *base.BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	assert.Equal(t, types.BudgetExceededKindTokens, budgetErr.Kind)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+// TestBudgetEnforcement_CostLimitBeforeTokenLimit verifies cost fires when token limit is not set
+// and cost is breached first.
+func TestBudgetEnforcement_CostLimitBeforeTokenLimit(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("answer", 500, 200, 700),
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxCostUSD:         0.001,
+		PromptUSDPer1M:     1.0,
+		CompletionUSDPer1M: 3.0,
+		OnExceeded:         types.BudgetStopRun,
+	}
+	rt := newBudgetRT(t, budget, client, nil)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:    "hello",
+		BudgetTracker: tracker,
+		EnforceBudget: true,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded))
+	var budgetErr *base.BudgetExceededError
+	require.ErrorAs(t, err, &budgetErr)
+	assert.Equal(t, types.BudgetExceededKindCost, budgetErr.Kind)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+// TestBudgetEnforcement_ApprovalTimedOut verifies that a timed-out budget approval
+// (handler never responds within timeout) stops the run with ErrBudgetExceeded.
+func TestBudgetEnforcement_ApprovalTimedOut(t *testing.T) {
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			llmResp("first", 60, 50, 110), // exceeds 100 → approval requested
+		},
+	}
+	budget := &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	// Handler never responds — the run context will expire or the loop will timeout.
+	// We simulate a timed-out response by sending ApprovalStatusTimedOut from the handler.
+	approvalHandler := func(_ context.Context, req *types.ApprovalRequest) {
+		_ = req.Respond(types.ApprovalStatusTimedOut)
+	}
+	rt := newBudgetRT(t, budget, client, approvalHandler)
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:      "hello",
+		BudgetTracker:   tracker,
+		EnforceBudget:   true,
+		ApprovalHandler: approvalHandler,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded), "timed-out approval must stop the run: %v", err)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+// TestBudgetEnforcement_MaxApprovalsExhausted verifies that once MaxApprovals is reached
+// the next budget breach stops the run even though OnExceeded is BudgetWaitForApproval.
+// The LLM first returns a tool call (so the loop iterates), approval #1 is granted, then
+// on the second LLM call the total exceeds the budget again and MaxApprovals is exhausted.
+func TestBudgetEnforcement_MaxApprovalsExhausted(t *testing.T) {
+	// MaxApprovals=1: first breach → approval; second breach → exhausted → stop.
+	budget := &types.BudgetConfig{
+		MaxTokens:           50,
+		ApprovalExtraTokens: 50,
+		OnExceeded:          types.BudgetWaitForApproval,
+		MaxApprovals:        1,
+	}
+
+	approvalCalls := 0
+	approvalHandler := func(_ context.Context, req *types.ApprovalRequest) {
+		approvalCalls++
+		_ = req.Respond(types.ApprovalStatusApproved)
+	}
+
+	client := &llmClientWithUsage{
+		responses: []*interfaces.LLMResponse{
+			// First call: tool call + 60 tokens → 60 > MaxTokens(50) → approval #1 → approved.
+			// Loop continues because there are tool calls.
+			{
+				ToolCalls: []*interfaces.ToolCall{{
+					ToolCallID: "c1",
+					ToolName:   "noop",
+					Args:       map[string]any{},
+				}},
+				Usage: &interfaces.LLMUsage{PromptTokens: 30, CompletionTokens: 30, TotalTokens: 60},
+			},
+			// Second call: 60 more tokens → total=120 >= watermark(60)+50=110 → breach again.
+			// MaxApprovals=1 already exhausted → stop with ErrBudgetExceeded.
+			llmResp("second", 30, 30, 60),
+		},
+	}
+	rt := newBudgetRT(t, budget, client, approvalHandler)
+	noopTool := stubTool{name: "noop", result: "ok"}
+	tracker := base.NewBudgetTracker(budget)
+	result, err := rt.executeAgentLoop(context.Background(), AgentLoopInput{
+		UserPrompt:      "hello",
+		Tools:           []interfaces.Tool{noopTool},
+		BudgetTracker:   tracker,
+		EnforceBudget:   true,
+		ApprovalHandler: approvalHandler,
+	})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, types.ErrBudgetExceeded), "got: %v", err)
+	require.NotNil(t, result)
+	assert.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+	assert.Equal(t, 1, approvalCalls, "approval handler should be called exactly once before exhaustion")
+}

--- a/internal/runtime/local/runtime.go
+++ b/internal/runtime/local/runtime.go
@@ -168,6 +168,7 @@ func (rt *LocalRuntime) driveRun(runCtx context.Context, req *sdkruntime.RunRequ
 		eventTypes = []events.AgentEventType{events.AgentEventTypeCustom}
 	}
 
+	budgetTracker := base.NewBudgetTracker(rt.AgentConfig.Limits.Budget)
 	loopResult, err := rt.executeAgentLoop(runCtx, AgentLoopInput{
 		UserPrompt:       req.UserPrompt,
 		RunID:            handle.id,
@@ -181,6 +182,8 @@ func (rt *LocalRuntime) driveRun(runCtx context.Context, req *sdkruntime.RunRequ
 		SubAgentDepth:    0,
 		MaxSubAgentDepth: req.MaxSubAgentDepth,
 		Tools:            req.Tools,
+		BudgetTracker:    budgetTracker,
+		EnforceBudget:    budgetTracker != nil,
 	})
 	if err != nil {
 		rt.logger.Error(runCtx, "runtime run failed",
@@ -309,6 +312,7 @@ func (rt *LocalRuntime) driveStream(
 		streamEventTypes = req.EventTypes
 	}
 
+	streamBudgetTracker := base.NewBudgetTracker(rt.AgentConfig.Limits.Budget)
 	result, loopErr := rt.executeAgentLoop(runCtx, AgentLoopInput{
 		UserPrompt:       req.UserPrompt,
 		RunID:            handle.id,
@@ -322,6 +326,8 @@ func (rt *LocalRuntime) driveStream(
 		SubAgentDepth:    0,
 		MaxSubAgentDepth: req.MaxSubAgentDepth,
 		Tools:            req.Tools,
+		BudgetTracker:    streamBudgetTracker,
+		EnforceBudget:    streamBudgetTracker != nil,
 	})
 	if loopErr != nil {
 		rt.logger.Error(runCtx, "runtime stream run failed",

--- a/internal/runtime/restate/agent_loop.go
+++ b/internal/runtime/restate/agent_loop.go
@@ -3,6 +3,7 @@ package restate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -223,7 +224,10 @@ func (s AgentLoop) handle(ctx restatesdk.Context, req AgentLoopRequest) (*AgentL
 		Tools:            tools,
 	})
 	if err != nil {
-		return nil, err
+		if isApplicationLoopError(err) {
+			s.rt.tools.stash.Delete(req.RunID)
+		}
+		return nil, terminalLoopError(err)
 	}
 
 	// Release the stash entry after success.
@@ -266,6 +270,27 @@ func (rt *RestateRuntime) validateAgentName(agentName string) error {
 		return nil
 	}
 	return fmt.Errorf("restate: agent name %q does not match this AgentLoop (%q)", agentName, rt.AgentSpec.Name)
+}
+
+// isApplicationLoopError reports errors that finish the run (do not retry).
+func isApplicationLoopError(err error) bool {
+	return errors.Is(err, types.ErrBudgetExceeded) || errors.Is(err, types.ErrBudgetApprovalUnavailable)
+}
+
+// terminalLoopError marks application-complete failures as Restate terminal so
+// the invocation is not retried (BudgetStopRun would otherwise loop forever).
+// ToTerminalError copies the message only, so the sentinel is re-wrapped for errors.Is.
+func terminalLoopError(err error) error {
+	if err == nil || restatesdk.IsTerminalError(err) {
+		return err
+	}
+	switch {
+	case errors.Is(err, types.ErrBudgetExceeded):
+		return fmt.Errorf("%w: %w", types.ErrBudgetExceeded, restatesdk.ToTerminalError(err))
+	case errors.Is(err, types.ErrBudgetApprovalUnavailable):
+		return fmt.Errorf("%w: %w", types.ErrBudgetApprovalUnavailable, restatesdk.ToTerminalError(err))
+	}
+	return err
 }
 
 // isMemoryScopeSet reports whether any field of a MemoryScope is populated.

--- a/internal/runtime/restate/agent_loop.go
+++ b/internal/runtime/restate/agent_loop.go
@@ -99,8 +99,9 @@ type AgentLoopResult struct {
 // toolResult holds the output of a single tool execution step.
 // Mirrors toolResult in the local runtime.
 type toolResult struct {
-	message interfaces.Message
-	failed  bool // true: hard error, ExecuteTool failure, or context cancellation
+	message  interfaces.Message
+	failed   bool // true: hard error, ExecuteTool failure, or context cancellation
+	llmUsage *interfaces.LLMUsage
 }
 
 // toolCallState tracks per-tool approval and completion status during parallel execution.
@@ -375,6 +376,11 @@ func (rt *RestateRuntime) executeAgentLoop(ctx restatesdk.Context, input AgentLo
 		telemetry.Storage.PrefetchSearches += res.TotalSearches
 	}
 
+	// Budget tracker: nil when no budget is configured.
+	// enforceBudget is true on root runs (EventTopic not inherited from a parent).
+	budgetTracker := base.NewBudgetTracker(rt.AgentConfig.Limits.Budget)
+	enforceBudget := budgetTracker != nil && input.SubAgentDepth == 0
+
 	var lastContent string
 	var llmUsage *interfaces.LLMUsage
 
@@ -403,6 +409,9 @@ func (rt *RestateRuntime) executeAgentLoop(ctx restatesdk.Context, input AgentLo
 		}
 		telemetry.Run.TotalLLMCalls++
 		llmUsage = base.MergeLLMUsage(llmUsage, llmResult.Usage)
+		if budgetErr := rt.checkBudget(ctx, budgetTracker, enforceBudget, telemetry, llmResult.Usage, emit); budgetErr != nil {
+			return &AgentLoopResult{Content: lastContent, LLMUsage: llmUsage, Telemetry: telemetry}, budgetErr
+		}
 
 		if len(llmResult.ToolCalls) == 0 {
 			messages = append(messages, interfaces.Message{Role: interfaces.MessageRoleAssistant, Content: llmResult.Content})
@@ -433,6 +442,9 @@ func (rt *RestateRuntime) executeAgentLoop(ctx restatesdk.Context, input AgentLo
 				return nil, fmt.Errorf("llm final call (iter %d): %w", iter, err)
 			}
 			llmUsage = base.MergeLLMUsage(llmUsage, llmResult.Usage)
+			if budgetErr := rt.checkBudget(ctx, budgetTracker, enforceBudget, telemetry, llmResult.Usage, emit); budgetErr != nil {
+				return &AgentLoopResult{Content: lastContent, LLMUsage: llmUsage, Telemetry: telemetry}, budgetErr
+			}
 			messages = append(messages, interfaces.Message{Role: interfaces.MessageRoleAssistant, Content: llmResult.Content})
 			lastContent = llmResult.Content
 			telemetry.Run.TotalLLMCalls++
@@ -490,6 +502,12 @@ func (rt *RestateRuntime) executeAgentLoop(ctx restatesdk.Context, input AgentLo
 					telemetry.Storage.FailedMemoryStores++
 				} else {
 					telemetry.Storage.TotalMemoryStores++
+				}
+			}
+			if res.llmUsage != nil {
+				llmUsage = base.MergeLLMUsage(llmUsage, res.llmUsage)
+				if budgetErr := rt.checkBudget(ctx, budgetTracker, enforceBudget, telemetry, res.llmUsage, emit); budgetErr != nil {
+					return &AgentLoopResult{Content: lastContent, LLMUsage: llmUsage, Telemetry: telemetry}, budgetErr
 				}
 			}
 		}
@@ -775,11 +793,12 @@ func (rt *RestateRuntime) executeToolsParallel(
 			continue
 		}
 		tc := states[i].tc
-		content, execErr := rt.delegateToSubAgent(ctx, input, tc, input.SubAgentRoutes[tc.ToolName], emit)
+		content, usage, execErr := rt.delegateToSubAgent(ctx, input, tc, input.SubAgentRoutes[tc.ToolName], emit)
 		if execErr != nil {
 			writeResult(i, "Tool execution failed: "+execErr.Error(), true)
 		} else {
 			writeResult(i, content, false)
+			results[i].llmUsage = usage
 		}
 	}
 	return results, nil
@@ -834,11 +853,12 @@ func (rt *RestateRuntime) executeSingleTool(
 
 	var content string
 	failed := false
+	var llmUsage *interfaces.LLMUsage
 	subAgentRoute, isSubAgent := input.SubAgentRoutes[tc.ToolName]
 	switch approvalStatus {
 	case types.ApprovalStatusApproved:
 		if isSubAgent {
-			content, err = rt.delegateToSubAgent(ctx, input, tc, subAgentRoute, emit)
+			content, llmUsage, err = rt.delegateToSubAgent(ctx, input, tc, subAgentRoute, emit)
 			if err != nil {
 				return toolResult{}, err
 			}
@@ -876,7 +896,7 @@ func (rt *RestateRuntime) executeSingleTool(
 	return toolResult{message: interfaces.Message{
 		Role: interfaces.MessageRoleTool, Content: content,
 		ToolName: tc.ToolName, ToolCallID: tc.ToolCallID,
-	}, failed: failed}, nil
+	}, failed: failed, llmUsage: llmUsage}, nil
 }
 
 // awaitApproval creates a Restate awakeable, emits the approval CUSTOM event with the token,
@@ -932,6 +952,96 @@ func emitApprovalRequest(
 			}))
 	}
 	return awakeable, restatesdk.After(ctx, rt.approvalTaskTimeout())
+}
+
+// checkBudget adds usage to the tracker and, when enforceBudget is true, applies OnExceeded.
+func (rt *RestateRuntime) checkBudget(
+	ctx restatesdk.Context,
+	tracker *base.BudgetTracker,
+	enforceBudget bool,
+	telemetry *types.AgentTelemetry,
+	usage *interfaces.LLMUsage,
+	emit func(events.AgentEvent),
+) error {
+	if !enforceBudget || tracker == nil {
+		if tracker != nil {
+			_ = tracker.Add(usage)
+		}
+		return nil
+	}
+	budgetErr := tracker.Add(usage)
+	if budgetErr == nil {
+		return nil
+	}
+	return rt.handleBudgetExceeded(ctx, tracker, telemetry, budgetErr, emit)
+}
+
+// handleBudgetExceeded applies OnExceeded: stop the run, or wait for approval then continue.
+func (rt *RestateRuntime) handleBudgetExceeded(
+	ctx restatesdk.Context,
+	tracker *base.BudgetTracker,
+	telemetry *types.AgentTelemetry,
+	budgetErr error,
+	emit func(events.AgentEvent),
+) error {
+	cfg := rt.AgentConfig.Limits.Budget
+	action := types.BudgetStopRun
+	if cfg != nil && cfg.OnExceeded != "" {
+		action = cfg.OnExceeded
+	}
+	rt.logger.Warn(ctx, "restate: per-run budget exceeded",
+		slog.String("scope", "loop"),
+		slog.String("action", string(action)),
+		slog.String("detail", budgetErr.Error()))
+
+	if action == types.BudgetWaitForApproval {
+		approved, waitErr := rt.awaitBudgetApproval(ctx, tracker, budgetErr.Error(), emit)
+		if waitErr != nil {
+			telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+			return fmt.Errorf("%w: %s", types.ErrBudgetExceeded, budgetErr.Error())
+		}
+		if approved {
+			tracker.AdvanceWatermark()
+			return nil
+		}
+	}
+	telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+	return fmt.Errorf("%w: %s", types.ErrBudgetExceeded, budgetErr.Error())
+}
+
+// awaitBudgetApproval emits a CUSTOM budget_approval event and blocks on a Restate awakeable.
+func (rt *RestateRuntime) awaitBudgetApproval(
+	ctx restatesdk.Context,
+	tracker *base.BudgetTracker,
+	detail string,
+	emit func(events.AgentEvent),
+) (bool, error) {
+	awakeable := restatesdk.Awakeable[types.ApprovalStatus](ctx)
+	token := awakeable.Id()
+	tokens, costUSD := tracker.Totals()
+	emit(events.NewAgentCustomEvent(string(events.AgentCustomEventNameBudget), events.AgentCustomEventBudgetValue{
+		AgentName:     rt.AgentSpec.Name,
+		Detail:        detail,
+		TotalTokens:   tokens,
+		CostUSD:       costUSD,
+		ApprovalToken: token,
+	}))
+	timeout := restatesdk.After(ctx, rt.approvalTaskTimeout())
+	first, waitErr := restatesdk.WaitFirst(ctx, awakeable, timeout)
+	if waitErr != nil {
+		return false, waitErr
+	}
+	if first == timeout {
+		if err := timeout.Done(); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+	status, err := awakeable.Result()
+	if err != nil {
+		return false, err
+	}
+	return status == types.ApprovalStatusApproved, nil
 }
 
 // ─── Event emission ───────────────────────────────────────────────────────────

--- a/internal/runtime/restate/agent_loop_test.go
+++ b/internal/runtime/restate/agent_loop_test.go
@@ -3,6 +3,7 @@ package restate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -402,4 +403,43 @@ func TestHandle_StreamAndUnknownDelegate(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "does not match this AgentLoop")
+}
+
+func TestHandle_BudgetStopRun_IsTerminal(t *testing.T) {
+	rt := testRestateRuntime("budget-stop")
+	rt.AgentConfig.Limits.MaxIterations = 3
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	rt.AgentConfig.LLM.Client = &seqLLM{responses: []*interfaces.LLMResponse{{
+		Content: "too much",
+		Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+	}}}
+	rt.tools.stash.Store("run-1", stagedRun{})
+
+	ctx := mocks.NewMockContext(t)
+	ctx.EXPECT().Wrap(mock.Anything).Return(ctx).Maybe()
+	expectRunExecutes(ctx, 2).Once()
+	expectRunExecutes(ctx, 6).Once()
+
+	_, err := (AgentLoop{rt: rt}).Run(restatesdk.WithMockContext(ctx), AgentLoopRequest{
+		agentLoopCore: agentLoopCore{RunID: "run-1", UserPrompt: "hi"},
+	})
+	require.Error(t, err)
+	require.True(t, restatesdk.IsTerminalError(err), "got: %v", err)
+	require.ErrorIs(t, err, types.ErrBudgetExceeded)
+	_, still := rt.tools.stash.Load("run-1")
+	require.False(t, still)
+}
+
+func TestTerminalLoopError(t *testing.T) {
+	require.Nil(t, terminalLoopError(nil))
+	require.ErrorIs(t, terminalLoopError(types.ErrBudgetExceeded), types.ErrBudgetExceeded)
+	require.True(t, restatesdk.IsTerminalError(terminalLoopError(types.ErrBudgetExceeded)))
+	require.True(t, restatesdk.IsTerminalError(terminalLoopError(types.ErrBudgetApprovalUnavailable)))
+	other := errors.New("llm timeout")
+	require.Equal(t, other, terminalLoopError(other))
+	already := restatesdk.ToTerminalError(types.ErrBudgetExceeded)
+	require.Equal(t, already, terminalLoopError(already))
 }

--- a/internal/runtime/restate/approval.go
+++ b/internal/runtime/restate/approval.go
@@ -8,7 +8,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/internal/types"
 )
 
-// ErrNotApprovalCustomEvent means the CUSTOM event name is not tool or delegation approval.
+// ErrNotApprovalCustomEvent means the CUSTOM event name is not tool, delegation, or budget approval.
 var ErrNotApprovalCustomEvent = errors.New("restate: custom event is not a recognized approval kind")
 
 func toolApprovalFromEventValue(ev events.AgentCustomEventApprovalValue) types.ToolApprovalRequestValue {
@@ -27,6 +27,16 @@ func delegationApprovalFromEventValue(ev events.AgentCustomEventDelegationValue)
 		AgentName:     ev.AgentName,
 		SubAgentName:  ev.SubAgentName,
 		Args:          cloneArgsMap(ev.Args),
+		ApprovalToken: ev.ApprovalToken,
+	}
+}
+
+func budgetApprovalFromEventValue(ev events.AgentCustomEventBudgetValue) types.BudgetApprovalRequestValue {
+	return types.BudgetApprovalRequestValue{
+		AgentName:     ev.AgentName,
+		Detail:        ev.Detail,
+		TotalTokens:   ev.TotalTokens,
+		CostUSD:       ev.CostUSD,
 		ApprovalToken: ev.ApprovalToken,
 	}
 }
@@ -51,6 +61,13 @@ func prepareApprovalFromCustomEvent(ev *events.AgentCustomEvent) (req *types.App
 		}
 		v := delegationApprovalFromEventValue(raw)
 		return &types.ApprovalRequest{Name: types.ApprovalRequestNameSubAgent, Value: v}, v.ApprovalToken, nil
+	case events.AgentCustomEventNameBudget:
+		raw, err := events.ParseCustomEventBudget(ev)
+		if err != nil {
+			return nil, "", err
+		}
+		v := budgetApprovalFromEventValue(raw)
+		return &types.ApprovalRequest{Name: types.ApprovalRequestNameBudget, Value: v}, v.ApprovalToken, nil
 	default:
 		return nil, "", ErrNotApprovalCustomEvent
 	}

--- a/internal/runtime/restate/approval_test.go
+++ b/internal/runtime/restate/approval_test.go
@@ -89,6 +89,34 @@ func TestPrepareApprovalFromCustomEvent_Delegation(t *testing.T) {
 	}
 }
 
+func TestPrepareApprovalFromCustomEvent_Budget(t *testing.T) {
+	ev := events.NewAgentCustomEvent(string(events.AgentCustomEventNameBudget), map[string]any{
+		"agentName":     "budget-agent",
+		"detail":        "tokens over",
+		"totalTokens":   float64(150),
+		"costUsd":       0.02,
+		"approvalToken": "tok-budget",
+	})
+
+	req, token, err := prepareApprovalFromCustomEvent(ev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "tok-budget" {
+		t.Fatalf("token: got %q want tok-budget", token)
+	}
+	if req == nil || req.Name != types.ApprovalRequestNameBudget {
+		t.Fatalf("unexpected req: %#v", req)
+	}
+	parsed, err := types.ParseBudgetApproval(req)
+	if err != nil {
+		t.Fatalf("ParseBudgetApproval: %v", err)
+	}
+	if parsed.AgentName != "budget-agent" || parsed.TotalTokens != 150 || parsed.ApprovalToken != "tok-budget" {
+		t.Fatalf("unexpected parsed budget: %#v", parsed)
+	}
+}
+
 func TestPrepareApprovalFromCustomEvent_ClonesArgs(t *testing.T) {
 	args := map[string]any{"k": "v"}
 	ev := events.NewAgentCustomEvent(string(events.AgentCustomEventNameToolApproval), &events.AgentCustomEventApprovalValue{

--- a/internal/runtime/restate/budget_test.go
+++ b/internal/runtime/restate/budget_test.go
@@ -1,0 +1,166 @@
+package restate
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agenticenv/agent-sdk-go/internal/types"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+	restatesdk "github.com/restatedev/sdk-go"
+	"github.com/restatedev/sdk-go/x/mocks"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecuteAgentLoop_BudgetStopRun(t *testing.T) {
+	rt := testRestateRuntime("budget-stop")
+	rt.AgentConfig.Limits.MaxIterations = 3
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	rt.AgentConfig.LLM.Client = &seqLLM{responses: []*interfaces.LLMResponse{{
+		Content: "too much",
+		Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+	}}}
+
+	ctx := mocks.NewMockContext(t)
+	ctx.EXPECT().Wrap(mock.Anything).Return(ctx).Maybe()
+	expectRunExecutes(ctx, 2).Once() // message-id
+	expectRunExecutes(ctx, 6).Once() // llm
+
+	result, err := rt.executeAgentLoop(restatesdk.WithMockContext(ctx), AgentLoopInput{
+		agentLoopCore: agentLoopCore{RunID: "run-1", UserPrompt: "hi"},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, types.ErrBudgetExceeded), "got: %v", err)
+	require.NotNil(t, result)
+	require.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+func expectBudgetApprovalAwakeable(t *testing.T, ctx *mocks.MockContext, status types.ApprovalStatus) {
+	t.Helper()
+	awake := mocks.NewMockAwakeableFuture(t)
+	awake.EXPECT().Id().Return("budget-tok")
+	awake.EXPECT().ResultAndReturn(status, nil).Once()
+	ctx.EXPECT().Awakeable().Return(awake).Once()
+
+	after := ctx.EXPECT().MockAfter(mock.Anything)
+	wait := ctx.EXPECT().MockWaitIter(mock.Anything, mock.Anything)
+	wait.Next().Return(true).Once()
+	wait.Value().Return(awake).Once()
+	wait.Err().Return(nil).Once()
+	_ = after
+}
+
+func TestExecuteAgentLoop_BudgetWaitForApproval_Approved(t *testing.T) {
+	rt := testRestateRuntime("budget-wait-ok")
+	rt.AgentConfig.Limits.MaxIterations = 3
+	rt.AgentConfig.Limits.ApprovalTimeout = 5 * time.Second
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	rt.AgentConfig.LLM.Client = &seqLLM{responses: []*interfaces.LLMResponse{{
+		Content: "first",
+		Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+	}}}
+
+	ctx := mocks.NewMockContext(t)
+	ctx.EXPECT().Wrap(mock.Anything).Return(ctx).Maybe()
+	expectRunExecutes(ctx, 2).Once()
+	expectRunExecutes(ctx, 6).Once()
+	expectBudgetApprovalAwakeable(t, ctx, types.ApprovalStatusApproved)
+
+	result, err := rt.executeAgentLoop(restatesdk.WithMockContext(ctx), AgentLoopInput{
+		agentLoopCore: agentLoopCore{RunID: "run-1", UserPrompt: "hi"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "first", result.Content)
+}
+
+func TestExecuteAgentLoop_BudgetWaitForApproval_Denied(t *testing.T) {
+	rt := testRestateRuntime("budget-wait-deny")
+	rt.AgentConfig.Limits.MaxIterations = 3
+	rt.AgentConfig.Limits.ApprovalTimeout = 5 * time.Second
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	rt.AgentConfig.LLM.Client = &seqLLM{responses: []*interfaces.LLMResponse{{
+		Content: "first",
+		Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+	}}}
+
+	ctx := mocks.NewMockContext(t)
+	ctx.EXPECT().Wrap(mock.Anything).Return(ctx).Maybe()
+	expectRunExecutes(ctx, 2).Once()
+	expectRunExecutes(ctx, 6).Once()
+	expectBudgetApprovalAwakeable(t, ctx, types.ApprovalStatusRejected)
+
+	result, err := rt.executeAgentLoop(restatesdk.WithMockContext(ctx), AgentLoopInput{
+		agentLoopCore: agentLoopCore{RunID: "run-1", UserPrompt: "hi"},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, types.ErrBudgetExceeded), "got: %v", err)
+	require.NotNil(t, result)
+	require.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+func TestExecuteAgentLoop_BudgetStopRun_MaxCostUSD(t *testing.T) {
+	rt := testRestateRuntime("budget-cost")
+	rt.AgentConfig.Limits.MaxIterations = 3
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxCostUSD:         0.001,
+		PromptUSDPer1M:     1.0,
+		CompletionUSDPer1M: 3.0,
+		OnExceeded:         types.BudgetStopRun,
+	}
+	rt.AgentConfig.LLM.Client = &seqLLM{responses: []*interfaces.LLMResponse{{
+		Content: "too costly",
+		Usage:   &interfaces.LLMUsage{PromptTokens: 500, CompletionTokens: 200, TotalTokens: 700},
+	}}}
+
+	ctx := mocks.NewMockContext(t)
+	ctx.EXPECT().Wrap(mock.Anything).Return(ctx).Maybe()
+	expectRunExecutes(ctx, 2).Once()
+	expectRunExecutes(ctx, 6).Once()
+
+	result, err := rt.executeAgentLoop(restatesdk.WithMockContext(ctx), AgentLoopInput{
+		agentLoopCore: agentLoopCore{RunID: "run-1", UserPrompt: "hi"},
+	})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, types.ErrBudgetExceeded), "got: %v", err)
+	require.NotNil(t, result)
+	require.Equal(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}
+
+func TestExecuteAgentLoop_BudgetNestedChildDoesNotEnforce(t *testing.T) {
+	// Nested Restate runs accumulate usage but do not apply OnExceeded (enforceBudget is false
+	// when SubAgentDepth > 0). Parent merges child usage after tools.
+	rt := testRestateRuntime("budget-nested")
+	rt.AgentConfig.Limits.MaxIterations = 3
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	rt.AgentConfig.LLM.Client = &seqLLM{responses: []*interfaces.LLMResponse{{
+		Content: "child",
+		Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+	}}}
+
+	ctx := mocks.NewMockContext(t)
+	ctx.EXPECT().Wrap(mock.Anything).Return(ctx).Maybe()
+	expectRunExecutes(ctx, 2).Once()
+	expectRunExecutes(ctx, 6).Once()
+
+	result, err := rt.executeAgentLoop(restatesdk.WithMockContext(ctx), AgentLoopInput{
+		agentLoopCore: agentLoopCore{RunID: "run-child", UserPrompt: "hi", SubAgentDepth: 1},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "child", result.Content)
+	require.NotEqual(t, types.FinishReasonBudgetExceeded, result.Telemetry.Run.FinishReason)
+}

--- a/internal/runtime/restate/run_handle.go
+++ b/internal/runtime/restate/run_handle.go
@@ -154,7 +154,7 @@ func (h *runHandle) awaitCompletion() {
 			h.err = context.Canceled
 			return
 		}
-		h.err = err
+		h.err = mapInvocationError(err)
 		return
 	}
 	if out != nil && out.Result != nil {
@@ -163,4 +163,20 @@ func (h *runHandle) awaitCompletion() {
 			h.res.RunID = h.id
 		}
 	}
+}
+
+// mapInvocationError restores SDK sentinels lost when Restate serializes a
+// terminal handler failure (message kept, Go error chain dropped).
+func mapInvocationError(err error) error {
+	if err == nil || isApplicationLoopError(err) {
+		return err
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, types.ErrBudgetExceeded.Error()):
+		return fmt.Errorf("%w: %v", types.ErrBudgetExceeded, err)
+	case strings.Contains(msg, types.ErrBudgetApprovalUnavailable.Error()):
+		return fmt.Errorf("%w: %v", types.ErrBudgetApprovalUnavailable, err)
+	}
+	return err
 }

--- a/internal/runtime/restate/run_handle_test.go
+++ b/internal/runtime/restate/run_handle_test.go
@@ -152,3 +152,24 @@ func TestRunHandle_AwaitCompletion(t *testing.T) {
 		t.Fatalf("got %#v err=%v", res, err)
 	}
 }
+
+func TestMapInvocationError_BudgetExceeded(t *testing.T) {
+	raw := errors.New("invocation failed: agent: per-run budget exceeded: total tokens 76 exceeds limit 50")
+	if !errors.Is(mapInvocationError(raw), types.ErrBudgetExceeded) {
+		t.Fatalf("got %v", mapInvocationError(raw))
+	}
+	if !errors.Is(mapInvocationError(types.ErrBudgetExceeded), types.ErrBudgetExceeded) {
+		t.Fatal("sentinel not preserved")
+	}
+	unavail := errors.New("agent: budget approval unavailable (stream not connected): no subscriber")
+	if !errors.Is(mapInvocationError(unavail), types.ErrBudgetApprovalUnavailable) {
+		t.Fatalf("got %v", mapInvocationError(unavail))
+	}
+	other := errors.New("connection refused")
+	if mapInvocationError(other) != other {
+		t.Fatalf("got %v", mapInvocationError(other))
+	}
+	if mapInvocationError(nil) != nil {
+		t.Fatal("nil should stay nil")
+	}
+}

--- a/internal/runtime/restate/subagent.go
+++ b/internal/runtime/restate/subagent.go
@@ -8,6 +8,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/internal/events"
 	sdkruntime "github.com/agenticenv/agent-sdk-go/internal/runtime"
 	"github.com/agenticenv/agent-sdk-go/internal/runtime/base"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
 	"github.com/google/uuid"
 	restatesdk "github.com/restatedev/sdk-go"
 )
@@ -64,17 +65,17 @@ func (rt *RestateRuntime) delegateToSubAgent(
 	tc base.ToolCallRequest,
 	route SubAgentRoute,
 	emit func(events.AgentEvent),
-) (string, error) {
+) (string, *interfaces.LLMUsage, error) {
 	childName := strings.TrimSpace(route.Name)
 	if childName == "" {
 		childName = tc.ToolName
 	}
 	serviceName := strings.TrimSpace(route.ServiceName)
 	if serviceName == "" {
-		return "Sub-agent delegation failed: sub-agent AgentLoop service is not configured.", nil
+		return "Sub-agent delegation failed: sub-agent AgentLoop service is not configured.", nil, nil
 	}
 	if input.SubAgentDepth >= input.MaxSubAgentDepth {
-		return fmt.Sprintf("Sub-agent delegation refused: maximum nesting depth (%d) reached.", input.MaxSubAgentDepth), nil
+		return fmt.Sprintf("Sub-agent delegation refused: maximum nesting depth (%d) reached.", input.MaxSubAgentDepth), nil, nil
 	}
 
 	query := base.SubAgentQuery(tc.Args)
@@ -85,7 +86,6 @@ func (rt *RestateRuntime) delegateToSubAgent(
 	if eventTopic == "" {
 		eventTopic = input.RunID
 	}
-	// Root of this stream: use own event log. Nested: keep the root's EventLogService.
 	eventLogService := strings.TrimSpace(input.EventLogService)
 	if eventLogService == "" {
 		eventLogService = strings.TrimSpace(rt.eventLogServiceName)
@@ -109,7 +109,7 @@ func (rt *RestateRuntime) delegateToSubAgent(
 			sdkruntime.ExecutionPolicy{MaxAttempts: 1},
 			func(restatesdk.RunContext) (string, error) { return uuid.New().String(), nil })
 		if idErr != nil {
-			return "", idErr
+			return "", nil, idErr
 		}
 
 		childReq := AgentLoopRequest{
@@ -132,9 +132,9 @@ func (rt *RestateRuntime) delegateToSubAgent(
 		resp, err := rt.invokeSubAgentHandler(ctx, serviceName, handler, childReq, policy.Timeout)
 		if err == nil {
 			if resp == nil || resp.Result == nil {
-				return "", nil
+				return "", nil, nil
 			}
-			return resp.Result.Content, nil
+			return resp.Result.Content, resp.Result.LLMUsage, nil
 		}
 		lastErr = err
 		if attempt >= attempts {
@@ -142,7 +142,7 @@ func (rt *RestateRuntime) delegateToSubAgent(
 		}
 		if backoff > 0 {
 			if sleepErr := restatesdk.Sleep(ctx, backoff); sleepErr != nil {
-				return "Sub-agent execution failed: " + sleepErr.Error(), nil
+				return "Sub-agent execution failed: " + sleepErr.Error(), nil, nil
 			}
 			next := time.Duration(float64(backoff) * policy.Retry.BackoffCoefficient)
 			if policy.Retry.MaximumInterval > 0 && next > policy.Retry.MaximumInterval {
@@ -153,9 +153,9 @@ func (rt *RestateRuntime) delegateToSubAgent(
 		}
 	}
 	if lastErr == nil {
-		return "", nil
+		return "", nil, nil
 	}
-	return "Sub-agent execution failed: " + lastErr.Error(), nil
+	return "Sub-agent execution failed: " + lastErr.Error(), nil, nil
 }
 
 // invokeSubAgentHandler calls the child's AgentLoop service synchronously, optionally

--- a/internal/runtime/restate/subagent_test.go
+++ b/internal/runtime/restate/subagent_test.go
@@ -115,7 +115,7 @@ func TestValidateAgentName(t *testing.T) {
 func TestDelegateToSubAgent_MaxDepth(t *testing.T) {
 	rt := testRestateRuntime("root")
 	ctx := mocks.NewMockContext(t)
-	content, err := rt.delegateToSubAgent(restatesdk.WithMockContext(ctx), AgentLoopInput{
+	content, _, err := rt.delegateToSubAgent(restatesdk.WithMockContext(ctx), AgentLoopInput{
 		agentLoopCore: agentLoopCore{SubAgentDepth: 2, MaxSubAgentDepth: 2, RunID: "r"},
 	}, base.ToolCallRequest{ToolName: "child", ToolDisplayName: "Child"},
 		SubAgentRoute{Name: "Child", ServiceName: "AgentLoop_Child"}, func(events.AgentEvent) {})
@@ -126,7 +126,7 @@ func TestDelegateToSubAgent_MaxDepth(t *testing.T) {
 func TestDelegateToSubAgent_EmptyServiceName(t *testing.T) {
 	rt := testRestateRuntime("root")
 	ctx := mocks.NewMockContext(t)
-	content, err := rt.delegateToSubAgent(restatesdk.WithMockContext(ctx), AgentLoopInput{
+	content, _, err := rt.delegateToSubAgent(restatesdk.WithMockContext(ctx), AgentLoopInput{
 		agentLoopCore: agentLoopCore{MaxSubAgentDepth: 2, RunID: "r"},
 	}, base.ToolCallRequest{ToolName: "child", ToolDisplayName: "Child"},
 		SubAgentRoute{Name: "Child"}, func(events.AgentEvent) {})

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -217,11 +217,13 @@ type AgentSession struct {
 	ConversationSaveOnIteration bool
 }
 
-// AgentLimits caps iteration and wall-clock behavior for this run.
+// AgentLimits caps iteration, wall-clock, and per-run budget behavior.
 type AgentLimits struct {
 	MaxIterations   int
 	Timeout         time.Duration
 	ApprovalTimeout time.Duration
+	// Budget is the optional per-run token and cost budget. Nil means no budget enforcement.
+	Budget *types.BudgetConfig
 }
 
 // RunRequest carries one run request from Agent to Runtime.

--- a/internal/runtime/temporal/agent_workflow.go
+++ b/internal/runtime/temporal/agent_workflow.go
@@ -90,6 +90,12 @@ type AgentWorkflowState struct {
 	Messages  []interfaces.Message  `json:"messages"`
 	LLMUsage  *interfaces.LLMUsage  `json:"llm_usage,omitempty"`
 	Telemetry *types.AgentTelemetry `json:"telemetry,omitempty"`
+	// BudgetTokens and BudgetCostUSD carry accumulated budget totals across ContinueAsNew boundaries.
+	BudgetTokens  int64   `json:"budget_tokens,omitempty"`
+	BudgetCostUSD float64 `json:"budget_cost_usd,omitempty"`
+	// BudgetWatermarkTokens and BudgetWatermarkCostUSD carry the approval watermark.
+	BudgetWatermarkTokens  int64   `json:"budget_watermark_tokens,omitempty"`
+	BudgetWatermarkCostUSD float64 `json:"budget_watermark_cost_usd,omitempty"`
 }
 
 // AgentRetrieverInput is the input to AgentRetrieverActivity.
@@ -229,14 +235,16 @@ type agentToolCallInput struct {
 
 // agentToolCallOutput is the output of executeAgentToolCall.
 type agentToolCallOutput struct {
-	msg    interfaces.Message
-	failed bool // true: hard err or ExecuteTool err
+	msg      interfaces.Message
+	failed   bool // true: hard err or ExecuteTool err
+	llmUsage *interfaces.LLMUsage
 }
 
 // agentToolResult is one tool outcome collected for the conversation and telemetry.
 type agentToolResult struct {
-	message interfaces.Message
-	failed  bool
+	message  interfaces.Message
+	failed   bool
+	llmUsage *interfaces.LLMUsage
 }
 
 // AgentToolExecuteInput is the input to AgentToolExecuteActivity.
@@ -290,6 +298,17 @@ type AddConversationMessagesInput struct {
 type PublishStreamEventInput struct {
 	StreamWorkflowID string          `json:"stream_workflow_id"`
 	EventJSON        json.RawMessage `json:"event_json"`
+}
+
+// AgentBudgetApprovalInput is the input to AgentBudgetApprovalActivity.
+// StreamWorkflowID is the workflow whose WorkflowStream receives the budget approval event.
+type AgentBudgetApprovalInput struct {
+	AgentName        string  `json:"agent_name"`
+	Detail           string  `json:"detail"`
+	TotalTokens      int64   `json:"total_tokens"`
+	TotalCostUSD     float64 `json:"total_cost_usd"`
+	StreamWorkflowID string  `json:"stream_workflow_id"`
+	AgentFingerprint string  `json:"agent_fingerprint,omitempty"`
 }
 
 // AgentWorkflow runs the agent loop: LLM → tool calls → approval/execute → feed results back to LLM → repeat.
@@ -454,6 +473,24 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 
 	messages := input.State.Messages
 
+	// Budget tracker: restored from ContinueAsNew state; nil when no budget is configured.
+	budgetTracker := base.NewBudgetTracker(rt.AgentConfig.Limits.Budget)
+	if budgetTracker != nil && input.State != nil {
+		budgetTracker.RestoreState(input.State.BudgetTokens, input.State.BudgetCostUSD,
+			input.State.BudgetWatermarkTokens, input.State.BudgetWatermarkCostUSD)
+	}
+	// enforceBudget is true on root runs; false on sub-agent child workflows where the parent
+	// owns the shared budget (sub-agent usage is rolled up at the parent level via activity results).
+	// A budget configured on a sub-agent (budgetTracker != nil) is intentionally not enforced here;
+	// the parent run's budget governs the full tree. Log a warning so developers are not surprised.
+	enforceBudget := budgetTracker != nil && input.RootWorkflowID == ""
+	if budgetTracker != nil && input.RootWorkflowID != "" {
+		logger.Warn("workflow: agent has WithBudget but is running as a sub-agent; "+
+			"budget enforcement is disabled for this invocation — the parent run's budget applies",
+			"scope", "workflow",
+			"root_workflow_id", input.RootWorkflowID)
+	}
+
 	memoryContext := ""
 	if rt.MemoryConfigured() && rt.RecallEnabled() {
 		logger.Debug("workflow: memory recall started", "scope", "workflow")
@@ -536,6 +573,13 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 		telemetry.Run.TotalLLMCalls++
 		telemetry.Run.LLMRetryCount += int64(llmResult.RetryCount)
 		llmUsage = base.MergeLLMUsage(llmUsage, llmResult.Usage)
+		if enforceBudget {
+			if budgetErr := budgetTracker.Add(llmResult.Usage); budgetErr != nil {
+				if stopErr := rt.handleBudgetExceeded(ctx, input, budgetTracker, telemetry, budgetErr.Error(), activityIDSuffix, streamWorkflowID, emitAgentEvent); stopErr != nil {
+					return &types.AgentRunResult{LLMUsage: llmUsage, Telemetry: telemetry}, stopErr
+				}
+			}
+		}
 
 		if len(llmResult.ToolCalls) == 0 {
 			// Final response: accumulate assistant message for conversation
@@ -562,6 +606,13 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 				return nil, err
 			}
 			llmUsage = base.MergeLLMUsage(llmUsage, llmResult.Usage)
+			if enforceBudget {
+				if budgetErr := budgetTracker.Add(llmResult.Usage); budgetErr != nil {
+					if stopErr := rt.handleBudgetExceeded(ctx, input, budgetTracker, telemetry, budgetErr.Error(), activityIDSuffix, streamWorkflowID, emitAgentEvent); stopErr != nil {
+						return &types.AgentRunResult{LLMUsage: llmUsage, Telemetry: telemetry}, stopErr
+					}
+				}
+			}
 			messages = append(messages, interfaces.Message{Role: interfaces.MessageRoleAssistant, Content: llmResult.Content})
 			lastContent = llmResult.Content
 			telemetry.Run.TotalLLMCalls++
@@ -669,8 +720,9 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 							"toolName", tc.ToolName,
 							"toolCallID", tc.ToolCallID)
 						toolResults[i] = agentToolResult{
-							message: v.msg,
-							failed:  v.failed,
+							message:  v.msg,
+							failed:   v.failed,
+							llmUsage: v.llmUsage,
 						}
 					}
 				}
@@ -716,8 +768,9 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 						"toolName", tc.ToolName,
 						"toolCallID", tc.ToolCallID)
 					toolResults[i] = agentToolResult{
-						message: toolOutput.msg,
-						failed:  toolOutput.failed,
+						message:  toolOutput.msg,
+						failed:   toolOutput.failed,
+						llmUsage: toolOutput.llmUsage,
 					}
 				}
 			}
@@ -745,6 +798,18 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 				}
 			}
 			messages = append(messages, result.message)
+			if result.llmUsage != nil {
+				llmUsage = base.MergeLLMUsage(llmUsage, result.llmUsage)
+				if enforceBudget {
+					if budgetErr := budgetTracker.Add(result.llmUsage); budgetErr != nil {
+						if stopErr := rt.handleBudgetExceeded(ctx, input, budgetTracker, telemetry, budgetErr.Error(), activityIDSuffix, streamWorkflowID, emitAgentEvent); stopErr != nil {
+							return &types.AgentRunResult{LLMUsage: llmUsage, Telemetry: telemetry}, stopErr
+						}
+					}
+				} else if budgetTracker != nil {
+					_ = budgetTracker.Add(result.llmUsage)
+				}
+			}
 		}
 
 		if rt.conversationMemoryEnabled(input.ConversationID) && rt.AgentConfig.Session.ConversationSaveOnIteration && len(messages) > 0 {
@@ -788,11 +853,21 @@ func (rt *TemporalRuntime) AgentWorkflow(ctx workflow.Context, input AgentWorkfl
 				input.StreamState = streamState
 			}
 
+			bt, bc := int64(0), float64(0)
+			bwt, bwc := int64(0), float64(0)
+			if budgetTracker != nil {
+				bt, bc = budgetTracker.Totals()
+				bwt, bwc = budgetTracker.WatermarkTotals()
+			}
 			input.State = &AgentWorkflowState{
-				Iteration: iter + 1,
-				Messages:  messages,
-				LLMUsage:  llmUsage,
-				Telemetry: telemetry,
+				Iteration:              iter + 1,
+				Messages:               messages,
+				LLMUsage:               llmUsage,
+				Telemetry:              telemetry,
+				BudgetTokens:           bt,
+				BudgetCostUSD:          bc,
+				BudgetWatermarkTokens:  bwt,
+				BudgetWatermarkCostUSD: bwc,
 			}
 			return nil, workflow.NewContinueAsNewError(ctx, rt.AgentWorkflow, input)
 		}
@@ -1000,6 +1075,7 @@ func (rt *TemporalRuntime) executeAgentToolCall(input agentToolCallInput, tc Too
 	}
 
 	var content string
+	var llmUsage *interfaces.LLMUsage
 	failed := false
 	switch approvalStatus {
 	case types.ApprovalStatusApproved:
@@ -1011,7 +1087,7 @@ func (rt *TemporalRuntime) executeAgentToolCall(input agentToolCallInput, tc Too
 				"childTaskQueue", strings.TrimSpace(route.TaskQueue),
 				"subAgentDepth", input.input.SubAgentDepth)
 			var subErr error
-			content, subErr = rt.delegateToSubAgent(input.wfCtx, input.input, tc, route, input.emitEvent)
+			content, llmUsage, subErr = rt.delegateToSubAgent(input.wfCtx, input.input, tc, route, input.emitEvent)
 			if subErr != nil {
 				return nil, subErr
 			}
@@ -1061,7 +1137,8 @@ func (rt *TemporalRuntime) executeAgentToolCall(input agentToolCallInput, tc Too
 			ToolName:   tc.ToolName,
 			ToolCallID: tc.ToolCallID,
 		},
-		failed: failed,
+		failed:   failed,
+		llmUsage: llmUsage,
 	}, nil
 }
 
@@ -1539,14 +1616,14 @@ func (rt *TemporalRuntime) PublishStreamEventActivity(ctx context.Context, in Pu
 
 // delegateToSubAgent runs a child AgentWorkflow for one sub-agent tool call and returns its text content.
 // RootWorkflowID is propagated so the child workflow's events reach the root's WorkflowStream.
-func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentWorkflowInput, tc ToolCallRequest, route SubAgentRoute, emitEvent func(events.AgentEvent) error) (string, error) {
+func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentWorkflowInput, tc ToolCallRequest, route SubAgentRoute, emitEvent func(events.AgentEvent) error) (string, *interfaces.LLMUsage, error) {
 	logger := workflow.GetLogger(ctx)
 	if strings.TrimSpace(route.TaskQueue) == "" {
 		logger.Warn("workflow: sub-agent delegation skipped (empty task queue)",
 			"scope", "workflow",
 			"tool", tc.ToolName,
 			"toolCallID", tc.ToolCallID)
-		return "Sub-agent delegation failed: sub-agent task queue is not configured.", nil
+		return "Sub-agent delegation failed: sub-agent task queue is not configured.", nil, nil
 	}
 	maxDepth := input.MaxSubAgentDepth
 	if input.SubAgentDepth >= maxDepth {
@@ -1556,7 +1633,7 @@ func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentW
 			"maxDepth", maxDepth,
 			"tool", tc.ToolName,
 			"toolCallID", tc.ToolCallID)
-		return fmt.Sprintf("Sub-agent delegation refused: maximum nesting depth (%d) reached for this agent.", maxDepth), nil
+		return fmt.Sprintf("Sub-agent delegation refused: maximum nesting depth (%d) reached for this agent.", maxDepth), nil, nil
 	}
 
 	query := base.SubAgentQuery(tc.Args)
@@ -1570,7 +1647,7 @@ func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentW
 		return uuid.New().String()
 	}).Get(&childSuffix); err != nil {
 		logger.Warn("workflow: sub-agent child run id failed", "scope", "workflow", "error", err)
-		return "", err
+		return "", nil, err
 	}
 
 	// rootWorkflowIDForChild is the stream owner for the child's events.
@@ -1625,7 +1702,7 @@ func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentW
 	}
 
 	if emitErr := emitEvent(events.NewAgentStepStartedEvent(delegationName)); emitErr != nil {
-		return "", emitErr
+		return "", nil, emitErr
 	}
 
 	var childResult *types.AgentRunResult
@@ -1635,11 +1712,15 @@ func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentW
 			"childWorkflowID", childWfID,
 			"tool", tc.ToolName,
 			"error", err)
-		return "Sub-agent workflow failed: " + err.Error(), nil
+		return "Sub-agent workflow failed: " + err.Error(), nil, nil
 	}
 
 	if emitErr := emitEvent(events.NewAgentStepFinishedEvent(delegationName)); emitErr != nil {
-		return "", emitErr
+		return "", nil, emitErr
+	}
+
+	if childResult == nil {
+		return "", nil, nil
 	}
 
 	logger.Debug("workflow: sub-agent child run completed",
@@ -1648,7 +1729,7 @@ func (rt *TemporalRuntime) delegateToSubAgent(ctx workflow.Context, input AgentW
 		"tool", tc.ToolName,
 		"resultContentLen", len(childResult.Content))
 
-	return childResult.Content, nil
+	return childResult.Content, childResult.LLMUsage, nil
 }
 
 // subAgentChildWorkflowTimeout caps how long the main agent waits on a delegated sub-agent run.
@@ -1718,6 +1799,136 @@ func pendingApprovalActivityIDs(pendingApprovals map[string]*pendingApproval) []
 		ids = append(ids, p.ActivityID)
 	}
 	return ids
+}
+
+// handleBudgetExceeded is called when a budget limit is breached inside AgentWorkflow.
+// For BudgetStopRun it sets the finish reason and returns ErrBudgetExceeded.
+// For BudgetWaitForApproval it executes AgentBudgetApprovalActivity and, if approved,
+// advances the watermark so the next trigger fires only on further growth. When MaxApprovals
+// is exhausted it falls through to BudgetStopRun. When the stream is unavailable it returns
+// ErrBudgetApprovalUnavailable so the caller can distinguish infrastructure failures from denials.
+func (rt *TemporalRuntime) handleBudgetExceeded(
+	wfCtx workflow.Context,
+	input AgentWorkflowInput,
+	tracker *base.BudgetTracker,
+	telemetry *types.AgentTelemetry,
+	detail string,
+	activityIDSuffix string,
+	streamWorkflowID string,
+	emitAgentEvent func(workflow.Context, events.AgentEvent) error,
+) error {
+	cfg := rt.AgentConfig.Limits.Budget
+	action := cfg.OnExceeded
+	if action == "" {
+		action = types.BudgetStopRun
+	}
+
+	approvalsExhausted := action == types.BudgetWaitForApproval && tracker.ApprovalsExhausted()
+
+	workflow.GetLogger(wfCtx).Warn("workflow: per-run budget exceeded",
+		"scope", "workflow",
+		"action", string(action),
+		"approvals_exhausted", approvalsExhausted,
+		"approval_count", tracker.ApprovalCount(),
+		"detail", detail)
+
+	if action == types.BudgetWaitForApproval && !approvalsExhausted {
+		// Unique per pause so a second budget approval in the same workflow does not
+		// collide on Temporal's ActivityID (must be unique for the workflow execution).
+		var pauseID string
+		if err := workflow.SideEffect(wfCtx, func(workflow.Context) interface{} {
+			return uuid.New().String()
+		}).Get(&pauseID); err != nil {
+			telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+			return fmt.Errorf("%w: %s", types.ErrBudgetExceeded, detail)
+		}
+		tokens, costUSD := tracker.Totals()
+		approvalActCtx := workflow.WithActivityOptions(wfCtx, workflow.ActivityOptions{
+			ActivityID:          "AgentBudgetApprovalActivity_" + activityIDSuffix + "_" + pauseID,
+			StartToCloseTimeout: rt.AgentConfig.Limits.ApprovalTimeout,
+			RetryPolicy:         retryPolicy(agentToolApprovalActivityMaxAttempts),
+		})
+		var status types.ApprovalStatus
+		if err := workflow.ExecuteActivity(approvalActCtx, rt.AgentBudgetApprovalActivity, AgentBudgetApprovalInput{
+			AgentName:        rt.AgentSpec.Name,
+			Detail:           detail,
+			TotalTokens:      tokens,
+			TotalCostUSD:     costUSD,
+			StreamWorkflowID: streamWorkflowID,
+			AgentFingerprint: input.AgentFingerprint,
+		}).Get(approvalActCtx, &status); err != nil {
+			telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+			return fmt.Errorf("%w: %s", types.ErrBudgetExceeded, detail)
+		}
+		switch status {
+		case types.ApprovalStatusApproved:
+			tracker.AdvanceWatermark()
+			return nil
+		case types.ApprovalStatusUnavailable:
+			// Stream had no subscriber when the approval event was published. This is a
+			// transient infrastructure failure, not a budget denial. Return a distinct error
+			// so callers can distinguish it from a genuine ErrBudgetExceeded.
+			workflow.GetLogger(wfCtx).Warn("workflow: budget approval unavailable (no stream subscriber)",
+				"scope", "workflow", "detail", detail)
+			telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+			return fmt.Errorf("%w: %s", types.ErrBudgetApprovalUnavailable, detail)
+		case types.ApprovalStatusTimedOut:
+			workflow.GetLogger(wfCtx).Warn("workflow: budget approval timed out",
+				"scope", "workflow", "detail", detail)
+		}
+	} else if approvalsExhausted {
+		workflow.GetLogger(wfCtx).Warn("workflow: budget approval limit exhausted; stopping run",
+			"scope", "workflow",
+			"max_approvals", cfg.MaxApprovals,
+			"approval_count", tracker.ApprovalCount())
+	}
+
+	telemetry.Run.FinishReason = types.FinishReasonBudgetExceeded
+	return fmt.Errorf("%w: %s", types.ErrBudgetExceeded, detail)
+}
+
+// AgentBudgetApprovalActivity blocks until the driver completes it via CompleteActivity.
+// Publishes a CUSTOM (budget_approval) event to the WorkflowStream so the client can display
+// the budget breach and call StreamHandle.Approve with the task token.
+func (rt *TemporalRuntime) AgentBudgetApprovalActivity(ctx context.Context, input AgentBudgetApprovalInput) (types.ApprovalStatus, error) {
+	if err := rt.verifyAgentFingerprint(ctx, input.AgentFingerprint, nil); err != nil {
+		return types.ApprovalStatusNone, err
+	}
+	logger := activity.GetLogger(ctx)
+	logger.Debug("activity: budget approval started", "scope", "activity", "agent", input.AgentName)
+
+	info := activity.GetInfo(ctx)
+	taskTokenB64 := base64.StdEncoding.EncodeToString(info.TaskToken)
+
+	ev := events.NewAgentCustomEvent(string(events.AgentCustomEventNameBudget), events.AgentCustomEventBudgetValue{
+		AgentName:     input.AgentName,
+		Detail:        input.Detail,
+		TotalTokens:   input.TotalTokens,
+		CostUSD:       input.TotalCostUSD,
+		ApprovalToken: taskTokenB64,
+	})
+
+	eventBytes, err := ev.ToJSON()
+	if err != nil {
+		return types.ApprovalStatusNone, fmt.Errorf("activity: marshal budget approval event: %w", err)
+	}
+
+	sc := rt.newActivityStreamClient(ctx, input.StreamWorkflowID)
+	if sc == nil {
+		return types.ApprovalStatusUnavailable, nil
+	}
+	sc.Topic(streamTopicEvents).Publish(json.RawMessage(eventBytes), true)
+	if closeErr := sc.Close(ctx); closeErr != nil {
+		logger.Warn("activity: budget approval event flush failed, returning unavailable",
+			"scope", "activity", "agent", input.AgentName, "error", closeErr)
+		return types.ApprovalStatusUnavailable, nil
+	}
+
+	logger.Debug("activity: budget approval event published, pending driver completion",
+		"scope", "activity", "agent", input.AgentName)
+	// Return ErrResultPending: Temporal parks the activity until CompleteActivity is called
+	// (via StreamHandle.Approve) with the task token.
+	return types.ApprovalStatusPending, activity.ErrResultPending
 }
 
 // retryPolicy builds a Temporal *RetryPolicy with SDK default backoff.

--- a/internal/runtime/temporal/approval.go
+++ b/internal/runtime/temporal/approval.go
@@ -8,7 +8,7 @@ import (
 	"github.com/agenticenv/agent-sdk-go/internal/types"
 )
 
-// ErrNotApprovalCustomEvent means the CUSTOM event name is not tool or delegation approval.
+// ErrNotApprovalCustomEvent means the CUSTOM event name is not tool, delegation, or budget approval.
 var ErrNotApprovalCustomEvent = errors.New("temporal: custom event is not a recognized approval kind")
 
 // toolApprovalFromEventValue copies the CUSTOM approval payload into an SDK approval value.
@@ -33,9 +33,19 @@ func delegationApprovalFromEventValue(ev events.AgentCustomEventDelegationValue)
 	}
 }
 
+func budgetApprovalFromEventValue(ev events.AgentCustomEventBudgetValue) types.BudgetApprovalRequestValue {
+	return types.BudgetApprovalRequestValue{
+		AgentName:     ev.AgentName,
+		Detail:        ev.Detail,
+		TotalTokens:   ev.TotalTokens,
+		CostUSD:       ev.CostUSD,
+		ApprovalToken: ev.ApprovalToken,
+	}
+}
+
 // prepareApprovalFromCustomEvent parses a CUSTOM event and returns Name + Value as SDK types and the approval token for Temporal CompleteActivity.
 // Respond is nil; the caller must set it before calling types.ApprovalHandler.
-// Returns ErrNotApprovalCustomEvent when ev.Name is not tool or delegation approval.
+// Returns ErrNotApprovalCustomEvent when ev.Name is not tool, delegation, or budget approval.
 func prepareApprovalFromCustomEvent(ev *events.AgentCustomEvent) (req *types.ApprovalRequest, approvalToken string, err error) {
 	if ev == nil {
 		return nil, "", fmt.Errorf("temporal: nil custom event")
@@ -61,6 +71,18 @@ func prepareApprovalFromCustomEvent(ev *events.AgentCustomEvent) (req *types.App
 		v := delegationApprovalFromEventValue(raw)
 		return &types.ApprovalRequest{
 				Name:  types.ApprovalRequestNameSubAgent,
+				Value: v,
+			},
+			v.ApprovalToken,
+			nil
+	case events.AgentCustomEventNameBudget:
+		raw, err := events.ParseCustomEventBudget(ev)
+		if err != nil {
+			return nil, "", err
+		}
+		v := budgetApprovalFromEventValue(raw)
+		return &types.ApprovalRequest{
+				Name:  types.ApprovalRequestNameBudget,
 				Value: v,
 			},
 			v.ApprovalToken,

--- a/internal/runtime/temporal/approval_test.go
+++ b/internal/runtime/temporal/approval_test.go
@@ -115,6 +115,34 @@ func TestPrepareApprovalFromCustomEvent_Delegation(t *testing.T) {
 	}
 }
 
+func TestPrepareApprovalFromCustomEvent_Budget(t *testing.T) {
+	ev := events.NewAgentCustomEvent(string(events.AgentCustomEventNameBudget), map[string]any{
+		"agentName":     "budget-agent",
+		"detail":        "tokens over",
+		"totalTokens":   float64(150),
+		"costUsd":       0.02,
+		"approvalToken": "tok-budget",
+	})
+
+	req, token, err := prepareApprovalFromCustomEvent(ev)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != "tok-budget" {
+		t.Fatalf("token: got %q want tok-budget", token)
+	}
+	if req == nil || req.Name != types.ApprovalRequestNameBudget {
+		t.Fatalf("unexpected req: %#v", req)
+	}
+	parsed, err := types.ParseBudgetApproval(req)
+	if err != nil {
+		t.Fatalf("ParseBudgetApproval: %v", err)
+	}
+	if parsed.AgentName != "budget-agent" || parsed.TotalTokens != 150 || parsed.ApprovalToken != "tok-budget" {
+		t.Fatalf("unexpected parsed budget: %#v", parsed)
+	}
+}
+
 func TestPrepareApprovalFromCustomEvent_ClonesArgs(t *testing.T) {
 	args := map[string]any{"k": "v"}
 	ev := events.NewAgentCustomEvent(string(events.AgentCustomEventNameToolApproval), &events.AgentCustomEventApprovalValue{

--- a/internal/runtime/temporal/budget_test.go
+++ b/internal/runtime/temporal/budget_test.go
@@ -1,0 +1,257 @@
+package temporal
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/testsuite"
+	"go.temporal.io/sdk/workflow"
+
+	"github.com/agenticenv/agent-sdk-go/internal/types"
+	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
+)
+
+func TestAgentWorkflow_BudgetStopRun(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	rt.AgentConfig.Limits.ApprovalTimeout = 5 * time.Second
+
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(
+		&AgentLLMResult{
+			Content: "too much",
+			Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+		}, nil)
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{UserPrompt: "hello"})
+	require.True(t, env.IsWorkflowCompleted())
+	wfErr := env.GetWorkflowError()
+	require.Error(t, wfErr)
+	require.True(t,
+		errors.Is(wfErr, types.ErrBudgetExceeded) || strings.Contains(wfErr.Error(), "budget"),
+		"expected budget exceeded, got: %v", wfErr)
+}
+
+func TestAgentWorkflow_BudgetWaitForApproval_Approved(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	rt.AgentConfig.Limits.ApprovalTimeout = 5 * time.Second
+
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(
+		&AgentLLMResult{
+			Content: "first",
+			Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+		}, nil)
+	env.OnActivity(rt.AgentBudgetApprovalActivity, mock.Anything, mock.Anything).Return(
+		types.ApprovalStatusApproved, nil)
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{UserPrompt: "hello"})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	var result types.AgentRunResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "first", result.Content)
+}
+
+func TestAgentWorkflow_BudgetWaitForApproval_Denied(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	rt.AgentConfig.Limits.ApprovalTimeout = 5 * time.Second
+
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(
+		&AgentLLMResult{
+			Content: "first",
+			Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+		}, nil)
+	env.OnActivity(rt.AgentBudgetApprovalActivity, mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, in AgentBudgetApprovalInput) (types.ApprovalStatus, error) {
+			require.Equal(t, int64(110), in.TotalTokens)
+			return types.ApprovalStatusRejected, nil
+		})
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{UserPrompt: "hello"})
+	require.True(t, env.IsWorkflowCompleted())
+	wfErr := env.GetWorkflowError()
+	require.Error(t, wfErr)
+	require.True(t,
+		errors.Is(wfErr, types.ErrBudgetExceeded) || strings.Contains(wfErr.Error(), "budget"),
+		"expected budget exceeded, got: %v", wfErr)
+}
+
+func TestAgentWorkflow_BudgetStopRun_MaxCostUSD(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxCostUSD:         0.001,
+		PromptUSDPer1M:     1.0,
+		CompletionUSDPer1M: 3.0,
+		OnExceeded:         types.BudgetStopRun,
+	}
+
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	// 500 prompt + 200 completion = 0.0005 + 0.0006 = 0.0011 USD
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(
+		&AgentLLMResult{
+			Content: "too costly",
+			Usage:   &interfaces.LLMUsage{PromptTokens: 500, CompletionTokens: 200, TotalTokens: 700},
+		}, nil)
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{UserPrompt: "hello"})
+	require.True(t, env.IsWorkflowCompleted())
+	wfErr := env.GetWorkflowError()
+	require.Error(t, wfErr)
+	require.True(t, strings.Contains(wfErr.Error(), "budget"), "got: %v", wfErr)
+}
+
+func TestAgentWorkflow_BudgetRestoredFromContinueAsNewState(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	// Prior CAN left 90 tokens; this LLM adds 20 → 110 → exceed.
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(
+		&AgentLLMResult{
+			Content: "over",
+			Usage:   &interfaces.LLMUsage{PromptTokens: 10, CompletionTokens: 10, TotalTokens: 20},
+		}, nil)
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{
+		UserPrompt: "hello",
+		State: &AgentWorkflowState{
+			Iteration:    0,
+			Messages:     []interfaces.Message{{Role: interfaces.MessageRoleUser, Content: "hello"}},
+			BudgetTokens: 90,
+		},
+	})
+	require.True(t, env.IsWorkflowCompleted())
+	wfErr := env.GetWorkflowError()
+	require.Error(t, wfErr)
+	require.True(t, strings.Contains(wfErr.Error(), "budget"), "got: %v", wfErr)
+}
+
+func TestAgentWorkflow_BudgetWaitTwice_UniqueActivityIDs(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:           100,
+		ApprovalExtraTokens: 100,
+		OnExceeded:          types.BudgetWaitForApproval,
+	}
+	rt.AgentConfig.Limits.ApprovalTimeout = 5 * time.Second
+	rt.ToolExecutionMode = types.AgentToolExecutionModeSequential
+
+	var activityIDs []string
+	var llmCalls int
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(func(ctx context.Context, in AgentLLMInput) (*AgentLLMResult, error) {
+		llmCalls++
+		switch llmCalls {
+		case 1:
+			return &AgentLLMResult{
+				Content:   "need tool",
+				ToolCalls: []ToolCallRequest{testWorkflowToolCall("tc1", "echo", types.ToolKindNative, map[string]any{"x": 1})},
+				Usage:     &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+			}, nil
+		case 2:
+			return &AgentLLMResult{
+				Content: "final",
+				Usage:   &interfaces.LLMUsage{PromptTokens: 60, CompletionTokens: 50, TotalTokens: 110},
+			}, nil
+		default:
+			return &AgentLLMResult{Content: "extra"}, nil
+		}
+	})
+	env.OnActivity(rt.AgentToolAuthorizeActivity, mock.Anything, mock.Anything).Return(AgentToolAuthorizeResult{Allowed: true}, nil)
+	env.OnActivity(rt.AgentToolExecuteActivity, mock.Anything, mock.Anything).Return("ok", nil)
+	env.OnActivity(rt.AgentBudgetApprovalActivity, mock.Anything, mock.Anything).Return(
+		func(ctx context.Context, in AgentBudgetApprovalInput) (types.ApprovalStatus, error) {
+			info := activity.GetInfo(ctx)
+			activityIDs = append(activityIDs, info.ActivityID)
+			return types.ApprovalStatusApproved, nil
+		})
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{UserPrompt: "hello"})
+	require.True(t, env.IsWorkflowCompleted())
+	require.NoError(t, env.GetWorkflowError())
+	require.Len(t, activityIDs, 2)
+	require.NotEqual(t, activityIDs[0], activityIDs[1], "second budget pause must use a distinct ActivityID")
+	var result types.AgentRunResult
+	require.NoError(t, env.GetWorkflowResult(&result))
+	require.Equal(t, "final", result.Content)
+}
+
+func TestAgentWorkflow_BudgetAfterNestedSubagent(t *testing.T) {
+	var suite testsuite.WorkflowTestSuite
+	env := suite.NewTestWorkflowEnvironment()
+	rt := testRuntimeForWorkflow(t)
+	rt.AgentConfig.Limits.Budget = &types.BudgetConfig{
+		MaxTokens:  100,
+		OnExceeded: types.BudgetStopRun,
+	}
+	rt.ToolExecutionMode = types.AgentToolExecutionModeSequential
+
+	env.RegisterWorkflow(rt.AgentWorkflow)
+	env.OnActivity(rt.AgentLLMActivity, mock.Anything, mock.Anything).Return(
+		&AgentLLMResult{
+			Content:   "delegate",
+			ToolCalls: []ToolCallRequest{testWorkflowToolCall("tc1", "research", types.ToolKindSubAgent, map[string]any{"query": "q"})},
+			Usage:     &interfaces.LLMUsage{PromptTokens: 5, CompletionTokens: 5, TotalTokens: 10},
+		}, nil)
+	env.OnActivity(rt.AgentToolAuthorizeActivity, mock.Anything, mock.Anything).Return(AgentToolAuthorizeResult{Allowed: true}, nil)
+	// OnWorkflow stubs every AgentWorkflow invocation (including the root). Run the real
+	// workflow for the root; return canned child usage for nested RootWorkflowID != "".
+	env.OnWorkflow(rt.AgentWorkflow, mock.Anything, mock.Anything).Return(
+		func(ctx workflow.Context, in AgentWorkflowInput) (*types.AgentRunResult, error) {
+			if in.RootWorkflowID != "" {
+				return &types.AgentRunResult{
+					Content:  "child done",
+					LLMUsage: &interfaces.LLMUsage{PromptTokens: 50, CompletionTokens: 50, TotalTokens: 100},
+				}, nil
+			}
+			return rt.AgentWorkflow(ctx, in)
+		})
+
+	env.ExecuteWorkflow(rt.AgentWorkflow, AgentWorkflowInput{
+		UserPrompt:       "go",
+		MaxSubAgentDepth: 2,
+		SubAgentRoutes: map[string]SubAgentRoute{
+			"research": {Name: "researcher", TaskQueue: "child-tq"},
+		},
+	})
+	require.True(t, env.IsWorkflowCompleted())
+	wfErr := env.GetWorkflowError()
+	require.Error(t, wfErr)
+	require.True(t, strings.Contains(wfErr.Error(), "budget"), "got: %v", wfErr)
+}

--- a/internal/runtime/temporal/fingerprint.go
+++ b/internal/runtime/temporal/fingerprint.go
@@ -66,6 +66,14 @@ type AgentFingerprintPayload struct {
 	MaxIterations     int   `json:"max_iterations"`
 	TimeoutNs         int64 `json:"timeout_ns"`
 	ApprovalTimeoutNs int64 `json:"approval_timeout_ns"`
+
+	// BudgetMaxTokens, BudgetMaxCostUSD, BudgetOnExceeded capture the per-run budget
+	// configuration for fingerprinting. Zero values mean no budget enforcement.
+	BudgetMaxTokens            int64   `json:"budget_max_tokens,omitempty"`
+	BudgetMaxCostUSD           float64 `json:"budget_max_cost_usd,omitempty"`
+	BudgetOnExceeded           string  `json:"budget_on_exceeded,omitempty"`
+	BudgetApprovalExtraTokens  int64   `json:"budget_approval_extra_tokens,omitempty"`
+	BudgetApprovalExtraCostUSD float64 `json:"budget_approval_extra_cost_usd,omitempty"`
 }
 
 // ComputeAgentFingerprint returns a stable SHA-256 hex digest of the payload (identity, prompts, tools,
@@ -128,6 +136,13 @@ func BuildAgentFingerprintPayload(
 		MaxIterations:            limits.MaxIterations,
 		TimeoutNs:                limits.Timeout.Nanoseconds(),
 		ApprovalTimeoutNs:        limits.ApprovalTimeout.Nanoseconds(),
+	}
+	if limits.Budget != nil {
+		m.BudgetMaxTokens = limits.Budget.MaxTokens
+		m.BudgetMaxCostUSD = limits.Budget.MaxCostUSD
+		m.BudgetOnExceeded = string(limits.Budget.OnExceeded)
+		m.BudgetApprovalExtraTokens = limits.Budget.ApprovalExtraTokens
+		m.BudgetApprovalExtraCostUSD = limits.Budget.ApprovalExtraCostUSD
 	}
 	if spec.ResponseFormat != nil {
 		rf := spec.ResponseFormat

--- a/internal/runtime/temporal/run_handle.go
+++ b/internal/runtime/temporal/run_handle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	sdkruntime "github.com/agenticenv/agent-sdk-go/internal/runtime"
@@ -171,6 +172,8 @@ func (h *runHandle) awaitCompletion() {
 			err = context.DeadlineExceeded
 		case errors.Is(h.stopCause, context.Canceled):
 			err = context.Canceled
+		default:
+			err = mapWorkflowError(err)
 		}
 	}
 	h.err = err
@@ -183,4 +186,26 @@ func (h *runHandle) awaitCompletion() {
 			h.cleanup = nil
 		}
 	})
+}
+
+// isApplicationWorkflowError reports run-complete failures that Temporal
+// serializes as ApplicationError (Go error chain dropped).
+func isApplicationWorkflowError(err error) bool {
+	return errors.Is(err, types.ErrBudgetExceeded) || errors.Is(err, types.ErrBudgetApprovalUnavailable)
+}
+
+// mapWorkflowError restores SDK sentinels lost when Temporal serializes workflow
+// failures as ApplicationError (message preserved, Go error chain dropped).
+func mapWorkflowError(err error) error {
+	if err == nil || isApplicationWorkflowError(err) {
+		return err
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, types.ErrBudgetExceeded.Error()):
+		return fmt.Errorf("%w: %v", types.ErrBudgetExceeded, err)
+	case strings.Contains(msg, types.ErrBudgetApprovalUnavailable.Error()):
+		return fmt.Errorf("%w: %v", types.ErrBudgetApprovalUnavailable, err)
+	}
+	return err
 }

--- a/internal/runtime/temporal/run_handle_test.go
+++ b/internal/runtime/temporal/run_handle_test.go
@@ -326,3 +326,30 @@ func TestRunHandle_Status_MapsCompleted(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, types.StatusCompleted, st)
 }
+
+func TestMapWorkflowError_BudgetExceeded(t *testing.T) {
+	raw := errors.New("workflow execution error: agent: per-run budget exceeded: total tokens 76 exceeds limit 50 (type: wrapError, retryable: true)")
+	require.ErrorIs(t, mapWorkflowError(raw), types.ErrBudgetExceeded)
+	require.ErrorIs(t, mapWorkflowError(types.ErrBudgetExceeded), types.ErrBudgetExceeded)
+
+	unavail := errors.New("workflow execution error: agent: budget approval unavailable (stream not connected): no subscriber")
+	require.ErrorIs(t, mapWorkflowError(unavail), types.ErrBudgetApprovalUnavailable)
+	require.ErrorIs(t, mapWorkflowError(types.ErrBudgetApprovalUnavailable), types.ErrBudgetApprovalUnavailable)
+
+	require.Equal(t, context.Canceled, mapWorkflowError(context.Canceled))
+	require.Nil(t, mapWorkflowError(nil))
+}
+
+func TestRunHandle_Get_RemapsBudgetExceeded(t *testing.T) {
+	release := make(chan struct{})
+	tc := temporalmocks.NewClient(t)
+	wfErr := errors.New("workflow execution error (type: , workflowID: wf-1): agent: per-run budget exceeded: total tokens 76 exceeds limit 50 (type: wrapError, retryable: true): agent: per-run budget exceeded")
+	wfRun := blockingWorkflowRun(release, nil, wfErr)
+	h := newTestRunHandle("run-budget", "wf-1", tc, wfRun, nil)
+
+	close(release)
+	waitHandleDone(t, h.Done())
+
+	_, err := h.Get(context.Background())
+	require.ErrorIs(t, err, types.ErrBudgetExceeded)
+}

--- a/internal/runtime/temporal/runtime.go
+++ b/internal/runtime/temporal/runtime.go
@@ -182,6 +182,7 @@ func (rt *TemporalRuntime) Start(ctx context.Context) error {
 	w.RegisterActivityWithOptions(rt.AgentMemoryStoreActivity, activity.RegisterOptions{Name: "AgentMemoryStoreActivity"})
 	w.RegisterActivityWithOptions(rt.AgentToolAuthorizeActivity, activity.RegisterOptions{Name: "AgentToolAuthorizeActivity"})
 	w.RegisterActivityWithOptions(rt.AgentToolApprovalActivity, activity.RegisterOptions{Name: "AgentToolApprovalActivity"})
+	w.RegisterActivityWithOptions(rt.AgentBudgetApprovalActivity, activity.RegisterOptions{Name: "AgentBudgetApprovalActivity"})
 	w.RegisterActivityWithOptions(rt.AgentToolExecuteActivity, activity.RegisterOptions{Name: "AgentToolExecuteActivity"})
 	w.RegisterActivityWithOptions(rt.AgentWorkflowCleanupActivity, activity.RegisterOptions{Name: "AgentWorkflowCleanupActivity"})
 	// PublishStreamEventActivity: used by sub-agent workflows to forward events to the root WorkflowStream.

--- a/internal/types/approval.go
+++ b/internal/types/approval.go
@@ -39,10 +39,11 @@ type ApprovalRequestName string
 const (
 	ApprovalRequestNameTool     ApprovalRequestName = "tool_approval"
 	ApprovalRequestNameSubAgent ApprovalRequestName = "sub_agent_delegation"
+	ApprovalRequestNameBudget   ApprovalRequestName = "budget_approval"
 )
 
 // ApprovalRequest is one pending approval callback. Name + Value match CUSTOM semantics;
-// Value is a [ToolApprovalRequestValue] or [SubAgentDelegationApprovalRequestValue].
+// Value is a [ToolApprovalRequestValue], [SubAgentDelegationApprovalRequestValue], or [BudgetApprovalRequestValue].
 // Set Respond before invoking the handler.
 type ApprovalRequest struct {
 	Name    ApprovalRequestName `json:"name,omitempty"`
@@ -66,6 +67,15 @@ type SubAgentDelegationApprovalRequestValue struct {
 	SubAgentName  string         `json:"subAgentName,omitempty"`
 	Args          map[string]any `json:"args,omitempty"`
 	ApprovalToken string         `json:"approvalToken,omitempty"`
+}
+
+// BudgetApprovalRequestValue is the JSON payload for a per-run budget approval.
+type BudgetApprovalRequestValue struct {
+	AgentName     string  `json:"agentName,omitempty"`
+	Detail        string  `json:"detail,omitempty"`
+	TotalTokens   int64   `json:"totalTokens,omitempty"`
+	CostUSD       float64 `json:"costUsd,omitempty"`
+	ApprovalToken string  `json:"approvalToken,omitempty"`
 }
 
 func parseApprovalPayload[V any](v any) (out V, err error) {
@@ -118,4 +128,18 @@ func ParseDelegationApproval(req *ApprovalRequest) (SubAgentDelegationApprovalRe
 		return SubAgentDelegationApprovalRequestValue{}, errors.New("types: delegation approval request has empty value")
 	}
 	return parseApprovalPayload[SubAgentDelegationApprovalRequestValue](req.Value)
+}
+
+// ParseBudgetApproval decodes Value for ApprovalRequestNameBudget.
+func ParseBudgetApproval(req *ApprovalRequest) (BudgetApprovalRequestValue, error) {
+	if req == nil {
+		return BudgetApprovalRequestValue{}, errors.New("types: nil approval request")
+	}
+	if req.Name != ApprovalRequestNameBudget {
+		return BudgetApprovalRequestValue{}, errors.New("types: not a budget approval request")
+	}
+	if req.Value == nil {
+		return BudgetApprovalRequestValue{}, errors.New("types: budget approval request has empty value")
+	}
+	return parseApprovalPayload[BudgetApprovalRequestValue](req.Value)
 }

--- a/internal/types/approval_test.go
+++ b/internal/types/approval_test.go
@@ -1,0 +1,178 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseToolApproval(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameTool,
+		Value: map[string]any{
+			"agentName":       "a",
+			"toolCallId":      "tc-1",
+			"toolName":        "search",
+			"toolDisplayName": "Search",
+			"args":            map[string]any{"q": "hello"},
+			"approvalToken":   "tok-tool",
+		},
+	}
+	got, err := ParseToolApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "a", got.AgentName)
+	require.Equal(t, "tc-1", got.ToolCallID)
+	require.Equal(t, "search", got.ToolName)
+	require.Equal(t, "Search", got.ToolDisplayName)
+	require.Equal(t, "tok-tool", got.ApprovalToken)
+	require.Equal(t, "hello", got.Args["q"])
+}
+
+func TestParseToolApproval_TypedValue(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameTool,
+		Value: ToolApprovalRequestValue{
+			ToolName:      "calc",
+			ToolCallID:    "c1",
+			ApprovalToken: "tok",
+			Args:          map[string]any{"x": 1},
+		},
+	}
+	got, err := ParseToolApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "calc", got.ToolName)
+	require.Equal(t, "c1", got.ToolCallID)
+}
+
+func TestParseToolApproval_PointerValue(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameTool,
+		Value: &ToolApprovalRequestValue{
+			ToolName:      "ptr",
+			ApprovalToken: "tok-p",
+		},
+	}
+	got, err := ParseToolApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "ptr", got.ToolName)
+}
+
+func TestParseToolApproval_Errors(t *testing.T) {
+	_, err := ParseToolApproval(nil)
+	require.Error(t, err)
+
+	_, err = ParseToolApproval(&ApprovalRequest{Name: ApprovalRequestNameBudget, Value: map[string]any{}})
+	require.Error(t, err)
+
+	_, err = ParseToolApproval(&ApprovalRequest{Name: ApprovalRequestNameTool})
+	require.Error(t, err)
+
+	_, err = ParseToolApproval(&ApprovalRequest{
+		Name:  ApprovalRequestNameTool,
+		Value: (*ToolApprovalRequestValue)(nil),
+	})
+	require.Error(t, err)
+}
+
+func TestParseDelegationApproval(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameSubAgent,
+		Value: map[string]any{
+			"agentName":     "parent",
+			"subAgentName":  "child",
+			"args":          map[string]any{"task": "summarize"},
+			"approvalToken": "tok-del",
+		},
+	}
+	got, err := ParseDelegationApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "parent", got.AgentName)
+	require.Equal(t, "child", got.SubAgentName)
+	require.Equal(t, "tok-del", got.ApprovalToken)
+	require.Equal(t, "summarize", got.Args["task"])
+}
+
+func TestParseDelegationApproval_TypedValue(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameSubAgent,
+		Value: SubAgentDelegationApprovalRequestValue{
+			SubAgentName:  "researcher",
+			ApprovalToken: "tok",
+		},
+	}
+	got, err := ParseDelegationApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "researcher", got.SubAgentName)
+}
+
+func TestParseDelegationApproval_Errors(t *testing.T) {
+	_, err := ParseDelegationApproval(nil)
+	require.Error(t, err)
+
+	_, err = ParseDelegationApproval(&ApprovalRequest{Name: ApprovalRequestNameTool, Value: map[string]any{}})
+	require.Error(t, err)
+
+	_, err = ParseDelegationApproval(&ApprovalRequest{Name: ApprovalRequestNameSubAgent})
+	require.Error(t, err)
+}
+
+func TestParseBudgetApproval(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameBudget,
+		Value: map[string]any{
+			"agentName":     "a",
+			"detail":        "over limit",
+			"totalTokens":   float64(120),
+			"costUsd":       0.01,
+			"approvalToken": "tok-b",
+		},
+	}
+	got, err := ParseBudgetApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "a", got.AgentName)
+	require.Equal(t, "over limit", got.Detail)
+	require.Equal(t, int64(120), got.TotalTokens)
+	require.InDelta(t, 0.01, got.CostUSD, 1e-9)
+	require.Equal(t, "tok-b", got.ApprovalToken)
+}
+
+func TestParseBudgetApproval_TypedValue(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameBudget,
+		Value: BudgetApprovalRequestValue{
+			AgentName:     "b",
+			TotalTokens:   50,
+			ApprovalToken: "tok",
+		},
+	}
+	got, err := ParseBudgetApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "b", got.AgentName)
+	require.Equal(t, int64(50), got.TotalTokens)
+}
+
+func TestParseBudgetApproval_PointerValue(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameBudget,
+		Value: &BudgetApprovalRequestValue{
+			AgentName:     "ptr",
+			TotalTokens:   10,
+			ApprovalToken: "tok-p",
+		},
+	}
+	got, err := ParseBudgetApproval(req)
+	require.NoError(t, err)
+	require.Equal(t, "ptr", got.AgentName)
+	require.Equal(t, int64(10), got.TotalTokens)
+}
+
+func TestParseBudgetApproval_Errors(t *testing.T) {
+	_, err := ParseBudgetApproval(nil)
+	require.Error(t, err)
+
+	_, err = ParseBudgetApproval(&ApprovalRequest{Name: ApprovalRequestNameTool, Value: map[string]any{}})
+	require.Error(t, err)
+
+	_, err = ParseBudgetApproval(&ApprovalRequest{Name: ApprovalRequestNameBudget})
+	require.Error(t, err)
+}

--- a/internal/types/budget.go
+++ b/internal/types/budget.go
@@ -1,0 +1,94 @@
+package types
+
+// BudgetExceededAction is the action taken when a per-run budget limit is reached.
+// Budget limits apply per run and reset when a new run starts.
+type BudgetExceededAction string
+
+const (
+	// BudgetStopRun stops the run immediately and returns an error to the caller.
+	// This is the default when OnExceeded is not set.
+	BudgetStopRun BudgetExceededAction = "stop_run"
+
+	// BudgetWaitForApproval pauses the run and waits for the caller to approve or deny
+	// continuation. On Run, the registered ApprovalHandler is called. On Stream, a CUSTOM
+	// AG-UI event is emitted and the caller calls Approve on the stream handle.
+	//
+	// For Run: WithApprovalHandler must be set when calling Run() (not at NewAgent).
+	// For Stream: no ApprovalHandler is needed; set up handling via AgentStream.Approve.
+	//
+	// On deny the run stops with ErrBudgetExceeded. On approve the run continues; totals
+	// are not reset. The next pause fires when usage grows by ApprovalExtraTokens or
+	// ApprovalExtraCostUSD from the amount at approval (those default to MaxTokens /
+	// MaxCostUSD when unset). After MaxApprovals approvals the next breach stops the run
+	// immediately regardless of OnExceeded (defaults to 5 when unset).
+	BudgetWaitForApproval BudgetExceededAction = "wait_for_approval"
+)
+
+// IsValid reports whether the action is a recognised BudgetExceededAction value.
+func (a BudgetExceededAction) IsValid() bool {
+	switch a {
+	case BudgetStopRun, BudgetWaitForApproval:
+		return true
+	default:
+		return false
+	}
+}
+
+// BudgetExceededKind describes which limit was breached.
+type BudgetExceededKind string
+
+const (
+	BudgetExceededKindTokens BudgetExceededKind = "tokens"
+	BudgetExceededKindCost   BudgetExceededKind = "cost_usd"
+)
+
+// BudgetConfig configures per-run token and cost limits for an agent.
+// At least one of MaxTokens or MaxCostUSD must be set.
+// Limits apply to the current run only and reset when a new run starts.
+//
+// When the agent runs nested sub-agents, their token and cost usage is included in the
+// parent run's totals. The parent budget governs the entire run tree; a budget configured
+// on a sub-agent is silently ignored when the sub-agent is called from a parent.
+//
+// When both MaxTokens and MaxCostUSD are set, the token limit is checked first on each LLM
+// call. Whichever limit is breached first triggers OnExceeded.
+type BudgetConfig struct {
+	// MaxTokens is the maximum total tokens (prompt + completion) allowed for a single run.
+	// Zero means no token limit. Must be >= 0.
+	MaxTokens int64
+
+	// MaxCostUSD is the maximum estimated cost in US dollars allowed for a single run.
+	// Zero means no cost limit. Must be >= 0.
+	// Requires PromptUSDPer1M and CompletionUSDPer1M to be set when non-zero.
+	MaxCostUSD float64
+
+	// PromptUSDPer1M is the cost per one million prompt (input) tokens in US dollars.
+	// Required when MaxCostUSD is non-zero. Example: 3.0 for $3 per 1M tokens. Must be >= 0.
+	PromptUSDPer1M float64
+
+	// CompletionUSDPer1M is the cost per one million completion (output) tokens in US dollars.
+	// Required when MaxCostUSD is non-zero. Example: 15.0 for $15 per 1M tokens. Must be >= 0.
+	CompletionUSDPer1M float64
+
+	// OnExceeded specifies the action to take when MaxTokens or MaxCostUSD is reached.
+	// Defaults to BudgetStopRun when not set.
+	OnExceeded BudgetExceededAction
+
+	// ApprovalExtraTokens is how many additional tokens are allowed after each
+	// BudgetWaitForApproval approval, measured from the totals at the time of approval.
+	// Zero means "use MaxTokens"; NewAgent fills that in during validation when OnExceeded is
+	// BudgetWaitForApproval. Ignored when OnExceeded is BudgetStopRun. Must be >= 0.
+	ApprovalExtraTokens int64
+
+	// ApprovalExtraCostUSD is how much additional estimated USD cost is allowed after each
+	// BudgetWaitForApproval approval. Zero means "use MaxCostUSD"; NewAgent fills that in
+	// during validation when OnExceeded is BudgetWaitForApproval. Ignored when OnExceeded
+	// is BudgetStopRun. Must be >= 0.
+	ApprovalExtraCostUSD float64
+
+	// MaxApprovals is the maximum number of times a BudgetWaitForApproval pause may be
+	// approved in a single run. Once this count is reached the next budget breach stops the
+	// run immediately with ErrBudgetExceeded regardless of OnExceeded.
+	// Zero means "use the default of 5". Ignored when OnExceeded is BudgetStopRun.
+	MaxApprovals int
+}

--- a/internal/types/errors.go
+++ b/internal/types/errors.go
@@ -41,3 +41,14 @@ var ErrStreamAlreadyConsumed = errors.New("runtime: stream events already consum
 // store instead of reconnecting. Also returned by [RunHandle.Cancel] / [StreamHandle.Cancel]
 // when the run is already terminal (nothing left to cancel).
 var ErrRunAlreadyCompleted = errors.New("runtime: run already completed, stream unavailable")
+
+// ErrBudgetExceeded is returned when a per-run budget limit (MaxTokens or MaxCostUSD) is
+// reached and the configured action is BudgetStopRun, or when BudgetWaitForApproval is
+// configured and the caller denies continuation, or when MaxApprovals is exhausted.
+var ErrBudgetExceeded = errors.New("agent: per-run budget exceeded")
+
+// ErrBudgetApprovalUnavailable is returned when a BudgetWaitForApproval pause cannot
+// deliver the approval request to the caller because the event stream is unavailable
+// (e.g. no subscriber connected). This is a transient infrastructure failure, not a
+// budget denial. Callers may retry the run; the budget limit remains in effect.
+var ErrBudgetApprovalUnavailable = errors.New("agent: budget approval unavailable (stream not connected)")

--- a/internal/types/metrics.go
+++ b/internal/types/metrics.go
@@ -96,6 +96,17 @@ const (
 	MetricMemoryExtractFailed    = "agent.memory.extract.failed"
 	MetricMemoryExtractLatencyMs = "agent.memory.extract.latency_ms"
 
+	// Runtime — budget enforcement events, emitted when a limit is breached.
+	// agent.budget.exceeded fires on every breach (before stop or approval).
+	// agent.budget.approval.* fire only when OnExceeded is BudgetWaitForApproval.
+	MetricBudgetExceeded            = "agent.budget.exceeded"
+	MetricBudgetApprovalRequested   = "agent.budget.approval.requested"
+	MetricBudgetApprovalApproved    = "agent.budget.approval.approved"
+	MetricBudgetApprovalRejected    = "agent.budget.approval.rejected"
+	MetricBudgetApprovalTimedOut    = "agent.budget.approval.timed_out"
+	MetricBudgetApprovalUnavailable = "agent.budget.approval.unavailable"
+	MetricBudgetApprovalExhausted   = "agent.budget.approval.exhausted"
+
 	// Attribute keys used on both metrics and spans.
 	MetricAttrModel      = "model"
 	MetricAttrProvider   = "provider"
@@ -103,5 +114,7 @@ const (
 	MetricAttrRetriever  = "retriever"
 	MetricAttrMemoryKind = "memory.kind"
 	// MetricAttrMemoryDedup is "upsert" when an existing record is updated, else "append".
-	MetricAttrMemoryDedup = "memory.dedup"
+	MetricAttrMemoryDedup  = "memory.dedup"
+	MetricAttrBudgetKind   = "budget.kind"   // "tokens" or "cost_usd"
+	MetricAttrBudgetAction = "budget.action" // "stop_run" or "wait_for_approval"
 )

--- a/internal/types/telemetry.go
+++ b/internal/types/telemetry.go
@@ -22,6 +22,10 @@ const (
 	FinishReasonComplete FinishReason = "complete"
 	// FinishReasonMaxIterations indicates that the agent run completed because the maximum number of iterations was reached.
 	FinishReasonMaxIterations FinishReason = "max_iterations"
+	// FinishReasonBudgetExceeded indicates that the agent run stopped because a per-run budget
+	// limit (MaxTokens or MaxCostUSD) was reached and the configured action was BudgetStopRun,
+	// or because the caller denied continuation after BudgetWaitForApproval.
+	FinishReasonBudgetExceeded FinishReason = "budget_exceeded"
 )
 
 // RunTelemetry captures the orchestration lifecycle metrics for a single agent run.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -50,6 +50,39 @@ type AgentTelemetry = types.AgentTelemetry
 // LLMUsage is the token usage for a single LLM call.
 type LLMUsage = types.LLMUsage
 
+// BudgetConfig configures per-run token and cost limits for an agent.
+// Use [WithBudget] to apply it. At least one of MaxTokens or MaxCostUSD must be set.
+// Limits apply to the current run only and reset when a new run starts.
+type BudgetConfig = types.BudgetConfig
+
+// BudgetExceededAction is the action taken when a per-run budget limit is reached.
+type BudgetExceededAction = types.BudgetExceededAction
+
+const (
+	// BudgetStopRun stops the run immediately and returns an error to the caller.
+	BudgetStopRun = types.BudgetStopRun
+	// BudgetWaitForApproval pauses the run and waits for the caller to approve or deny continuation.
+	// For Run: WithApprovalHandler must be provided at the Run() call site, not at NewAgent.
+	// For Stream: no ApprovalHandler is needed; handle via AgentStream.Approve.
+	// Approving continues the run; the next pause fires after another limit window from current usage.
+	// After MaxApprovals approvals the run stops with ErrBudgetExceeded (default limit: 5).
+	BudgetWaitForApproval = types.BudgetWaitForApproval
+)
+
+// ErrBudgetApprovalUnavailable is returned when a BudgetWaitForApproval pause cannot deliver
+// the approval request because the event stream has no connected subscriber. This is a
+// transient infrastructure failure, not a budget denial. Retry the run to recover.
+var ErrBudgetApprovalUnavailable = types.ErrBudgetApprovalUnavailable
+
+// ErrBudgetExceeded is returned when a per-run budget limit (MaxTokens or MaxCostUSD) is
+// reached and the configured action is BudgetStopRun, or when the caller denies continuation
+// after BudgetWaitForApproval.
+var ErrBudgetExceeded = types.ErrBudgetExceeded
+
+// FinishReasonBudgetExceeded is the finish reason set on AgentTelemetry when a run stops
+// because a per-run budget limit was reached.
+const FinishReasonBudgetExceeded = types.FinishReasonBudgetExceeded
+
 // RunTelemetry captures the orchestration lifecycle metrics for a single agent run.
 type RunTelemetry = types.RunTelemetry
 
@@ -150,6 +183,11 @@ func (a *Agent) Run(ctx context.Context, input string, opts *AgentRunOptions) (A
 	}
 	if a.hasApprovalTools(tools) && a.approvalHandler == nil {
 		return nil, fmt.Errorf("tools require approval but WithApprovalHandler was not set (required for Run)")
+	}
+	if a.budgetConfig != nil &&
+		a.budgetConfig.OnExceeded == types.BudgetWaitForApproval &&
+		a.approvalHandler == nil {
+		return nil, fmt.Errorf("WithBudget: OnExceeded %q requires WithApprovalHandler when calling Run; for stream-only use no handler is needed", a.budgetConfig.OnExceeded)
 	}
 	subAgents, err := a.resolveSubAgentSpecs(ctx)
 	if err != nil {

--- a/pkg/agent/approval.go
+++ b/pkg/agent/approval.go
@@ -41,10 +41,11 @@ type ApprovalRequestName = types.ApprovalRequestName
 const (
 	ApprovalRequestNameTool     = types.ApprovalRequestNameTool
 	ApprovalRequestNameSubAgent = types.ApprovalRequestNameSubAgent
+	ApprovalRequestNameBudget   = types.ApprovalRequestNameBudget
 )
 
-// ApprovalRequest describes a pending tool approval for [Agent.Run].
-// Name + Value mirror CUSTOM stream events; use [ParseToolApproval] / [ParseDelegationApproval].
+// ApprovalRequest describes a pending approval for [Agent.Run].
+// Name + Value mirror CUSTOM stream events; use [ParseToolApproval] / [ParseDelegationApproval] / [ParseBudgetApproval].
 // Respond is always set; call it once with ApprovalStatusApproved or ApprovalStatusRejected.
 // For streaming approvals, use [AgentStream.Approve] with the approval token from the CUSTOM event Value.
 type ApprovalRequest = types.ApprovalRequest
@@ -55,6 +56,9 @@ type ToolApprovalRequestValue = types.ToolApprovalRequestValue
 // SubAgentDelegationApprovalRequestValue is the decoded Value for delegation approvals.
 type SubAgentDelegationApprovalRequestValue = types.SubAgentDelegationApprovalRequestValue
 
+// BudgetApprovalRequestValue is the decoded Value for budget approvals.
+type BudgetApprovalRequestValue = types.BudgetApprovalRequestValue
+
 // ParseToolApproval decodes Value when Name is [ApprovalRequestNameTool] (handles map[string]any from JSON).
 func ParseToolApproval(req *ApprovalRequest) (ToolApprovalRequestValue, error) {
 	return types.ParseToolApproval(req)
@@ -63,6 +67,11 @@ func ParseToolApproval(req *ApprovalRequest) (ToolApprovalRequestValue, error) {
 // ParseDelegationApproval decodes Value when Name is [ApprovalRequestNameSubAgent].
 func ParseDelegationApproval(req *ApprovalRequest) (SubAgentDelegationApprovalRequestValue, error) {
 	return types.ParseDelegationApproval(req)
+}
+
+// ParseBudgetApproval decodes Value when Name is [ApprovalRequestNameBudget].
+func ParseBudgetApproval(req *ApprovalRequest) (BudgetApprovalRequestValue, error) {
+	return types.ParseBudgetApproval(req)
 }
 
 // OnApproval completes a pending tool or delegation approval when using [Agent.Stream].

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -179,7 +179,7 @@ type ObservabilityConfig struct {
 //     pkg/agent/runtime/temporal or pkg/agent/runtime/restate,
 //     WithInstanceId, WithLLMClient, WithToolApprovalPolicy, WithTools, WithToolRegistry,
 //     WithMCPRegistry, WithA2ARegistry, WithSubAgentRegistry,
-//     WithMaxIterations, WithLogger, WithLogLevel, WithConversation, WithMemory,
+//     WithMaxIterations, WithBudget, WithLogger, WithLogLevel, WithConversation, WithMemory,
 //     WithResponseFormat, WithLLMSampling, WithSubAgents, WithMaxSubAgentDepth,
 //     WithMCPConfig, WithMCPClients, WithA2AConfig, WithA2AClients, WithRetrievers, WithRetrieverMode, WithAgentMode, WithDisableFingerprintCheck, WithAgentToolExecutionMode,
 //     WithLLMExecutionConfig, WithToolAuthExecutionConfig, WithToolExecutionConfig, WithMCPExecutionConfig, WithA2AExecutionConfig,
@@ -248,6 +248,9 @@ type agentConfig struct {
 
 	agentMode              AgentMode
 	agentToolExecutionMode AgentToolExecutionMode
+
+	// budgetConfig is the optional per-run token/cost budget. Nil means no budget enforcement.
+	budgetConfig *types.BudgetConfig
 
 	// Observability: optional OTLP config and/or injected clients. When [observabilityConfig] is
 	// non-nil, [buildAgentConfig] may construct [tracer], [metrics], and [logs] via
@@ -362,6 +365,21 @@ func WithSubAgentRegistry(reg SubAgentRegistry) Option {
 // WithMaxIterations sets the max number of LLM rounds. Applies to Agent and AgentWorker.
 func WithMaxIterations(n int) Option {
 	return func(c *agentConfig) { c.maxIterations = n }
+}
+
+// WithBudget sets a per-run token and cost budget for the agent.
+// Limits apply to the current run only and reset when a new run starts.
+// When the agent runs nested subagents, their usage is included in the parent run totals.
+//
+// At least one of cfg.MaxTokens or cfg.MaxCostUSD must be non-zero.
+// When cfg.MaxCostUSD is non-zero, cfg.PromptUSDPer1M and cfg.CompletionUSDPer1M must be set.
+// When cfg.OnExceeded is BudgetWaitForApproval, WithApprovalHandler must also be set;
+// zero ApprovalExtraTokens / ApprovalExtraCostUSD default to MaxTokens / MaxCostUSD.
+// cfg.OnExceeded defaults to BudgetStopRun when not set (ApprovalExtra* are ignored).
+//
+// Applies to Agent and AgentWorker.
+func WithBudget(cfg types.BudgetConfig) Option {
+	return func(c *agentConfig) { c.budgetConfig = &cfg }
 }
 
 // WithLogger sets the SDK logger (structured logging with log/slog-style attributes).
@@ -846,6 +864,10 @@ func buildAgentConfig(opts []Option) (*agentConfig, error) {
 
 	if c.maxIterations <= 0 {
 		c.maxIterations = defaultMaxIterations
+	}
+
+	if err := c.validateBudget(); err != nil {
+		return nil, err
 	}
 
 	// Snapshot injected OTLP clients before observability may replace them (WithTracer / WithMetrics / WithLogs).
@@ -1362,6 +1384,7 @@ func (c *agentConfig) runtimeAgentConfig() runtime.AgentConfig {
 			MaxIterations:   c.maxIterations,
 			Timeout:         c.timeout,
 			ApprovalTimeout: c.approvalTimeout,
+			Budget:          c.budgetConfig,
 		},
 		ExecutionConfigs: c.executionConfigs,
 		Hooks:            c.runtimeHookGroups(),
@@ -1386,6 +1409,70 @@ func (c *agentConfig) runtimeHookGroups() []hooks.HookGroup {
 	out := make([]hooks.HookGroup, len(c.hooks))
 	copy(out, c.hooks)
 	return out
+}
+
+// validateBudget checks that the BudgetConfig (if set) is internally consistent.
+// When OnExceeded is BudgetWaitForApproval, zero ApprovalExtraTokens / ApprovalExtraCostUSD
+// are filled from MaxTokens / MaxCostUSD so the tracker always uses the Extra fields for
+// the watermark window. ApprovalHandler presence is NOT checked here; it is validated at
+// Run() call time so that stream-only callers never need to provide a handler.
+func (c *agentConfig) validateBudget() error {
+	b := c.budgetConfig
+	if b == nil {
+		return nil
+	}
+	if b.MaxTokens < 0 {
+		return fmt.Errorf("WithBudget: MaxTokens must be >= 0")
+	}
+	if b.MaxCostUSD < 0 {
+		return fmt.Errorf("WithBudget: MaxCostUSD must be >= 0")
+	}
+	if b.PromptUSDPer1M < 0 {
+		return fmt.Errorf("WithBudget: PromptUSDPer1M must be >= 0")
+	}
+	if b.CompletionUSDPer1M < 0 {
+		return fmt.Errorf("WithBudget: CompletionUSDPer1M must be >= 0")
+	}
+	if b.MaxTokens == 0 && b.MaxCostUSD == 0 {
+		return fmt.Errorf("WithBudget: at least one of MaxTokens or MaxCostUSD must be non-zero")
+	}
+	if b.MaxCostUSD > 0 && (b.PromptUSDPer1M <= 0 || b.CompletionUSDPer1M <= 0) {
+		return fmt.Errorf("WithBudget: MaxCostUSD requires PromptUSDPer1M and CompletionUSDPer1M to be set")
+	}
+	if b.ApprovalExtraTokens < 0 {
+		return fmt.Errorf("WithBudget: ApprovalExtraTokens must be >= 0")
+	}
+	if b.ApprovalExtraCostUSD < 0 {
+		return fmt.Errorf("WithBudget: ApprovalExtraCostUSD must be >= 0")
+	}
+	if b.MaxApprovals < 0 {
+		return fmt.Errorf("WithBudget: MaxApprovals must be >= 0")
+	}
+	if b.OnExceeded == "" {
+		b.OnExceeded = types.BudgetStopRun
+	}
+	switch b.OnExceeded {
+	case types.BudgetStopRun:
+		if b.ApprovalExtraTokens != 0 || b.ApprovalExtraCostUSD != 0 {
+			return fmt.Errorf("WithBudget: ApprovalExtraTokens and ApprovalExtraCostUSD are only valid with BudgetWaitForApproval, not BudgetStopRun")
+		}
+		if b.MaxApprovals != 0 {
+			return fmt.Errorf("WithBudget: MaxApprovals is only valid with BudgetWaitForApproval, not BudgetStopRun")
+		}
+	case types.BudgetWaitForApproval:
+		// ApprovalHandler is validated at Run() call time, not here, so stream-only
+		// callers are not forced to provide a no-op handler.
+		if b.ApprovalExtraTokens == 0 && b.MaxTokens > 0 {
+			b.ApprovalExtraTokens = b.MaxTokens
+		}
+		if b.ApprovalExtraCostUSD == 0 && b.MaxCostUSD > 0 {
+			b.ApprovalExtraCostUSD = b.MaxCostUSD
+		}
+		// MaxApprovals defaults are applied in BudgetTracker; no mutation needed here.
+	default:
+		return fmt.Errorf("WithBudget: unknown OnExceeded action %q; use BudgetStopRun or BudgetWaitForApproval", b.OnExceeded)
+	}
+	return nil
 }
 
 // hookGroupsFingerprint returns a stable SHA-256 digest of configured hook group names for

--- a/pkg/agent/config_test.go
+++ b/pkg/agent/config_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+	"github.com/agenticenv/agent-sdk-go/internal/events"
 	"github.com/agenticenv/agent-sdk-go/internal/runtime"
 	"github.com/agenticenv/agent-sdk-go/internal/runtime/temporal"
 	"github.com/agenticenv/agent-sdk-go/internal/types"
@@ -46,6 +47,7 @@ func agentConfigFingerprintTools(c *agentConfig, tools []interfaces.Tool) string
 			MaxIterations:   c.maxIterations,
 			Timeout:         c.timeout,
 			ApprovalTimeout: c.approvalTimeout,
+			Budget:          c.budgetConfig,
 		},
 		mcpConfigFingerprint(c.mcpServers, mcpExtraClientNames(c.mcpClients)),
 		a2aConfigFingerprint(c.a2aServers, a2aExtraClientNames(c.a2aClients)),
@@ -2170,5 +2172,238 @@ func TestBuildAgentConfig_WithExplicitRegistryOptions(t *testing.T) {
 	}
 	if len(tools) < 2 {
 		t.Fatalf("resolveTools len = %d, want at least native + sub-agent tools", len(tools))
+	}
+}
+
+func TestWithBudget_Validation(t *testing.T) {
+	approvalHandler := func(context.Context, *types.ApprovalRequest) {}
+	cases := []struct {
+		name    string
+		opts    []Option
+		wantErr string
+	}{
+		{
+			name: "valid MaxTokens only",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{MaxTokens: 500, OnExceeded: BudgetStopRun}),
+			},
+		},
+		{
+			name: "valid MaxCostUSD with rates",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{
+					MaxCostUSD:         1.0,
+					PromptUSDPer1M:     3.0,
+					CompletionUSDPer1M: 15.0,
+					OnExceeded:         BudgetStopRun,
+				}),
+			},
+		},
+		{
+			name: "valid WaitForApproval with handler",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithApprovalHandler(approvalHandler),
+				WithBudget(BudgetConfig{MaxTokens: 500, OnExceeded: BudgetWaitForApproval}),
+			},
+		},
+		{
+			name: "no limits set",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{OnExceeded: BudgetStopRun}),
+			},
+			wantErr: "at least one of MaxTokens or MaxCostUSD",
+		},
+		{
+			name: "MaxCostUSD without rates",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{MaxCostUSD: 1.0}),
+			},
+			wantErr: "PromptUSDPer1M and CompletionUSDPer1M",
+		},
+		{
+			// ApprovalHandler is no longer required at NewAgent for BudgetWaitForApproval;
+			// it is validated at Run() call time so stream-only callers need no handler.
+			name: "WaitForApproval without handler is valid at NewAgent",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{MaxTokens: 500, OnExceeded: BudgetWaitForApproval}),
+			},
+			wantErr: "", // no error expected — handler check deferred to Run()
+		},
+		{
+			name: "unknown action",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{MaxTokens: 500, OnExceeded: BudgetExceededAction("explode")}),
+			},
+			wantErr: "unknown OnExceeded action",
+		},
+		{
+			name: "negative ApprovalExtraTokens",
+			opts: []Option{
+				WithName("budget-agent"), WithLLMClient(testLLM(t)),
+				WithBudget(BudgetConfig{MaxTokens: 500, ApprovalExtraTokens: -1}),
+			},
+			wantErr: "ApprovalExtraTokens must be >= 0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildAgentConfig(tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error %q to contain %q", err.Error(), tc.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestWithBudget_DefaultsApprovalExtraFromMax(t *testing.T) {
+	approvalHandler := func(context.Context, *types.ApprovalRequest) {}
+	cfg, err := buildAgentConfig([]Option{
+		WithName("budget-agent"),
+		WithLLMClient(testLLM(t)),
+		WithApprovalHandler(approvalHandler),
+		WithBudget(BudgetConfig{
+			MaxTokens:          500,
+			MaxCostUSD:         1.0,
+			PromptUSDPer1M:     3.0,
+			CompletionUSDPer1M: 15.0,
+			OnExceeded:         BudgetWaitForApproval,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.budgetConfig.ApprovalExtraTokens != 500 {
+		t.Fatalf("ApprovalExtraTokens: got %d want 500", cfg.budgetConfig.ApprovalExtraTokens)
+	}
+	if cfg.budgetConfig.ApprovalExtraCostUSD != 1.0 {
+		t.Fatalf("ApprovalExtraCostUSD: got %v want 1.0", cfg.budgetConfig.ApprovalExtraCostUSD)
+	}
+}
+
+func TestWithBudget_PreservesExplicitApprovalExtra(t *testing.T) {
+	approvalHandler := func(context.Context, *types.ApprovalRequest) {}
+	cfg, err := buildAgentConfig([]Option{
+		WithName("budget-agent"),
+		WithLLMClient(testLLM(t)),
+		WithApprovalHandler(approvalHandler),
+		WithBudget(BudgetConfig{
+			MaxTokens:           500,
+			ApprovalExtraTokens: 100,
+			OnExceeded:          BudgetWaitForApproval,
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.budgetConfig.ApprovalExtraTokens != 100 {
+		t.Fatalf("ApprovalExtraTokens: got %d want 100", cfg.budgetConfig.ApprovalExtraTokens)
+	}
+}
+
+func TestWithBudget_StopRunRejectsApprovalExtra(t *testing.T) {
+	// Setting ApprovalExtraTokens with BudgetStopRun is now an explicit validation error
+	// rather than silent clearing, so callers are not surprised.
+	_, err := buildAgentConfig([]Option{
+		WithName("budget-agent"),
+		WithLLMClient(testLLM(t)),
+		WithBudget(BudgetConfig{
+			MaxTokens:           500,
+			ApprovalExtraTokens: 100,
+			OnExceeded:          BudgetStopRun,
+		}),
+	})
+	if err == nil {
+		t.Fatal("expected validation error for ApprovalExtraTokens with BudgetStopRun, got nil")
+	}
+	if !strings.Contains(err.Error(), "BudgetWaitForApproval") {
+		t.Fatalf("expected error to mention BudgetWaitForApproval, got: %v", err)
+	}
+}
+
+func TestWithBudget_FingerprintIncludesBudget(t *testing.T) {
+	baseOpts := []Option{
+		WithName("fp-agent"), WithLLMClient(testLLM(t)),
+	}
+	cfg0, err := buildAgentConfig(baseOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp0 := agentConfigFingerprint(cfg0)
+
+	cfg1, err := buildAgentConfig(append(baseOpts, WithBudget(BudgetConfig{
+		MaxTokens:  1000,
+		OnExceeded: BudgetStopRun,
+	})))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fp1 := agentConfigFingerprint(cfg1)
+
+	if fp0 == fp1 {
+		t.Fatal("fingerprint should differ when budget is added")
+	}
+}
+
+func TestWithBudget_DefaultsOnExceededToStopRun(t *testing.T) {
+	cfg, err := buildAgentConfig([]Option{
+		WithName("budget-agent"),
+		WithLLMClient(testLLM(t)),
+		WithBudget(BudgetConfig{MaxTokens: 500}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.budgetConfig.OnExceeded != BudgetStopRun {
+		t.Fatalf("expected OnExceeded to default to BudgetStopRun, got %q", cfg.budgetConfig.OnExceeded)
+	}
+}
+
+func TestParseBudgetApproval_PublicAPI(t *testing.T) {
+	req := &ApprovalRequest{
+		Name: ApprovalRequestNameBudget,
+		Value: map[string]any{
+			"agentName":     "pub",
+			"totalTokens":   float64(99),
+			"approvalToken": "tok",
+		},
+	}
+	got, err := ParseBudgetApproval(req)
+	if err != nil {
+		t.Fatalf("ParseBudgetApproval: %v", err)
+	}
+	if got.AgentName != "pub" || got.TotalTokens != 99 {
+		t.Fatalf("unexpected: %#v", got)
+	}
+}
+
+func TestParseCustomEventBudget_PublicAPI(t *testing.T) {
+	ev := events.NewAgentCustomEvent(string(AgentCustomEventNameBudget), map[string]any{
+		"agentName":     "pub",
+		"totalTokens":   float64(42),
+		"costUsd":       0.002,
+		"approvalToken": "tok-ce",
+	})
+	got, err := ParseCustomEventBudget(ev)
+	if err != nil {
+		t.Fatalf("ParseCustomEventBudget: %v", err)
+	}
+	if got.AgentName != "pub" || got.TotalTokens != 42 || got.ApprovalToken != "tok-ce" {
+		t.Fatalf("unexpected: %#v", got)
 	}
 }

--- a/pkg/agent/event.go
+++ b/pkg/agent/event.go
@@ -109,6 +109,8 @@ const (
 	AgentCustomEventNameToolApproval AgentCustomEventName = events.AgentCustomEventNameToolApproval
 	// AgentCustomEventNameSubAgentDelegation is approval to run a registered sub-agent (delegate).
 	AgentCustomEventNameSubAgentDelegation AgentCustomEventName = events.AgentCustomEventNameSubAgentDelegation
+	// AgentCustomEventNameBudget is a per-run budget limit pause.
+	AgentCustomEventNameBudget AgentCustomEventName = events.AgentCustomEventNameBudget
 )
 
 // AgentCustomEventApprovalValue is the value of the custom event for tool approval.
@@ -116,6 +118,9 @@ type AgentCustomEventApprovalValue = events.AgentCustomEventApprovalValue
 
 // AgentCustomEventDelegationValue is the value of the custom event for sub-agent delegation.
 type AgentCustomEventDelegationValue = events.AgentCustomEventDelegationValue
+
+// AgentCustomEventBudgetValue is the value of the custom event for budget approval.
+type AgentCustomEventBudgetValue = events.AgentCustomEventBudgetValue
 
 // ParseCustomEventApproval returns the typed value for CUSTOM events with name [AgentCustomEventNameToolApproval].
 // Use this when handling stream events: JSON decode leaves Value as map[string]any.
@@ -126,4 +131,9 @@ func ParseCustomEventApproval(ev *AgentCustomEvent) (AgentCustomEventApprovalVal
 // ParseCustomEventDelegation returns the typed value for CUSTOM events with name [AgentCustomEventNameSubAgentDelegation].
 func ParseCustomEventDelegation(ev *AgentCustomEvent) (AgentCustomEventDelegationValue, error) {
 	return events.ParseCustomEventDelegation(ev)
+}
+
+// ParseCustomEventBudget returns the typed value for CUSTOM events with name [AgentCustomEventNameBudget].
+func ParseCustomEventBudget(ev *AgentCustomEvent) (AgentCustomEventBudgetValue, error) {
+	return events.ParseCustomEventBudget(ev)
 }

--- a/taskfiles/examples.yml
+++ b/taskfiles/examples.yml
@@ -221,6 +221,7 @@ tasks:
         - NAME: agent_with_json_response
         - NAME: agent_with_stream
         - NAME: agent_with_reasoning
+        - NAME: agent_with_budget
         - NAME: multiple_agents
         - NAME: agent_with_mcp_config
         - NAME: agent_with_mcp_client


### PR DESCRIPTION
## Description

Adds `WithBudget` to the agent SDK, giving callers hard limits on token usage and estimated cost per run.

### What this does

- **`BudgetConfig`** — configure `MaxTokens`, `MaxCostUSD` (with per-model rates), and `OnExceeded` action per agent
- **`BudgetStopRun`** — stops the run immediately and returns `ErrBudgetExceeded`
- **`BudgetWaitForApproval`** — pauses the run and waits for human approval via `ApprovalHandler` (Run) or `AgentStream.Approve` (Stream); enforces `MaxApprovals` cap (default 5) to prevent runaway cost
- **Shared tracker across sub-agents** — child usage rolls up to the parent budget; the parent governs the entire run tree
- **Integer cost accumulation** — costs stored as nano-dollars (int64) to eliminate float64 drift over long runs
- **`ErrBudgetApprovalUnavailable`** — distinct sentinel when the stream has no subscriber, distinguishable from a genuine budget denial
- **`OnBudgetExceeded` hook** — fire-and-forget hook for custom metrics, alerts, and audit logging on every breach
- **Budget metrics** — `agent.budget.exceeded`, `agent.budget.approval.*` counters emitted across all runtimes (Local, Temporal, Restate)
- Works across all three runtimes; Temporal persists budget state across `ContinueAsNew` boundaries

### Validation
- `NewAgent` rejects invalid config (missing limits, bad rates, negative values, `ApprovalExtra*` with `BudgetStopRun`)
- `ApprovalHandler` presence checked at `Run()` call time only — stream-only callers need no handler

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / chore

## Related issues

Closes #61 

## Checklist

- [x] I have run `task check`
- [x] I have run `task examples:all`
- [x] I have run `task tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
