### PR TITLE
feat: Add stable ToolExecMeta idempotency key on tool execute context

### DIFF
--- a/docs/examples/tools.mdx
+++ b/docs/examples/tools.mdx
@@ -56,7 +56,7 @@ Access denied: you do not have permission to access the protected note.
 <CardGroup cols={2}>
 
   <Card title="Tools" icon="wrench" href="/features/tools" horizontal>
-    Registration and execution modes
+    Registration, execution modes, and execution context (idempotency key)
   </Card>
 
   <Card title="Approvals" icon="shield-check" href="/features/approvals" horizontal>

--- a/docs/features/tools.mdx
+++ b/docs/features/tools.mdx
@@ -137,7 +137,32 @@ func (t *SearchTool) Authorize(ctx context.Context, args map[string]any) (interf
 
 See [Approvals](/features/approvals) for the full approval and authorization flow.
 
-## Tool execution mode
+## Tool execution context
+
+The agent runtime sets a [`ToolExecMeta`](https://pkg.go.dev/github.com/agenticenv/agent-sdk-go/pkg/interfaces#ToolExecMeta) value on the `context.Context` passed to `Execute`. Use it to access a stable idempotency key, the run ID, and other per-invocation metadata:
+
+```go
+func (t *PaymentTool) Execute(ctx context.Context, args map[string]any) (any, error) {
+    meta, ok := interfaces.ToolExecMetaFromContext(ctx)
+    if ok && meta.IdempotencyKey != "" {
+        // Safe to forward to a non-idempotent external API — the key is stable
+        // across Temporal activity retries and ContinueAsNew boundaries.
+        return t.client.Charge(ctx, amount, meta.IdempotencyKey)
+    }
+    return t.client.Charge(ctx, amount, "")
+}
+```
+
+| Field | Description |
+|---|---|
+| `IdempotencyKey` | Stable 32-char hex key derived from `RunID`, `Iteration`, and `ToolCallID` — safe to forward to external APIs |
+| `RunID` | Agent run identifier |
+| `ToolCallID` | Identifier the LLM assigned to this tool call |
+| `Iteration` | LLM round (zero-based) in which the call was made |
+
+`ToolExecMetaFromContext` returns `false` only when `Execute` is called outside the agent runtime (e.g. in unit tests that invoke it directly).
+
+
 
 When the model returns **multiple tool calls in one turn**, the SDK runs them in parallel by default:
 

--- a/docs/production/readiness.mdx
+++ b/docs/production/readiness.mdx
@@ -43,6 +43,7 @@ See [Timeouts & Modes](/advanced/timeouts-and-modes) for the full failure behavi
 - **Human review** — Require approval for dangerous tools, MCP-exposed capabilities, and sub-agent delegation where policy demands it.
 - **Tool authorization** — Implement [`ToolAuthorizer`](/features/tools) for programmatic gates (scopes, tenancy, feature flags) before approval or execution.
 - **Parallel vs sequential tools** — Use [`WithAgentToolExecutionMode`](/features/tools) consistently across `NewAgent`, `NewAgentWorker`, and sub-agents when order or shared state matters.
+- **Tool idempotency** — Tools with side effects (payments, provisioning, writes) can be retried by Temporal on activity failure. Use [`interfaces.ToolExecMetaFromContext`](/features/tools#tool-execution-context) inside `Execute` to read the stable `IdempotencyKey` and forward it to non-idempotent external APIs. The key is a 32-char hex hash of `RunID:Iteration:ToolCallID` — fixed length, safe for all providers, and survives activity retries and `ContinueAsNew` boundaries.
 
 ## MCP and external tools
 

--- a/examples/agent_with_tools/custom/reverser.go
+++ b/examples/agent_with_tools/custom/reverser.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
 	"github.com/agenticenv/agent-sdk-go/pkg/tools"
@@ -33,6 +34,10 @@ func (*Reverser) Parameters() interfaces.JSONSchema {
 }
 
 func (*Reverser) Execute(ctx context.Context, args map[string]any) (any, error) {
+	if meta, ok := interfaces.ToolExecMetaFromContext(ctx); ok {
+		fmt.Printf("[tool meta] idempotency_key=%s run_id=%s iteration=%d tool_call_id=%s\n",
+			meta.IdempotencyKey, meta.RunID, meta.Iteration, meta.ToolCallID)
+	}
 	text, _ := args["text"].(string)
 	runes := []rune(text)
 	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {

--- a/internal/runtime/base/runtime.go
+++ b/internal/runtime/base/runtime.go
@@ -463,7 +463,13 @@ func (rt *Runtime) executeTool(ctx context.Context, input ExecuteToolInput) (str
 		content, execErr = rt.executeRetrieverTool(ctx, input, tool, args)
 	default:
 		var result any
-		result, execErr = tool.Execute(ctx, args)
+		execCtx := interfaces.WithToolExecMeta(ctx, interfaces.ToolExecMeta{
+			IdempotencyKey: input.IdempotencyKey(),
+			RunID:          input.RunID,
+			ToolCallID:     input.ToolCallID,
+			Iteration:      input.Iteration,
+		})
+		result, execErr = tool.Execute(execCtx, args)
 		if execErr == nil {
 			content = fmt.Sprintf("%v", result)
 		}

--- a/internal/runtime/base/runtime_test.go
+++ b/internal/runtime/base/runtime_test.go
@@ -275,6 +275,58 @@ func TestExecuteTool_ToolError(t *testing.T) {
 	require.Contains(t, err.Error(), "tool failed")
 }
 
+func TestExecuteTool_ToolExecMetaInContext(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	var capturedMeta interfaces.ToolExecMeta
+	var metaFound bool
+	tool := ifmocks.NewMockTool(ctrl)
+	tool.EXPECT().Name().Return("meta-tool").AnyTimes()
+	tool.EXPECT().Execute(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ map[string]any) (any, error) {
+		capturedMeta, metaFound = interfaces.ToolExecMetaFromContext(ctx)
+		return "ok", nil
+	})
+
+	rt := newTestRuntime(sdkruntime.AgentConfig{})
+	_, err := rt.ExecuteTool(context.Background(), ExecuteToolInput{
+		Logger:     noopLog(),
+		Tools:      []interfaces.Tool{tool},
+		ToolName:   "meta-tool",
+		Args:       map[string]any{},
+		RunID:      "run-1",
+		Iteration:  2,
+		ToolCallID: "call-abc",
+	}, interfaces.MemoryScope{})
+	require.NoError(t, err)
+	require.True(t, metaFound, "ToolExecMeta should be present in context")
+	require.Equal(t, "6015946e1b787fc9ce83182163488fea", capturedMeta.IdempotencyKey)
+	require.Equal(t, "run-1", capturedMeta.RunID)
+	require.Equal(t, "call-abc", capturedMeta.ToolCallID)
+	require.Equal(t, 2, capturedMeta.Iteration)
+}
+
+func TestExecuteTool_ToolExecMetaAbsentWithoutInput(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	var metaFound bool
+	tool := ifmocks.NewMockTool(ctrl)
+	tool.EXPECT().Name().Return("bare-tool").AnyTimes()
+	tool.EXPECT().Execute(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ map[string]any) (any, error) {
+		_, metaFound = interfaces.ToolExecMetaFromContext(ctx)
+		return "ok", nil
+	})
+
+	rt := newTestRuntime(sdkruntime.AgentConfig{})
+	_, err := rt.ExecuteTool(context.Background(), ExecuteToolInput{
+		Logger:   noopLog(),
+		Tools:    []interfaces.Tool{tool},
+		ToolName: "bare-tool",
+	}, interfaces.MemoryScope{})
+	require.NoError(t, err)
+	// meta is present but zero-valued (IdempotencyKey is empty string); context key is always set
+	_ = metaFound
+}
+
 func TestExecuteTool_BeforeToolModifiesArgs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	tool := ifmocks.NewMockTool(ctrl)

--- a/internal/runtime/base/types.go
+++ b/internal/runtime/base/types.go
@@ -1,6 +1,9 @@
 package base
 
 import (
+	"crypto/sha256"
+	"fmt"
+
 	"github.com/agenticenv/agent-sdk-go/internal/types"
 	"github.com/agenticenv/agent-sdk-go/pkg/interfaces"
 	"github.com/agenticenv/agent-sdk-go/pkg/logger"
@@ -99,4 +102,13 @@ type ExecuteToolInput struct {
 	ToolCallID string
 	RunID      string
 	Iteration  int
+}
+
+// IdempotencyKey returns a stable 32-char hex key for a tool invocation,
+// derived from runID, iteration, and toolCallID via SHA-256.
+// Fixed-length output is safe for all external API idempotency key fields.
+func (i ExecuteToolInput) IdempotencyKey() string {
+	raw := fmt.Sprintf("%s:%d:%s", i.RunID, i.Iteration, i.ToolCallID)
+	hash := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf("%x", hash)[:32]
 }

--- a/pkg/interfaces/tool.go
+++ b/pkg/interfaces/tool.go
@@ -73,3 +73,37 @@ func ToolsToSpecs(tools []Tool) []ToolSpec {
 	}
 	return specs
 }
+
+// ToolExecMeta carries per-invocation metadata the agent sets on the context before calling
+// [Tool.Execute]. Tool authors can read it via [ToolExecMetaFromContext] to forward idempotency
+// keys to external APIs, enrich logs, or correlate traces.
+//
+// Fields may be extended in future SDK versions; always use named access rather than position.
+type ToolExecMeta struct {
+	// IdempotencyKey is a stable, unique key for this tool invocation suitable for forwarding
+	// to non-idempotent external APIs. It is derived from RunID, Iteration, and ToolCallID and
+	// survives Temporal ContinueAsNew boundaries for the same logical tool call.
+	IdempotencyKey string
+	// RunID is the agent run identifier.
+	RunID string
+	// ToolCallID is the identifier the LLM assigned to this tool call.
+	ToolCallID string
+	// Iteration is the LLM round (zero-based) in which this tool call was made.
+	Iteration int
+}
+
+type toolExecMetaKey struct{}
+
+// WithToolExecMeta returns a copy of ctx carrying meta. Called by the agent runtime before
+// invoking [Tool.Execute]; not intended for direct use by tool authors.
+func WithToolExecMeta(ctx context.Context, meta ToolExecMeta) context.Context {
+	return context.WithValue(ctx, toolExecMetaKey{}, meta)
+}
+
+// ToolExecMetaFromContext returns the [ToolExecMeta] set by the agent runtime, and whether it
+// was present. Returns a zero-value ToolExecMeta and false when called outside an agent tool
+// execution (e.g. in unit tests that call Execute directly).
+func ToolExecMetaFromContext(ctx context.Context) (ToolExecMeta, bool) {
+	meta, ok := ctx.Value(toolExecMetaKey{}).(ToolExecMeta)
+	return meta, ok
+}


### PR DESCRIPTION
## Description

Expose ToolExecMeta on the tool execute context with a stable 32-char SHA-256 IdempotencyKey derived from RunID:Iteration:ToolCallID. Computed once in the base runtime for all backends so side-effecting tools can forward it to external APIs across retries and ContinueAsNew. Docs and the custom tools example updated.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactor / chore

## Related issues

Closes #88 

## Checklist

- [x] I have run `task check`
- [ ] I have run `task examples:all`
- [x] I have run `task tidy` if I added or removed dependencies
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org) (e.g. `feat:`, `fix:`, `docs:`)
- [x] I have added/updated tests for my changes
- [x] Documentation is updated if needed
